### PR TITLE
security: drop .trivyignore baseline CVEs — all 9 deps already remediated

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -7,38 +7,9 @@
 # Add a CVE here ONLY after a deliberate accept-risk decision, and ALWAYS
 # document it inline: CVE → why deferred → who accepted it → date.
 #
-# ── Baseline at gate introduction (CI 1.8), 2026-05-23, Daedalus ──
-# Every entry below is a pre-existing HIGH finding (zero CRITICAL) carried at the
-# moment the Trivy gate was added. They are TEMPORARILY accepted so the gate is
-# green and starts catching NEW regressions immediately. Remediation (dependency
-# bumps) is tracked in Mesh task 1bf42b38 — remove each line in the PR that lands
-# its bump. Bumps are deferred to a verified follow-up (not bundled into this
-# CI-only PR) because several need real work: pillow 10→12 is blocked by the
-# pyproject pin `pillow>=10.0,<11.0` (major bump), cryptography is a 2-major bump,
-# and lodash-es is a transitive npm dep needing a package.json override.
-
-# apps/control-plane/uv.lock (Python) — fix tracked in task 1bf42b38
-# pillow 10.4.0 → 12.x (blocked by pyproject pin pillow>=10.0,<11.0; major bump)
-CVE-2026-25990
-CVE-2026-40192
-CVE-2026-42311
-# cryptography 42.0.8 → 46.0.5 (2 major versions, validate)
-CVE-2026-26007
-# cbor2 5.8.0 → 5.9.0
-CVE-2026-26209
-# authlib 1.6.6 → 1.6.9
-CVE-2026-27962
-CVE-2026-28490
-CVE-2026-28498
-CVE-2026-28802
-# pyjwt 2.11.0 → 2.12.0
-CVE-2026-32597
-# mako 1.3.10 → 1.3.12
-CVE-2026-41205
-CVE-2026-44307
-# python-multipart 0.0.22 → 0.0.27
-CVE-2026-42561
-
-# apps/web-publish/package-lock.json (npm, transitive) — fix tracked in task 1bf42b38
-# lodash-es 4.17.x → 4.18.0 (transitive; needs package.json override)
-CVE-2026-4800
+# All baseline findings (CI 1.8, 2026-05-23) have been remediated — task 1bf42b38:
+# - pillow 12.2.0 (constraint relaxed from >=10.0,<11.0 to >=12.2.0,<13.0)
+# - cryptography 46.0.7 (constraint updated to >=46.0.5,<47.0)
+# - authlib 1.6.12 (constraint updated to >=1.6.12)
+# - cbor2 5.9.0, pyjwt 2.13.0, mako 1.3.12, python-multipart 0.0.29
+# - lodash-es 4.18.1 (package.json override >=4.18.1, PRs #14 #16 #17)


### PR DESCRIPTION
## Summary

All HIGH findings from the CI 1.8 Trivy baseline are already fixed in the lockfile (via PRs #14, #16, #17). This PR removes the temporary `.trivyignore` exemptions so the gate runs clean against the real installed versions.

**Packages cleared:**
| Package | Was | Now |
|---------|-----|-----|
| pillow | 10.4.0 | 12.2.0 |
| cryptography | 42.0.8 | 46.0.7 |
| authlib | 1.6.6 | 1.6.12 |
| cbor2 | 5.8.0 | 5.9.0 |
| pyjwt | 2.11.0 | 2.13.0 |
| mako | 1.3.10 | 1.3.12 |
| python-multipart | 0.0.22 | 0.0.29 |
| lodash-es | 4.17.21 | 4.18.1 |

## Test plan
- [ ] Trivy CI gate passes on this branch (no HIGH/CRITICAL findings, no ignored CVEs)
- [ ] No `uv.lock` or `package-lock.json` changes (deps were already fixed before this PR)