### PR TITLE
fix(lint): drop unused imports + fix E501 in control-plane test files

### DIFF
--- a/apps/control-plane/tests/test_cwt_tokens.py
+++ b/apps/control-plane/tests/test_cwt_tokens.py
@@ -24,7 +24,6 @@ from app.core.security import (
     verify_relay_token_cwt,
 )
 
-
 # ── Helpers ──────────────────────────────────────────────────
 
 
@@ -334,7 +333,11 @@ class TestCWTVerification:
         cose = inner.value if isinstance(inner, cbor2.CBORTag) else inner
 
         # Change claims
-        tampered_claims = {CWT_CLAIM_ISS: "evil-issuer", CWT_CLAIM_IAT: 0, CWT_CLAIM_SCOPE: "doc:hacked:rw"}
+        tampered_claims = {
+            CWT_CLAIM_ISS: "evil-issuer",
+            CWT_CLAIM_IAT: 0,
+            CWT_CLAIM_SCOPE: "doc:hacked:rw",
+        }
         cose[2] = cbor2.dumps(tampered_claims)  # replace payload
 
         # Re-encode with original signature (now invalid)

--- a/apps/control-plane/tests/test_relay_token_endpoint.py
+++ b/apps/control-plane/tests/test_relay_token_endpoint.py
@@ -11,9 +11,6 @@ import base64
 import cbor2
 from fastapi.testclient import TestClient
 
-from app.core.security import CWT_CLAIM_IAT, CWT_CLAIM_ISS, CWT_CLAIM_SCOPE, CWT_TAG
-
-
 # ── Helpers ──────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

- Remove 4 unused imports (`CWT_CLAIM_IAT`, `CWT_CLAIM_ISS`, `CWT_CLAIM_SCOPE`, `CWT_TAG`) from `tests/test_relay_token_endpoint.py` (F401)
- Fix import block sort order in both CWT test files (I001)
- Wrap long dict literal in `test_cwt_tokens.py:337` across 4 lines to satisfy 100-char limit (E501)

Fixes `lint-python` CI check which was permanently red on every PR due to pre-existing test debt. No behavior change — pure cleanup.

**Note for Daedalus:** `daedalus/sec-deps-control-plane` also contains this lint commit. If that branch opens a PR after this one merges, please rebase on `main` first to avoid overlap.

## Test plan

- [x] `ruff check app/ tests/` → 0 errors
- [x] `ruff format --check app/ tests/` → 106 files already formatted
- [x] `pytest tests/ -x -q` → all passed (1 skipped)