### PR TITLE
fix(admin-ui): TemplateResponse keyword-only signature — fix /admin-ui/login 500

### DIFF
--- a/apps/control-plane/app/api/routers/admin_ui.py
+++ b/apps/control-plane/app/api/routers/admin_ui.py
@@ -85,7 +85,7 @@ def render_template(
             ctx["branding"] = instance_settings_service.get_branding(db)
         except Exception:
             ctx["branding"] = None
-    return templates.TemplateResponse(template, ctx)
+    return templates.TemplateResponse(request=request, name=template, context=ctx)
 
 
 @router.get("", response_class=HTMLResponse)


### PR DESCRIPTION
## Summary
- Fixes HTTP 500 crash on all `/admin-ui/*` routes caused by starlette deprecating the positional-arg signature for `TemplateResponse`
- One-line change in `apps/control-plane/app/api/routers/admin_ui.py:88`
- Hotfix was already applied in prod via `docker exec`; this commit makes it permanent and survives container rebuilds

## Root cause
`render_template()` called `templates.TemplateResponse(template, ctx)` (old positional API). Current starlette passes the dict as a cache key, triggering `TypeError: unhashable type: 'dict'`.

## Fix
```python
# Before
return templates.TemplateResponse(template, ctx)
# After
return templates.TemplateResponse(request=request, name=template, context=ctx)
```

## Test plan
- [ ] CI green
- [ ] After merge + autodeploy: `curl https://cp.tr.entire.vc/admin-ui/login` returns 200 HTML (not 500)
- [ ] Other `admin-ui/*` routes verified accessible