### PR TITLE
ci: add Trivy dependency scan (CI 1.8)

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,30 @@
+name: trivy
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    name: Trivy dependency scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Trivy vulnerability scan (CRITICAL,HIGH)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          scanners: vuln
+          severity: CRITICAL,HIGH
+          exit-code: '1'
+          ignore-unfixed: true
+          format: table
+          cache: 'true'
+          trivyignores: .trivyignore

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,44 @@
+# .trivyignore — accepted / triaged Trivy findings for evc-team-relay
+#
+# The trivy CI gate (.github/workflows/trivy.yml) runs `trivy fs` over the repo
+# and fails the build on any CRITICAL or HIGH dependency vulnerability that HAS
+# a fix available (ignore-unfixed: true).
+#
+# Add a CVE here ONLY after a deliberate accept-risk decision, and ALWAYS
+# document it inline: CVE → why deferred → who accepted it → date.
+#
+# ── Baseline at gate introduction (CI 1.8), 2026-05-23, Daedalus ──
+# Every entry below is a pre-existing HIGH finding (zero CRITICAL) carried at the
+# moment the Trivy gate was added. They are TEMPORARILY accepted so the gate is
+# green and starts catching NEW regressions immediately. Remediation (dependency
+# bumps) is tracked in Mesh task 1bf42b38 — remove each line in the PR that lands
+# its bump. Bumps are deferred to a verified follow-up (not bundled into this
+# CI-only PR) because several need real work: pillow 10→12 is blocked by the
+# pyproject pin `pillow>=10.0,<11.0` (major bump), cryptography is a 2-major bump,
+# and lodash-es is a transitive npm dep needing a package.json override.
+
+# apps/control-plane/uv.lock (Python) — fix tracked in task 1bf42b38
+# pillow 10.4.0 → 12.x (blocked by pyproject pin pillow>=10.0,<11.0; major bump)
+CVE-2026-25990
+CVE-2026-40192
+CVE-2026-42311
+# cryptography 42.0.8 → 46.0.5 (2 major versions, validate)
+CVE-2026-26007
+# cbor2 5.8.0 → 5.9.0
+CVE-2026-26209
+# authlib 1.6.6 → 1.6.9
+CVE-2026-27962
+CVE-2026-28490
+CVE-2026-28498
+CVE-2026-28802
+# pyjwt 2.11.0 → 2.12.0
+CVE-2026-32597
+# mako 1.3.10 → 1.3.12
+CVE-2026-41205
+CVE-2026-44307
+# python-multipart 0.0.22 → 0.0.27
+CVE-2026-42561
+
+# apps/web-publish/package-lock.json (npm, transitive) — fix tracked in task 1bf42b38
+# lodash-es 4.17.x → 4.18.0 (transitive; needs package.json override)
+CVE-2026-4800


### PR DESCRIPTION
Part of the Trivy CI initiative (parent: CI 1.8), mirroring the proven evc-mesh pilot (#118).

## What
- Adds `.github/workflows/trivy.yml` — `trivy fs` dependency scan, fails on **CRITICAL/HIGH** with an available fix (`ignore-unfixed: true`, `scanners: vuln`).
- Action pinned to **v0.36.0 commit SHA** (`ed142fd…`), least-priv `permissions: contents: read`.
- Adds `.trivyignore` baselining the pre-existing findings (all **HIGH**, zero CRITICAL) with per-CVE reasoning.

## Why baseline instead of bump in this PR
This PR is intentionally **CI-only** (no dependency changes). The pre-existing findings are documented in `.trivyignore` so the gate is **green immediately** and starts blocking any NEW CRITICAL/HIGH regression. The actual dependency bumps are tracked in follow-up **task `1bf42b38`** — several need real work (pillow major bump / constraint relax, cryptography 2-major bump, transitive npm overrides) and validation, so they are kept out of the gate PR. Same pattern the sibling tgbot scanner used (`f7bfad90`).

Local `trivy fs --severity CRITICAL,HIGH --ignore-unfixed --ignorefile .trivyignore` exits 0 (clean).