### PR TITLE
fix(ci): authenticate web-publish npm ci via BuildKit secret

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,9 @@ jobs:
   build-docker:
     runs-on: ubuntu-latest
     needs: [lint-python, test-python]
+    permissions:
+      contents: read
+      packages: read
     steps:
       - uses: actions/checkout@v4
 
@@ -76,3 +79,5 @@ jobs:
           tags: evc-team-relay/web-publish:test
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          secrets: |
+            github_token=${{ secrets.GITHUB_TOKEN }}

--- a/apps/web-publish/Dockerfile
+++ b/apps/web-publish/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 # Build stage
 FROM node:20-alpine AS builder
 
@@ -6,9 +7,9 @@ WORKDIR /app
 # Copy package files and registry config
 COPY package.json package-lock.json* .npmrc ./
 
-# Install dependencies (GITHUB_TOKEN for @entire-vc packages on GitHub Packages)
-ARG GITHUB_TOKEN
-RUN npm ci
+# Install dependencies — token mounted as BuildKit secret, never baked into a layer
+RUN --mount=type=secret,id=github_token \
+    GITHUB_TOKEN=$(cat /run/secrets/github_token) npm ci
 
 # Copy source code
 COPY . .


### PR DESCRIPTION
## Summary

- `apps/web-publish/Dockerfile` declared `ARG GITHUB_TOKEN` but never exported it as an env var, so `npm ci` ran unauthenticated → 401 on `@entire-vc/ui-svelte` / `@entire-vc/tokens` from GitHub Packages
- CI workflow had no `secrets:` or `build-args:` on the `Build web-publish` step

## Changes

**`apps/web-publish/Dockerfile`**
- Added `# syntax=docker/dockerfile:1` to enable BuildKit frontend syntax
- Replaced `ARG GITHUB_TOKEN` + bare `RUN npm ci` with `RUN --mount=type=secret,id=github_token GITHUB_TOKEN=$(cat /run/secrets/github_token) npm ci`
- Token is mounted ephemerally — never written to an image layer

**`.github/workflows/ci.yml`**
- Added `permissions: packages: read` to `build-docker` job so the default `GITHUB_TOKEN` is scoped to read org packages
- Added `secrets: github_token=${{ secrets.GITHUB_TOKEN }}` to the `Build web-publish` step

## Test plan

- [ ] PR CI build-docker job: `Build web-publish` step completes without 401
- [ ] `Build control-plane` step unaffected (no change to its Dockerfile)
- [ ] Docker image produced with no token in `docker history` / layer inspection