### PR TITLE
fix(deps): bump Mako 1.3.10 → 1.3.12 (GHSA-2h4p-vjrc-8xpq)

### DIFF
--- a/apps/control-plane/uv.lock
+++ b/apps/control-plane/uv.lock
@@ -488,14 +488,14 @@ wheels = [
 
 [[package]]
 name = "mako"
-version = "1.3.10"
+version = "1.3.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/38/bd5b78a920a64d708fe6bc8e0a2c075e1389d53bef8413725c63ba041535/mako-1.3.10.tar.gz", hash = "sha256:99579a6f39583fa7e5630a28c3c1f440e4e97a414b80372649c0ce338da2ea28", size = 392474, upload-time = "2025-04-10T12:44:31.16Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/62/791b31e69ae182791ec67f04850f2f062716bbd205483d63a215f3e062d3/mako-1.3.12.tar.gz", hash = "sha256:9f778e93289bd410bb35daadeb4fc66d95a746f0b75777b942088b7fd7af550a", size = 400219, upload-time = "2026-04-28T19:01:08.512Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/fb/99f81ac72ae23375f22b7afdb7642aba97c00a713c217124420147681a2f/mako-1.3.10-py3-none-any.whl", hash = "sha256:baef24a52fc4fc514a0887ac600f9f1cff3d82c61d4d700a1fa84d597b88db59", size = 78509, upload-time = "2025-04-10T12:50:53.297Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/b1/a0ec7a5a9db730a08daef1fdfb8090435b82465abbf758a596f0ea88727e/mako-1.3.12-py3-none-any.whl", hash = "sha256:8f61569480282dbf557145ce441e4ba888be453c30989f879f0d652e39f53ea9", size = 78521, upload-time = "2026-04-28T19:01:10.393Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Security fix — Dependabot alert #58 (high)

Bumps **Mako** `1.3.10` → `1.3.12` in `apps/control-plane/uv.lock`.

### Vulnerability
[GHSA-2h4p-vjrc-8xpq](https://github.com/advisories/GHSA-2h4p-vjrc-8xpq) — path traversal via backslash URI on Windows in `TemplateLookup`. A URI like `\..\..\secret.txt` bypasses the directory-traversal check in `Template.__init__` and the `posixpath` normalization in `get_template()`, allowing reads outside the configured template directory. Patched in 1.3.12.

### Scope
- Mako is a **transitive** dependency (via `alembic`, used for migration script templates).
- **Lock-only** change — no source, no API, no manifest constraint changes.
- Generated with `uv lock --upgrade-package mako`; only the `mako` entry changed.
- `uv lock --check` passes (lockfile consistent with pyproject).

### Verification
- [x] `uv lock --check` — consistent
- [ ] CI green (lint-python / test-python / build-docker)