### PR TITLE
fix(migration): UUID types and if_not_exists for share_agent_keys

### DIFF
--- a/apps/control-plane/app/db/migrations/versions/202605220001_add_share_agent_keys.py
+++ b/apps/control-plane/app/db/migrations/versions/202605220001_add_share_agent_keys.py
@@ -10,9 +10,10 @@ from typing import Sequence, Union
 
 import sqlalchemy as sa
 from alembic import op
+from sqlalchemy.dialects import postgresql
 
 revision: str = "202605220001"
-down_revision: Union[str, None] = "202602030003"
+down_revision: Union[str, None] = "202602190001"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
@@ -20,10 +21,10 @@ depends_on: Union[str, Sequence[str], None] = None
 def upgrade() -> None:
     op.create_table(
         "share_agent_keys",
-        sa.Column("id", sa.String(36), primary_key=True, nullable=False),
+        sa.Column("id", postgresql.UUID(as_uuid=False), primary_key=True, nullable=False),
         sa.Column(
             "share_id",
-            sa.String(36),
+            postgresql.UUID(as_uuid=False),
             sa.ForeignKey("shares.id", ondelete="CASCADE"),
             nullable=False,
             index=True,
@@ -33,7 +34,7 @@ def upgrade() -> None:
         sa.Column("scopes", sa.String(255), nullable=False, server_default="write"),
         sa.Column(
             "created_by",
-            sa.String(36),
+            postgresql.UUID(as_uuid=False),
             sa.ForeignKey("users.id", ondelete="SET NULL"),
             nullable=True,
         ),
@@ -53,8 +54,18 @@ def upgrade() -> None:
             nullable=False,
         ),
     )
-    op.create_index("ix_share_agent_keys_key_hash", "share_agent_keys", ["key_hash"])
-    op.create_index("ix_share_agent_keys_share_id", "share_agent_keys", ["share_id"])
+    op.create_index(
+        "ix_share_agent_keys_key_hash",
+        "share_agent_keys",
+        ["key_hash"],
+        if_not_exists=True,
+    )
+    op.create_index(
+        "ix_share_agent_keys_share_id",
+        "share_agent_keys",
+        ["share_id"],
+        if_not_exists=True,
+    )
 
 
 def downgrade() -> None:


### PR DESCRIPTION
## Summary

- Fix `down_revision` in `202605220001` to `202602190001` (actual prod DB head, was `202602030003`)
- Use `postgresql.UUID` instead of `String(36)` for id/share_id/created_by — prod uses native UUID, `String(36)` caused FK `DatatypeMismatch`
- Add `if_not_exists=True` to `op.create_index` — `create_table` with `index=True` already emits the index, causing `DuplicateTable` on explicit call

Found during prod deploy. Migration applied to production via server sync; this PR syncs the fix into the repo.

Pair: #2 (merged)