### PR TITLE
docs: agent keys UX research + design docs

### DIFF
--- a/dev-docs/research-agent-keys-ux.md
+++ b/dev-docs/research-agent-keys-ux.md
@@ -1,0 +1,378 @@
+# Agent Keys UX Research Report
+
+_Date: 2026-05-31 | Author: Daedalus_
+
+---
+
+## Executive Summary
+
+- A Casdoor-only user (e.g. `rj@entire.vc`) **can** create an agent key today — no local password is required. The control plane completes the Casdoor OAuth callback and mints a local HS256 JWT, which is the credential used for all subsequent API calls including agent-key creation. The Casdoor-issued token itself is never accepted; the locally-minted token is.
+- `Authorization: Bearer` for the agent-keys API comes from the control plane's own `security.create_access_token()` (HS256, signed with `settings.jwt_secret`). Every auth path — local password, Casdoor OAuth, or any future OIDC provider — converges to the same locally-minted JWT before any share or key operation is performed.
+- Any authenticated user who is a share owner, admin, or **any** share member (including viewer-role) can currently create, list, and revoke agent keys on shares they belong to. There is no further role restriction within the share for the key CRUD endpoints.
+- Agent key management should live in the **Obsidian plugin settings** (primary surface, under a dedicated "Agent Keys" tab per server), with a contextual shortcut inline in the share detail view. A web UI is not a blocker since the plugin already holds the Bearer token and the API is ready; building a separate web UI should be deferred until there is explicit demand.
+
+---
+
+## Current State: Backend Auth Architecture
+
+### Auth Layers
+
+#### 1. Local password session (primary user auth)
+
+Endpoints: `POST /v1/auth/login`, `POST /v1/auth/login/2fa`
+
+After login, all requests use `Authorization: Bearer <access_token>`. The validator lives in `app/api/deps.py` — `get_current_user` calls `security.decode_access_token(token)`, which performs HS256 validation against `settings.jwt_secret`. Token payload: `{"sub": "<user_uuid>", "exp": ..., "session_id": "..."}`. The resulting access token plus a refresh token are persisted in the `user_sessions` table.
+
+#### 2. Casdoor SSO (OAuth/OIDC)
+
+Endpoints: `GET /v1/auth/oauth/{provider}/authorize` → `GET /v1/auth/oauth/{provider}/callback`
+
+Flow: standard PKCE code exchange. `oauth.py:131–233` calls Casdoor's `/api/login/oauth/access_token` then `/api/userinfo`. The Casdoor-issued access token is used only to retrieve userinfo from Casdoor — it is never stored or accepted as a Bearer token by the control plane itself.
+
+After the callback, the control plane mints its own local HS256 JWT via the same `security.create_access_token()` used by password login, and creates a `user_sessions` row. From this point the Casdoor user is indistinguishable from a local-password user at the API level.
+
+There is no JWKS endpoint, no Casdoor JWT middleware, and no code path anywhere in the control plane that accepts a Casdoor-issued JWT as a Bearer credential. `security.py:48–50` confirms `decode_access_token` validates with the local `jwt_secret` using HS256 only.
+
+#### 3. Agent keys (per-share write tokens)
+
+Header format: `X-Agent-Key: tr_agent_<48 hex chars>`
+
+Validator in `web.py:1137–1175`: SHA-256 hashes the header value, looks up the `share_agent_keys` table by `key_hash`, verifies: matching `share_id`, `revoked_at IS NULL`, `expires_at` not passed, `scopes` contains `"write"`. No JWT involved.
+
+Scope: only valid for `POST /v1/web/shares/{slug}/upload`. No other endpoint accepts agent keys.
+
+### Agent Keys CRUD — Current State
+
+**Create** (`POST /v1/web/shares/{share_id}/agent-keys`, `agent_keys.py:19`):
+- Body: `{"label": "optional string", "expires_at": "optional ISO datetime"}`
+- Returns the raw key **once**: `{"id": "...", "key": "tr_agent_...", "label": ..., "expires_at": ..., "created_at": ...}`
+- Scope is hardcoded to `"write"` at `agent_keys.py:110`.
+
+**List** (`GET /v1/web/shares/{share_id}/agent-keys`):
+- Returns `AgentKeyListItem` objects — never includes `key_hash` or the raw key value.
+
+**Revoke** (`DELETE /v1/web/shares/{share_id}/agent-keys/{key_id}`):
+- Soft-revoke: sets `revoked_at` timestamp. Row remains in DB.
+
+**Auth for CRUD endpoints**: `_require_share_owner_or_admin` in `agent_keys.py:22–68` requires `Authorization: Bearer <local_cp_jwt>`. Caller must be global admin, share owner, or any `ShareMember` of the share. There is no further role restriction — a viewer-role member can create and revoke keys.
+
+**Owner tracking gap**: `ShareAgentKey` model (`models.py:566`) has a nullable `created_by` FK to `users`, but `agent_keys.py:106–112` does not populate it at creation time. Keys have no recorded creator.
+
+### Key Files
+
+| File | Role |
+|------|------|
+| `apps/control-plane/app/api/routers/agent_keys.py` | Full CRUD, `_require_share_owner_or_admin` |
+| `apps/control-plane/app/api/routers/oauth.py` | Casdoor OAuth callback flow |
+| `apps/control-plane/app/api/routers/auth.py` | Local password auth |
+| `apps/control-plane/app/api/deps.py` | `get_current_user`, `_get_user_from_token` |
+| `apps/control-plane/app/core/security.py` | `decode_access_token` (HS256 only) |
+| `apps/control-plane/app/api/routers/web.py:1093–1276` | `X-Agent-Key` validation on upload |
+| `apps/control-plane/app/db/models.py:566–588` | `ShareAgentKey` model |
+| `apps/control-plane/app/db/migrations/versions/202605220001_add_share_agent_keys.py` | Migration (landed 2026-05-22) |
+
+### Full Endpoint Inventory
+
+#### Auth (`/v1/auth/*`)
+
+| Method | Path | Auth required |
+|--------|------|---------------|
+| POST | `/v1/auth/register` | admin JWT |
+| POST | `/v1/auth/login` | none |
+| POST | `/v1/auth/login/2fa` | none |
+| POST | `/v1/auth/logout` | user JWT |
+| GET | `/v1/auth/me` | user JWT |
+| POST | `/v1/auth/refresh` | none (refresh token in body) |
+| GET | `/v1/auth/sessions` | user JWT |
+| DELETE | `/v1/auth/sessions/{session_id}` | user JWT |
+| DELETE | `/v1/auth/sessions` | user JWT |
+| POST | `/v1/auth/password-reset/request` | none |
+| GET | `/v1/auth/password-reset/{token}` | none |
+| POST | `/v1/auth/password-reset/confirm` | none |
+| GET | `/v1/auth/email/verify/status` | user JWT |
+| POST | `/v1/auth/email/verify/request` | user JWT |
+| GET | `/v1/auth/email/verify/{token}` | none |
+| GET | `/v1/auth/2fa/status` | user JWT |
+| POST | `/v1/auth/2fa/enable` | user JWT |
+| POST | `/v1/auth/2fa/verify` | user JWT |
+| POST | `/v1/auth/2fa/disable` | user JWT |
+
+#### OAuth (`/v1/auth/oauth/*`)
+
+| Method | Path | Auth required |
+|--------|------|---------------|
+| GET | `/v1/auth/oauth/providers` | none |
+| GET | `/v1/auth/oauth/{provider}/authorize` | none |
+| GET | `/v1/auth/oauth/{provider}/callback` | none (OAuth code) |
+
+#### Agent Keys
+
+| Method | Path | Auth required |
+|--------|------|---------------|
+| POST | `/v1/web/shares/{share_id}/agent-keys` | local CP JWT (owner/member/admin) |
+| GET | `/v1/web/shares/{share_id}/agent-keys` | local CP JWT (owner/member/admin) |
+| DELETE | `/v1/web/shares/{share_id}/agent-keys/{key_id}` | local CP JWT (owner/member/admin) |
+
+#### Upload (agent key consumption)
+
+| Method | Path | Auth required |
+|--------|------|---------------|
+| POST | `/v1/web/shares/{slug}/upload` | `X-Agent-Key` header |
+
+#### Shares (`/v1/shares/*`)
+
+| Method | Path | Auth required |
+|--------|------|---------------|
+| GET | `/v1/shares` | user JWT |
+| POST | `/v1/shares` | user JWT |
+| GET | `/v1/shares/{share_id}` | optional JWT or share password |
+| PATCH | `/v1/shares/{share_id}` | user JWT (owner/admin) |
+| DELETE | `/v1/shares/{share_id}` | user JWT (owner/admin) |
+| GET | `/v1/shares/{share_id}/members` | user JWT |
+| POST | `/v1/shares/{share_id}/members` | user JWT (owner/admin) |
+| PATCH | `/v1/shares/{share_id}/members/{user_id}` | user JWT (owner/admin) |
+| DELETE | `/v1/shares/{share_id}/members/{user_id}` | user JWT (owner/admin) |
+
+---
+
+## Current State: Plugin Auth Model
+
+### Two Operating Modes
+
+#### Mode A: System 3 / PocketBase (cloud-hosted EVC relay)
+
+Login is via OAuth2 redirect (Google, GitHub, Discord, Microsoft, OIDC). The plugin opens Obsidian's built-in webview, intercepts the OAuth redirect URI, and calls `pb.collection("users").authWithOAuth2Code(...)` (`LoginManager.ts:604–619`). No email/password form exists in this mode.
+
+Token storage: `LocalAuthStore` (`src/pocketbase/LocalAuthStore.ts`), localStorage key `evc-team-relay_pocketbase_auth_<vaultName>`. Stored as `{token: "<PocketBase JWT>", model: {...}}`. Refreshed daily via `setInterval(..., 86400000)`.
+
+#### Mode B: relay-onprem (self-hosted control plane)
+
+Login is via email/password form (`RelayOnPremLoginModal.ts:147–201`) or OAuth2 browser redirect (`lines 221–258`), depending on what providers the control plane advertises at `GET /v1/auth/oauth/providers`.
+
+Token storage: `RelayOnPremAuthStore` (`src/auth/RelayOnPremAuthStore.ts`), localStorage key `evc-team-relay_onprem_auth_<vaultName>_<serverId>`. Stored as `{user: AuthUser, token: "<access_token>", expiresAt: <ms>, refreshToken?: "<refresh_token>"}`.
+
+Token lifecycle: access token expiry decoded from JWT `exp` claim or `expires_in` from login response. Background refresh via `ensureTokenRefreshed()`, triggered lazily from `getToken()` when token is within a 5-minute expiry buffer. Calls `POST /v1/auth/refresh` with `{refresh_token}` — 3 attempts with 0/1s/3s delays.
+
+### Bearer JWT Availability in Plugin Memory
+
+After login in relay-onprem mode, `RelayOnPremAuthProvider.token` holds the raw access token string in memory:
+
+- `authProvider.getToken()` — synchronous, may return a stale token
+- `authProvider.getValidToken()` — async, triggers refresh if needed; the correct method for any outbound API call
+
+`LoginManager` exposes the active provider via `loginManager.getAuthProvider()` or `loginManager.getAuthProviderForServer(serverId)`.
+
+The existing `RelayOnPremTokenProvider` already uses this pattern at line 137:
+
+```typescript
+const token = await this.config.authProvider.getValidToken();
+// then: Authorization: `Bearer ${token}`
+```
+
+The JWT is already in plugin memory and already being sent as `Authorization: Bearer` to the control plane. No auth plumbing changes are required on the plugin side to support agent-key creation.
+
+### All Current API Calls from Plugin
+
+| Endpoint | Method | Auth |
+|----------|--------|------|
+| `<cp>/auth/login` | POST | none |
+| `<cp>/auth/me` | GET | Bearer |
+| `<cp>/auth/logout` | POST | Bearer |
+| `<cp>/v1/auth/refresh` | POST | none (body) |
+| `<cp>/v1/auth/oauth/<provider>/authorize` | GET | none |
+| `<cp>/v1/auth/oauth/<provider>/callback` | GET | none |
+| `<cp>/v1/auth/oauth/providers` | GET | none |
+| `<cp>/shares` | GET/POST | Bearer |
+| `<cp>/shares/<id>` | GET/PATCH/DELETE | Bearer |
+| `<cp>/shares/<id>/members` | GET/POST | Bearer |
+| `<cp>/shares/<id>/members/<uid>` | DELETE/PATCH | Bearer |
+| `<cp>/shares/<id>/invites` | GET/POST | Bearer |
+| `<cp>/shares/<id>/invites/<id>` | DELETE | Bearer |
+| `<cp>/users/search?email=<email>` | GET | Bearer |
+| `<cp>/server/info` | GET | none |
+| `<cp>/tokens/relay` | POST | Bearer |
+| `<cp>/v1/web/shares/<slug>/files` | POST | Bearer |
+| `<cp>/v1/billing/plan` | GET | Bearer |
+| `<cp>/v1/billing/plans` | GET | none |
+| `<cp>/v1/billing/checkout` | POST | Bearer |
+| `<cp>/v1/billing/change-plan` | POST | Bearer |
+| `<cp>/v1/billing/cancel` | POST | Bearer |
+| `<cp>/v1/billing/portal` | POST | Bearer |
+
+### Key Plugin Files
+
+| File | Role |
+|------|------|
+| `src/auth/RelayOnPremAuthProvider.ts` | Auth logic, token lifecycle, `getValidToken()` |
+| `src/auth/RelayOnPremAuthStore.ts` | localStorage persistence |
+| `src/auth/IAuthProvider.ts` | Interface contract |
+| `src/RelayOnPremShareClient.ts` | All CP API calls — add new `createAgentKey()` method here |
+| `src/components/RelayOnPremSettings.svelte` | Nav shell — add new view entry here |
+| `src/components/RelayOnPremServerList.svelte` | Server list — add "Agent Keys" button here |
+| `src/ui/RelayOnPremLoginModal.ts` | Login modal (reference for modal patterns) |
+
+---
+
+## UX Gap Analysis
+
+### Q1: Can a Casdoor-only user (e.g. rj@entire.vc) currently create an agent key without a local password?
+
+**Yes.** No local password is required. The sequence:
+
+1. `GET /v1/auth/oauth/casdoor/authorize?redirect_uri=...` — redirect to Casdoor
+2. User authenticates in Casdoor — callback `GET /v1/auth/oauth/casdoor/callback?code=...&state=...`
+3. Control plane exchanges the code, fetches userinfo, creates or finds the user record, then calls `security.create_access_token()` to mint a local HS256 JWT and a refresh token stored in `user_sessions`.
+4. That local JWT can be used immediately as `Authorization: Bearer <token>` to call `POST /v1/web/shares/{share_id}/agent-keys`.
+
+**What would block them** (both are non-issues for a known account):
+- Using the Casdoor-issued JWT directly as a Bearer header fails — `security.decode_access_token` uses HS256 + local `jwt_secret`; a Casdoor JWT uses RS256/Casdoor's private key and will produce `InvalidTokenError` → 401.
+- If `oauth_auto_register=false` and no existing account — 403 at `oauth.py:200`. For `rj@entire.vc` this does not apply.
+
+Programmatic use (without a browser) is also possible: the OAuth callback returns a JSON `OAuthCallbackResponse` when `Accept: application/json` is set or when no `return_url` is present in state.
+
+### Q2: Where does `Authorization: Bearer` come from for the agent-keys API right now?
+
+The Bearer token accepted by `POST/GET/DELETE /v1/web/shares/{share_id}/agent-keys` is a **locally-minted HS256 JWT** issued by `apps/control-plane/app/core/security.py` — specifically `security.create_access_token()`. Every auth path converges here before any agent-key operation:
+
+- Local password login → `auth.py` → `security.create_access_token()` → Bearer JWT
+- Casdoor OAuth callback → `oauth.py:200–210` → same `security.create_access_token()` → Bearer JWT
+- Any future OIDC provider → same convergence point
+
+The validator is `_require_share_owner_or_admin` in `agent_keys.py:22–68`, which calls `security.decode_access_token(token)` — HS256, local `jwt_secret`, no JWKS, no Casdoor middleware.
+
+On the plugin side, `RelayOnPremAuthProvider.getValidToken()` returns this same locally-minted token. All authenticated calls in `RelayOnPremShareClient` attach it via `getHeaders()` (`RelayOnPremShareClient.ts:291–300`). Adding a `createAgentKey()` method requires only a new `customFetch` call using the existing `getHeaders()` helper — no auth changes.
+
+### Q3: What can a regular user (non-admin) currently see/do regarding agent keys?
+
+Any authenticated user who is a **share member at any role level** (including viewer) can:
+- `POST /v1/web/shares/{share_id}/agent-keys` — create a new agent key, receiving the raw key value once
+- `GET /v1/web/shares/{share_id}/agent-keys` — list all keys on the share (metadata only, no raw values)
+- `DELETE /v1/web/shares/{share_id}/agent-keys/{key_id}` — soft-revoke any key on the share
+
+There is no role hierarchy enforcement within the share for key management. `_require_share_owner_or_admin` is misleadingly named — it actually accepts any `ShareMember`, not only owners or admins. A viewer-role member can create and revoke keys with the same permissions as the share owner.
+
+**Implication**: this is a permissions gap that should be addressed in a follow-up. Key creation and revocation should likely be restricted to share owners and global admins, not all members.
+
+**What a regular user cannot do**:
+- Retrieve the raw key value after creation (list endpoint omits it)
+- Use agent keys against any endpoint other than `POST /v1/web/shares/{slug}/upload`
+- Create account-scoped keys (no such concept exists yet — all keys are per-share)
+
+### Q4: Recommended placement — where should "create agent key" live — plugin settings vs web UI?
+
+**Plugin settings is the correct primary surface.** The web UI is not a blocker and should be deferred.
+
+Rationale:
+- The Bearer token is already in plugin memory — zero auth plumbing needed.
+- Agent keys are consumed by agent configurations, not by web users. The plugin is where an agent-integrating user already is when they configure shares and connections.
+- Obsidian plugins conventionally put credential management in Settings. This is where technically-minded users expect to find it and where documentation points.
+- A dedicated web UI adds a second place to manage the same resource, creating a split-brain problem if the two surfaces show different state.
+
+Implementation path: new `createAgentKey(label: string, expiresAt?: string)` method on `RelayOnPremShareClient` calling `POST /v1/web/shares/{share_id}/agent-keys` with `await this.getHeaders()`. New `AgentKeysView.svelte` component added to `RelayOnPremSettings.svelte`'s view union. Entry point button in `RelayOnPremServerList.svelte` alongside the existing "Open Shares" and "Billing" buttons.
+
+---
+
+## Prior Art: API Key UX Patterns
+
+### Comparison Table
+
+| Aspect | Notion | Linear | Anthropic Console | GitHub |
+|--------|--------|--------|-------------------|--------|
+| **Location in UI** | Settings → Connections → "Develop or manage integrations" (workspace-level); also notion.so/my-integrations | Settings → Account → API (personal settings, not workspace admin) | Console dashboard → API Keys (top-level nav item, prominent) | Settings → Developer settings → Personal access tokens (buried 3 levels deep) |
+| **Scope model** | Per-workspace integration, then per-page/database "connection" grant required | Per-account; one key works across all teams the user belongs to | Per-workspace (org-scoped); keys belong to org, not individual | Per-account (classic PAT); or per-repository / fine-grained (owner + resource + permission matrix) |
+| **Key naming** | Human name + optional description + logo; name mandatory | User-provided label; no description | User-provided label; optional description; shows creation date | Classic: user-provided note (required). Fine-grained: name + expiry + resource scope — structured wizard |
+| **One-time reveal** | Shown once in a modal immediately after creation, with a copy button | Shown once on creation page with copy button; navigating away loses it | Shown once after creation with "Copy" button and warning banner; not re-shown | Shown once on confirmation page; green "Copy" button; banner says it won't be shown again |
+| **Revocation** | List with "Delete" per integration; no bulk; permanent and disconnects all pages | List with trash icon per key; no bulk | List with "Revoke" action per key; shows last-used date | Classic: "Delete". Fine-grained: "Revoke"; can regenerate; no native bulk; expiry dates visible |
+| **Re-auth for create** | No re-auth; must be workspace admin or developer role | No re-auth; any member can create their own key | No re-auth at creation; workspace admin can restrict creation | Classic: no re-auth. Fine-grained: password confirmation if session is old (soft re-auth) |
+| **Rate limits / quotas shown** | Not shown in key UI | Not shown in key UI | Usage dashboard on a separate page; tier shown in billing, not per-key | Rate limit tier in API response headers, not in PAT UI; no quota meter in settings |
+
+### Product-by-Product Notes
+
+**Notion**: Splits authorization into two layers — create the integration key, then separately grant it access to specific pages. The key alone is inert until a page "connects" it. Good for data hygiene; creates friction for non-technical users. The management page (notion.so/my-integrations) lives outside the main Settings flow, causing discoverability problems.
+
+**Linear**: The cleanest minimal implementation. Single settings screen, no wizard, no scope configuration. The assumption is that the key inherits the account holder's permissions — no per-resource scoping. Fast to create, low cognitive overhead. Downside: no granularity for read-only keys.
+
+**Anthropic Console**: The most prominent placement — API Keys is a first-class top-level nav item, not buried in settings. This reflects that key creation is the primary reason users visit the console. Workspace-level scoping is appropriate for a developer tool where the "account" is typically a team billing entity. The last-used timestamp per key is genuinely useful for audit and cleanup. No per-key rate limit display — usage is aggregated at workspace level on a separate page.
+
+**GitHub**: The fine-grained PAT is the most sophisticated scope model: owner → specific repositories → permission matrix per capability. Powerful but creates significant UI complexity. Classic PATs are the opposite: broad scopes, simple checklist, fast. GitHub is alone in offering token regeneration (fine-grained), which allows key rotation without disrupting integrations that have received the value. Password re-confirmation for fine-grained tokens on stale sessions is a lightweight soft-2FA substitute.
+
+---
+
+## Recommendations
+
+### 1. Where to expose key management
+
+**Primary surface: Obsidian plugin settings, dedicated "Agent Keys" section per server.**
+
+This matches Linear and Anthropic Console — a dedicated section easy to explain, document, and link to from integration guides. Settings is where credential-holding users expect to find credentials in Obsidian.
+
+Implementation in plugin:
+- New view `"agentKeys"` added to the `ViewType` union in `RelayOnPremSettings.svelte`.
+- New `AgentKeysView.svelte` component: lists keys (name, scope, created, last-used, revoke button); "Create key" button opens a modal.
+- Entry point button in `RelayOnPremServerList.svelte` alongside the existing "Open Shares" and "Billing" buttons.
+
+**Secondary surface: contextual shortcut in the share detail view.**
+
+When a user is configuring a specific share, surface a "Create agent key for this share" button inline. Clicking it opens the same creation modal, pre-scoped to that share. This mirrors the Notion pattern (connecting integrations at the resource level) but in reverse — creation from context, not from a global list.
+
+This dual-surface design eliminates the Notion discoverability problem while keeping a canonical list in Settings.
+
+**Deferred: web UI.** A web management page for agent keys adds maintenance surface and creates a split state problem. Build it only when there is explicit demand from users who do not use the Obsidian plugin (e.g. API-only consumers of the self-hosted relay).
+
+### 2. Scope model
+
+**Per-share scope as the default, with account-scope as a deliberate advanced option.**
+
+Per-account keys that grant access to everything are a footgun in agent contexts. A single leaked key or misbehaving agent touches the entire vault history. Per-share scope limits blast radius.
+
+Recommended hierarchy:
+- **Share-scoped key** (default, encouraged): grants `write` access only to the specified share. Scope is set at creation and is immutable.
+- **Account-scoped key** (advanced): grants access to all current and future shares. Gated behind an explicit confirmation step ("This key will access all your shares — are you sure?"). Displayed with a warning badge in the key list.
+
+This maps to GitHub's fine-grained PAT philosophy: specific-by-default, broad by explicit choice.
+
+Note: scope is enforced server-side by the relay/MCP ACL layer, not solely by the key. The key is a credential; the share ACL is the policy. Keep these concerns separate — do not try to encode policy inside the key itself.
+
+**Immediate follow-up**: restrict key creation and revocation to share owners and global admins. The current `_require_share_owner_or_admin` validator accepts any `ShareMember`, including viewer-role. This should be tightened on the backend before shipping a UI that implies ownership semantics.
+
+### 3. One-time reveal
+
+Follow the Anthropic Console and GitHub pattern, adapted for Obsidian modal constraints:
+
+1. On key creation, open a dedicated `Modal` (not a toast, not inline text). Display the key value in a monospace `<input>` or `<code>` element.
+2. Show a prominent one-time warning: "This key will not be shown again. Copy it now."
+3. Single "Copy to clipboard" button with a visual confirmation state (changes to "Copied ✓" for 2 seconds).
+4. Optionally offer "Download as .txt" — useful for users who want to store it in a password manager without clipboard exposure.
+5. Dismiss requires an explicit "I've copied this key" button, not a generic close. This forces acknowledgment.
+
+Do not re-reveal the key anywhere after dismissal. The key list shows only: name, share scope, created date, last-used date (if the backend tracks it — currently it does not; worth adding a `last_used_at` column to `share_agent_keys`), and revoke action.
+
+**Never store the raw key value in plugin settings storage.** Store only the key ID, name, and share scope. The user is responsible for storing the secret in their password manager or agent config file.
+
+### 4. Security constraints and re-auth
+
+**Soft re-auth for key creation; no re-auth for revocation.**
+
+Key creation is a higher-stakes action: a stolen session that creates a key and passes it to an external agent creates a persistent threat that outlasts the stolen session. A stolen session that revokes keys is disruptive but self-limiting and immediately visible.
+
+Implementation with Casdoor SSO:
+- On "Create Agent Key": check the Casdoor session age. If the session token was issued more than 30 minutes ago, require the user to re-authenticate via Casdoor before the creation form appears. Use OIDC `prompt=login` or `max_age` parameter — not a full logout/login cycle.
+- Surface this as: "Creating agent keys requires confirming your identity. You'll be redirected to sign in." — neutral phrasing, not a security warning.
+- On "Revoke": no re-auth. Revocation is a protective action; adding friction here discourages timely cleanup.
+
+If Casdoor is unavailable (offline vault, local-only mode): skip re-auth silently. The threat model for an offline Obsidian vault is different, and blocking key creation when SSO is unreachable degrades a legitimate use case.
+
+This mirrors GitHub's fine-grained PAT behavior (soft password prompt on stale session) without requiring a separate credential-confirmation UI.
+
+### 5. Open follow-up items
+
+| Item | Priority | Owner |
+|------|----------|-------|
+| Restrict agent-key CRUD to share owners/admins (fix `_require_share_owner_or_admin`) | High | Gandalf |
+| Populate `created_by` FK on key creation (`agent_keys.py:106–112`) | Medium | Gandalf |
+| Add `last_used_at` column to `share_agent_keys` table and update on upload | Medium | Gandalf |
+| Add `createAgentKey()` method to `RelayOnPremShareClient.ts` | High | Gandalf |
+| Build `AgentKeysView.svelte` + entry point in `RelayOnPremServerList.svelte` | High | Gandalf |
+| Soft re-auth gate via OIDC `max_age` on key creation | Medium | Gandalf |
+| Account-scoped key support (backend + UI) | Low | Backlog |
+| Web UI for agent key management | Low | Backlog |

--- a/docs/design-agent-keys-plugin-ui.md
+++ b/docs/design-agent-keys-plugin-ui.md
@@ -1,0 +1,886 @@
+# Agent Keys — Design Doc: Plugin UI + Backend API
+
+_Date: 2026-05-31 | Author: Daedalus | Status: Ready for implementation_
+
+---
+
+## Overview
+
+Team Relay currently has no way for external tools (Mesh agents, CI pipelines, local scripts) to write to a share without using a user's personal JWT. This doc specifies the Agent Key feature end-to-end: the backend API changes required on the control plane and the Obsidian plugin UX for creating, listing, and revoking keys. The backend table and endpoints already exist (migration `202605220001`); this doc targets the gaps (auth tightening, missing field population, rate limits, audit logging) and the plugin UI that does not exist yet.
+
+---
+
+## Backend API Design
+
+_Date: 2026-05-31 | Designed by: Daedalus_
+
+---
+
+### 1. Current State Snapshot (What Already Exists)
+
+The `share_agent_keys` table and all three CRUD endpoints landed in migration `202605220001` (2026-05-22). The table schema and endpoints are already production-present. This spec does **not** propose a greenfield build — it proposes targeted changes to fix known gaps in the existing implementation.
+
+**Existing table: `share_agent_keys`**
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | UUID PK | `uuid4()` default |
+| `share_id` | UUID FK → `shares.id` CASCADE | indexed |
+| `key_hash` | VARCHAR(64) UNIQUE | SHA-256 hex of raw key, indexed |
+| `label` | VARCHAR(255) nullable | user-provided name |
+| `scopes` | VARCHAR(255) | hardcoded `"write"` at creation |
+| `created_by` | UUID FK → `users.id` SET NULL nullable | **not populated at creation — bug** |
+| `last_used_at` | TIMESTAMPTZ nullable | **not updated on upload — bug** |
+| `expires_at` | TIMESTAMPTZ nullable | optional TTL |
+| `revoked_at` | TIMESTAMPTZ nullable | soft-revoke timestamp |
+| `created_at` | TIMESTAMPTZ | server_default now() |
+| `updated_at` | TIMESTAMPTZ | server_default now() |
+
+**Existing endpoints** (`agent_keys.py`, router prefix `/v1/web/shares/{share_id}/agent-keys`):
+
+| Method | Path | Status |
+|--------|------|--------|
+| POST | `/v1/web/shares/{share_id}/agent-keys` | Exists, needs fixes |
+| GET | `/v1/web/shares/{share_id}/agent-keys` | Exists, correct |
+| DELETE | `/v1/web/shares/{share_id}/agent-keys/{key_id}` | Exists, correct |
+
+---
+
+### 2. Endpoint Design
+
+#### Architecture Decision: Option C (partial)
+
+Use the existing share-scoped paths for all operations. The `/v1/me/agent-keys` cross-share list endpoint is **deferred to backlog** — it requires an account-scope key concept that does not exist yet, and adds no value for the Obsidian plugin (which is always operating in the context of a specific share). The plugin can aggregate per-share lists client-side if needed.
+
+**Chosen path structure:**
+```
+POST   /v1/web/shares/{share_id}/agent-keys          # create
+GET    /v1/web/shares/{share_id}/agent-keys          # list (exists)
+DELETE /v1/web/shares/{share_id}/agent-keys/{key_id} # revoke (exists)
+```
+
+---
+
+#### 2.1 POST `/v1/web/shares/{share_id}/agent-keys` — Create
+
+**Current state:** exists. Needs three fixes: populate `created_by`, restrict to owners/admins, enforce per-share key count.
+
+**Authentication**
+
+Accepts only the control plane's own locally-minted HS256 JWT as `Authorization: Bearer <token>`. This is the same token already stored in `RelayOnPremAuthStore` and sent by all existing plugin API calls. No Casdoor JWT is accepted — see Section 4 on why Casdoor JWT middleware is not needed.
+
+Caller must be: global admin OR share owner. **Not** any share member (see Section 5 — current `_require_share_owner_or_admin` is misnamed and accepts viewers; this must be tightened).
+
+**Request**
+
+```
+POST /v1/web/shares/{share_id}/agent-keys
+Authorization: Bearer <cp_jwt>
+Content-Type: application/json
+```
+
+```json
+{
+  "label": "My Agent Config",
+  "expires_at": "2027-01-01T00:00:00Z"
+}
+```
+
+| Field | Type | Required | Validation |
+|-------|------|----------|------------|
+| `label` | string | no | max 255 chars; trimmed; defaults to `null` |
+| `expires_at` | ISO 8601 datetime | no | must be future; max 2 years from now; `null` = no expiry |
+
+**Response 201**
+
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "key": "tr_agent_a3f8b2c1d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3",
+  "label": "My Agent Config",
+  "scopes": ["write"],
+  "share_id": "...",
+  "expires_at": "2027-01-01T00:00:00Z",
+  "created_at": "2026-05-31T10:00:00Z"
+}
+```
+
+The `key` field contains the raw secret. It is shown **once only**. It is not stored — only its SHA-256 hash is persisted. The `key` field is absent from all subsequent GET responses.
+
+**Error responses**
+
+| Status | Condition |
+|--------|-----------|
+| 401 | Missing or invalid Bearer token |
+| 403 | Authenticated but caller is not owner or global admin of this share |
+| 404 | `share_id` does not exist |
+| 409 | Per-share key limit reached (default: 20 active non-revoked keys; see Section 5) |
+| 422 | `expires_at` is in the past or more than 2 years out; `label` > 255 chars |
+| 429 | Creation rate limit hit (see Section 5) |
+
+---
+
+#### 2.2 GET `/v1/web/shares/{share_id}/agent-keys` — List
+
+**Current state:** exists and correct. No structural changes needed. Add `created_by_email` to response once `created_by` is populated.
+
+**Authentication:** same as POST — Bearer CP JWT, owner or admin only (tighten from current any-member).
+
+**Response 200**
+
+```json
+[
+  {
+    "id": "550e8400-...",
+    "label": "My Agent Config",
+    "scopes": ["write"],
+    "share_id": "...",
+    "created_by": "user-uuid",
+    "created_at": "2026-05-31T10:00:00Z",
+    "last_used_at": "2026-05-31T11:30:00Z",
+    "expires_at": "2027-01-01T00:00:00Z",
+    "revoked_at": null,
+    "is_active": true
+  }
+]
+```
+
+`is_active` is a computed field: `revoked_at IS NULL AND (expires_at IS NULL OR expires_at > now())`. Computed in Python, not stored. Saves the plugin from duplicating this logic.
+
+Raw `key` value is **never** returned in list or any subsequent GET.
+
+**Error responses**
+
+| Status | Condition |
+|--------|-----------|
+| 401 | Missing or invalid Bearer token |
+| 403 | Not owner or admin |
+| 404 | Share not found |
+
+---
+
+#### 2.3 DELETE `/v1/web/shares/{share_id}/agent-keys/{key_id}` — Revoke
+
+**Current state:** exists and correct (soft-revoke via `revoked_at`). No structural changes needed beyond the auth tightening.
+
+**Authentication:** Bearer CP JWT, owner or admin only.
+
+**Response 200**
+
+```json
+{
+  "id": "550e8400-...",
+  "revoked_at": "2026-05-31T12:00:00Z"
+}
+```
+
+Idempotent: revoking an already-revoked key returns 200 with the original `revoked_at`. Revoking a non-existent key returns 404.
+
+**Error responses**
+
+| Status | Condition |
+|--------|-----------|
+| 401 | Missing or invalid Bearer token |
+| 403 | Not owner or admin |
+| 404 | Key not found or does not belong to this share |
+
+---
+
+### 3. Database Changes
+
+#### 3.1 No new table required
+
+`share_agent_keys` already exists with the correct schema. Two columns exist but are not used:
+
+- `created_by` — column exists, FK defined, but `agent_keys.py:106–112` does not set it. Fix: populate at creation time with `user_id` extracted from the validated JWT.
+- `last_used_at` — column exists, but `web.py:1137–1175` (the upload endpoint) does not update it after a successful upload auth check. Fix: add an async fire-and-forget update after the key lookup succeeds.
+
+#### 3.2 Required migration: add key count index
+
+The per-share active key count check (for the 20-key cap enforcement) will run a query like:
+
+```sql
+SELECT COUNT(*) FROM share_agent_keys
+WHERE share_id = $1 AND revoked_at IS NULL;
+```
+
+The `share_id` index already exists (`ix_share_agent_keys_share_id`). No additional index is needed for this query, but a partial index would be more efficient for large deployments:
+
+```python
+# Migration: 202606010001_add_share_agent_keys_active_index.py
+op.create_index(
+    "ix_share_agent_keys_share_id_active",
+    "share_agent_keys",
+    ["share_id"],
+    postgresql_where=sa.text("revoked_at IS NULL"),
+)
+```
+
+#### 3.3 Migration: backfill `created_by`
+
+Keys created before this fix have `created_by = NULL`. This is acceptable — display as "Unknown" in the plugin UI. No backfill migration needed; the column was designed nullable for exactly this case.
+
+#### 3.4 Migration: update `last_used_at` on upload
+
+No schema change required. Only code change: in `web.py` after line 1175 (scope check passes), add:
+
+```python
+# fire-and-forget last_used_at update
+agent_key.last_used_at = security.utcnow()
+db.add(agent_key)
+db.commit()
+```
+
+Note: this is a synchronous DB write on the upload hot path. If upload latency becomes a concern, move to a background task via FastAPI's `BackgroundTasks`. For current scale, synchronous is acceptable.
+
+---
+
+### 4. Authentication: Casdoor JWT Validation
+
+#### Decision: No Casdoor JWT middleware needed
+
+The research confirms (`security.py:48–50`, `oauth.py:200–210`): all auth paths — local password and Casdoor OAuth — converge to the same locally-minted HS256 JWT before any API call. The control plane never accepts a Casdoor-issued JWT as a Bearer credential, and no code path does JWKS validation.
+
+**Why this is correct for the agent-keys use case:**
+
+The Obsidian plugin completes Casdoor OAuth once (via webview redirect), receives a local CP JWT, and stores it in `RelayOnPremAuthStore`. All subsequent API calls use this local JWT. The agent-key CRUD endpoints are called from the plugin — not from Casdoor directly. Adding Casdoor JWT middleware would create a second auth path with different security properties (RS256, external key rotation, network dependency on Casdoor at request time) for no benefit.
+
+**Auth flow for the agent-keys API (current and proposed):**
+
+```
+Plugin login (Casdoor path)
+  → GET /v1/auth/oauth/casdoor/authorize
+  → [Casdoor auth completes]
+  → GET /v1/auth/oauth/casdoor/callback
+  → control plane calls security.create_access_token()
+  → returns HS256 JWT to plugin
+  → plugin stores in RelayOnPremAuthStore
+
+Later: plugin calls agent-keys endpoint
+  → Authorization: Bearer <hs256_jwt>
+  → _require_share_owner_or_admin() calls security.decode_access_token()
+  → HS256 validation against jwt_secret
+  → user_id extracted from "sub" claim
+  → share ownership/admin check
+  → proceed
+```
+
+No Casdoor JWKS endpoint, no `python-jose` RS256 verification, no network call to Casdoor at request time.
+
+**What a Casdoor-only user (no local password) can do today:** fully create, list, and revoke agent keys, because the OAuth callback mints a local HS256 JWT indistinguishable from a password-login JWT. This is the correct behavior and requires no changes.
+
+---
+
+### 5. Security Design
+
+#### 5.1 Fix: Restrict CRUD to Share Owners and Global Admins
+
+**Current bug:** `_require_share_owner_or_admin` accepts any `ShareMember` (including viewer-role members). The function name implies restriction; the code does not enforce it.
+
+**Fix in `agent_keys.py:54–61`:**
+
+```python
+# Current (incorrect):
+is_authorized = user.is_admin or share.owner_user_id == user_id
+if not is_authorized:
+    member_stmt = select(models.ShareMember).where(...)
+    member = db.execute(member_stmt).scalar_one_or_none()
+    is_authorized = member is not None  # accepts ANY member role
+
+# Fixed:
+is_authorized = user.is_admin or share.owner_user_id == user_id
+# Remove the member fallback entirely — key management is owner/admin only
+```
+
+Viewer-role members can read share contents but cannot create or revoke credentials that grant write access. This matches the expected ownership semantics and what the plugin UI will imply.
+
+#### 5.2 Key Format
+
+**Existing format:** `tr_agent_` + `secrets.token_hex(24)` → total 57 chars (`tr_agent_` = 9 chars + 48 hex chars).
+
+This format is already implemented and live. It is adequate. No change proposed.
+
+Rationale for keeping it:
+- `tr_agent_` prefix is recognizable in logs and config files. Secret scanners can be trained on it.
+- 24 bytes = 192 bits of entropy from `secrets.token_hex`. Collision probability is negligible at any realistic scale.
+- SHA-256 of 57-char string stored as 64-char hex — correct, no truncation.
+
+#### 5.3 Rate Limits
+
+| Limit | Value | Rationale |
+|-------|-------|-----------|
+| Max active keys per share | 20 | Prevents key sprawl; agents rarely need more than 2–5 per share |
+| Key creation rate per user | 10 per hour | Prevents programmatic bulk creation |
+| Key creation rate per share | 20 per hour | Separate from per-user to catch coordinated abuse |
+
+Enforcement point: at the top of `create_agent_key()`, before DB write:
+
+```python
+# 1. Count active keys for this share
+active_count_stmt = select(func.count()).where(
+    models.ShareAgentKey.share_id == share.id,
+    models.ShareAgentKey.revoked_at.is_(None),
+)
+active_count = db.execute(active_count_stmt).scalar_one()
+if active_count >= settings.agent_key_max_per_share:  # default 20
+    raise HTTPException(
+        status_code=status.HTTP_409_CONFLICT,
+        detail=f"Share has reached the maximum of {settings.agent_key_max_per_share} active agent keys.",
+    )
+```
+
+Rate-limit header on 429 response: `Retry-After: <seconds>`.
+
+#### 5.4 Expiry Policy
+
+- **No mandatory expiry.** Forcing expiry creates friction for always-on agent configurations.
+- **Optional TTL on creation.** Plugin UI presents expiry as an optional field with a suggested "1 year" default (pre-filled, not mandatory).
+- **Maximum TTL cap (server-enforced):** reject `expires_at` more than 2 years from creation time.
+- **Cleanup:** a periodic background task (daily) can mark expired keys as revoked. The `is_active` computed field in list responses already hides them from the plugin UI in the meantime.
+
+#### 5.5 Audit Log
+
+No separate audit table. Record events in Python's standard logger at `INFO` level with structured fields.
+
+**Events to log:**
+
+```python
+# On create:
+logger.info(
+    "agent_key.created",
+    extra={
+        "event": "agent_key.created",
+        "key_id": str(agent_key.id),
+        "share_id": str(share.id),
+        "created_by": str(user_id),
+        "label": payload.label,
+        "expires_at": payload.expires_at.isoformat() if payload.expires_at else None,
+        "scopes": agent_key.scopes,
+        "ip": request.client.host if request.client else None,
+    }
+)
+
+# On revoke:
+logger.info(
+    "agent_key.revoked",
+    extra={
+        "event": "agent_key.revoked",
+        "key_id": key_id,
+        "share_id": share_id,
+        "revoked_by": str(user_id),
+        "ip": request.client.host if request.client else None,
+    }
+)
+
+# On upload auth (key use):
+logger.info(
+    "agent_key.used",
+    extra={
+        "event": "agent_key.used",
+        "key_id": str(agent_key.id),
+        "share_id": str(share.id),
+        "path": path,
+        "ip": request.client.host if request.client else None,
+    }
+)
+```
+
+The raw key value is **never** logged. Only `key_id` (the UUID).
+
+---
+
+### 6. Code Changes Required (Prioritized)
+
+| File | Change | Priority |
+|------|--------|----------|
+| `app/api/routers/agent_keys.py` | Remove viewer-member fallback from `_require_share_owner_or_admin`; populate `created_by` on create; add active-key count check; add `share_id` to create response; add `is_active` computed field to list response; add audit log calls | High |
+| `app/api/routers/web.py` | After key auth passes at line 1175: update `agent_key.last_used_at` and commit; add `agent_key.used` audit log | High |
+| `app/db/migrations/` | New migration `202606010001` for partial index on `share_agent_keys (share_id) WHERE revoked_at IS NULL` | Medium |
+| `app/core/config.py` | Add `agent_key_max_per_share: int = 20` and `agent_key_creation_rate_per_hour: int = 10` to `Settings` | Medium |
+
+---
+
+### 7. Mermaid Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Plugin as Obsidian Plugin<br/>(relay-onprem mode)
+    participant CP as Control Plane<br/>(/v1)
+    participant Casdoor as Casdoor SSO
+    participant DB as PostgreSQL<br/>(share_agent_keys)
+    participant Agent as Mesh Agent<br/>(MCP/CLI)
+    participant MinIO as MinIO Storage
+
+    Note over Plugin,Casdoor: One-time login (already done; token persists in RelayOnPremAuthStore)
+    Plugin->>CP: GET /v1/auth/oauth/casdoor/authorize
+    CP-->>Plugin: 302 → Casdoor login URL
+    Plugin->>Casdoor: [user authenticates in webview]
+    Casdoor-->>Plugin: redirect to /v1/auth/oauth/casdoor/callback?code=...
+    Plugin->>CP: GET /v1/auth/oauth/casdoor/callback?code=...
+    CP->>Casdoor: exchange code → userinfo
+    Casdoor-->>CP: {sub, email, ...}
+    CP->>DB: upsert user row; create user_sessions row
+    CP->>CP: security.create_access_token(user_id) → HS256 JWT
+    CP-->>Plugin: {access_token, refresh_token}
+    Plugin->>Plugin: store JWT in RelayOnPremAuthStore
+
+    Note over Plugin,DB: Agent key creation (new flow — plugin settings UI)
+    Plugin->>CP: POST /v1/web/shares/{share_id}/agent-keys<br/>Authorization: Bearer {hs256_jwt}<br/>{"label": "My Agent", "expires_at": null}
+    CP->>CP: security.decode_access_token(token) → user_id
+    CP->>DB: SELECT share WHERE id=share_id
+    CP->>DB: assert user is owner or global admin
+    CP->>DB: SELECT COUNT(*) active keys WHERE share_id (cap check)
+    CP->>CP: raw_key = "tr_agent_" + secrets.token_hex(24)<br/>key_hash = sha256(raw_key)
+    CP->>DB: INSERT share_agent_keys (share_id, key_hash, label, created_by=user_id, scopes="write")
+    CP->>CP: logger.info("agent_key.created", key_id=..., created_by=user_id)
+    CP-->>Plugin: 201 {"id": "...", "key": "tr_agent_...", "label": "...", "created_at": "..."}
+    Plugin->>Plugin: show key in one-time-reveal modal<br/>(never stored in plugin settings)
+
+    Note over Plugin,DB: User copies key → pastes into agent config file
+
+    Note over Agent,MinIO: Agent upload (existing flow, now with last_used_at fix)
+    Agent->>CP: POST /v1/web/shares/{slug}/upload?path=notes/output.md<br/>X-Agent-Key: tr_agent_...
+    CP->>CP: key_hash = sha256(X-Agent-Key header value)
+    CP->>DB: SELECT share_agent_keys WHERE key_hash=...
+    DB-->>CP: agent_key row
+    CP->>CP: verify: share matches slug, not revoked, not expired, scopes has "write"
+    CP->>DB: UPDATE share_agent_keys SET last_used_at=now() WHERE id=key_id
+    CP->>CP: logger.info("agent_key.used", key_id=..., path=...)
+    CP->>MinIO: PUT web-assets/{share_id}/notes/output.md
+    CP->>DB: upsert share.web_folder_items; bump web_content_updated_at
+    CP-->>Agent: 200 {"message": "uploaded", "path": "notes/output.md", "size": 1024}
+    Note over Plugin: Next sync cycle: plugin pulls updated folder items
+```
+
+---
+
+### 8. Open Items for Gandalf (Backend)
+
+| # | Task | Blocking |
+|---|------|---------|
+| 1 | Fix `_require_share_owner_or_admin`: remove viewer-member fallback, restrict to owner + global admin | Plugin UI (users expect ownership semantics) |
+| 2 | Populate `created_by` in `create_agent_key()` (`agent_keys.py:106`) | Audit completeness |
+| 3 | Update `last_used_at` on successful upload auth (`web.py`, after line 1175) | Plugin UI shows last-used |
+| 4 | Add active-key count cap (default 20) in `create_agent_key()` before DB insert | Rate safety |
+| 5 | Add `share_id` and `scopes` to `AgentKeyCreateResponse` | Plugin needs to confirm scoping |
+| 6 | Add `is_active` computed field to `AgentKeyListItem` | Plugin active/inactive badge |
+| 7 | Structured audit logging (create / revoke / use events) | Operator observability |
+| 8 | Migration `202606010001`: partial index on `share_id WHERE revoked_at IS NULL` | Performance (low urgency) |
+| 9 | `agent_key_max_per_share` config knob in `Settings` | Operator configurability |
+
+---
+
+## Plugin UX Design
+
+---
+
+### Placement Decision
+
+**Recommendation: Option C — Settings as primary surface, share context as secondary shortcut.**
+
+**Rationale:**
+
+The research identifies two distinct user moments when agent keys become relevant:
+
+1. **Global credential audit** — "what keys do I have, across all my shares?" A user setting up a new agent config or rotating keys needs a single place to see everything. This belongs in Settings.
+
+2. **In-context provisioning** — "I'm configuring this share right now and I want a key for it." A user who is already looking at a share detail view should not have to navigate elsewhere.
+
+Option A alone fails moment 2 — too much navigation cost when the user is already at the resource. Option B alone fails moment 1 — no canonical list, no cross-share audit surface, poor discoverability. The Anthropic Console gets this right: API Keys is a first-class section in the nav, not a sub-menu of individual resources.
+
+**Selected architecture:**
+
+- **Primary**: "Agent Keys" entry in the server settings nav sidebar, rendered as a full list view (`AgentKeysView.svelte`)
+- **Secondary**: "Create agent key" button inline in the share detail view, pre-filling the share selector in the create modal
+- **Deferred**: web UI, account-scoped keys
+
+---
+
+### User Flow (Step by Step)
+
+**Path A: via Settings (discovery / management)**
+
+1. User opens Obsidian, clicks the Team Relay ribbon icon or opens Command Palette → "Team Relay: Open settings"
+2. Plugin opens the relay settings panel. If not yet authenticated, login modal appears first (existing `RelayOnPremLoginModal.ts` flow).
+3. Left sidebar shows the server list. Under the connected server, user sees nav items: Shares · Members · Billing · **Agent Keys** (new).
+4. User clicks **Agent Keys**. `AgentKeysView.svelte` renders with the full key list for all shares this user owns, grouped by share name.
+5. If no keys exist yet → empty state with a single "Create your first agent key" CTA.
+6. User clicks **Create agent key** button (top-right of list, or the CTA).
+7. **Soft re-auth check**: plugin reads `RelayOnPremAuthStore` and decodes the JWT `iat` claim. If token was issued more than 30 minutes ago, a banner appears: "Creating agent keys requires confirming your identity." Button reads "Continue to sign in" → plugin initiates OIDC authorize with `max_age=0` (force re-authentication). On callback, plugin re-stores the new JWT and returns the user to the create modal. If the server is unreachable (offline), skip re-auth silently.
+8. **Create key modal** opens. Fields: Label (required), Share (dropdown of user's owned shares), Expiry (optional, date picker — default: no expiry).
+9. User fills in label, selects share, clicks **Create key**.
+10. Plugin calls `POST /v1/web/shares/{share_id}/agent-keys` with `Authorization: Bearer {getValidToken()}` and body `{label, expires_at}`.
+11. On 201 response: create modal closes, **one-time reveal modal** opens immediately with the raw key value.
+12. User copies the key (copy button or manual selection), clicks **"I've copied this key"** to dismiss.
+13. User is returned to the key list. The new key appears in the list with: label, share name, created timestamp, "never expires" or expiry date, **Revoke** button. Raw key is never shown again.
+14. User pastes the key into `relay_mcp.py` config (or `.env` file) as the `AGENT_KEY` value.
+
+**Path B: via share detail (in-context provisioning)**
+
+1. User opens Team Relay sidebar, navigates to a specific share.
+2. In the share detail view, alongside existing "Members" and "Settings" buttons, a new **"Agent Keys"** button appears.
+3. User clicks it → create key modal opens, share selector is pre-filled and locked to this share.
+4. Steps 7–14 from Path A continue identically.
+
+---
+
+### Screen Designs
+
+#### Agent Keys List View
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  ← Team Relay Settings · my-relay-server                   │
+├─────────────────────────────────────────────────────────────┤
+│  Shares  Members  Billing  [Agent Keys]                     │
+├─────────────────────────────────────────────────────────────┤
+│                                                             │
+│  Agent Keys                          [+ Create agent key]  │
+│  ─────────────────────────────────────────────────────────  │
+│                                                             │
+│  Share: research-vault                                      │
+│  ┌────────────────────┬──────────────────┬──────────────┐   │
+│  │ Label              │ Created          │              │   │
+│  ├────────────────────┼──────────────────┼──────────────┤   │
+│  │ local-agent-v1     │ 2026-05-31       │ [Revoke]     │   │
+│  │ ci-pipeline        │ 2026-05-28       │ [Revoke]     │   │
+│  └────────────────────┴──────────────────┴──────────────┘   │
+│                                                             │
+│  Share: team-notes                                          │
+│  ┌────────────────────┬──────────────────┬──────────────┐   │
+│  │ Label              │ Created          │              │   │
+│  ├────────────────────┼──────────────────┼──────────────┤   │
+│  │ daedalus-agent     │ 2026-05-20       │ [Revoke]     │   │
+│  └────────────────────┴──────────────────┴──────────────┘   │
+│                                                             │
+│  Share: archive-2025                                        │
+│  ╌╌ No agent keys ╌╌                    [+ Create key]      │
+│                                                             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+Notes: no raw key value anywhere in this view. "Revoke" is styled in muted red, not the primary action color. The "Created" column uses relative time (e.g. "3 days ago") with full date on hover. Once `last_used_at` is populated by the backend fix, a "Last used" column appears here.
+
+---
+
+#### Create Key Modal
+
+```
+┌──────────────────────────────────────────┐
+│  Create agent key                    [×] │
+├──────────────────────────────────────────┤
+│                                          │
+│  Label *                                 │
+│  ┌──────────────────────────────────┐    │
+│  │ e.g. "local-agent-v2"            │    │
+│  └──────────────────────────────────┘    │
+│  Used to identify this key in the list   │
+│                                          │
+│  Share *                                 │
+│  ┌──────────────────────────────────┐    │
+│  │ research-vault               [▾] │    │
+│  └──────────────────────────────────┘    │
+│  (only shows shares you own or admin)    │
+│                                          │
+│  Expires                                 │
+│  ┌──────────────────────────────────┐    │
+│  │ Never (default)              [▾] │    │
+│  └──────────────────────────────────┘    │
+│  Options: 30 days · 90 days · 1 year ·   │
+│           Custom date · Never            │
+│                                          │
+│  ─────────────────────────────────────   │
+│                 [Cancel]  [Create key]   │
+└──────────────────────────────────────────┘
+```
+
+Notes: "Create key" button is disabled until label is non-empty. Share selector shows only shares where the user is owner (aligned to the permissions fix, even before the backend patch lands — optimistic UI, will 403 otherwise). If opened from share context, the share selector is replaced with a static text label showing the share name (no dropdown).
+
+---
+
+#### One-Time Reveal Modal
+
+```
+┌──────────────────────────────────────────────────┐
+│  Agent key created                           [×] │
+├──────────────────────────────────────────────────┤
+│                                                  │
+│  ⚠  This key will not be shown again.            │
+│     Copy it now and store it securely.           │
+│                                                  │
+│  ┌────────────────────────────────────────────┐  │
+│  │ tr_agent_4a7f2c1e9b3d6082a5f1c8e4b9d7...  │  │
+│  └────────────────────────────────────────────┘  │
+│  (monospace, full width, selectable)             │
+│                                                  │
+│              [Copy to clipboard]  [Download .txt]│
+│                                                  │
+│  ─────────────────────────────────────────────   │
+│  Label:   local-agent-v2                         │
+│  Share:   research-vault                         │
+│  Expires: Never                                  │
+│  ─────────────────────────────────────────────   │
+│                                                  │
+│            [I've copied this key — close]        │
+└──────────────────────────────────────────────────┘
+```
+
+Notes:
+- The `[×]` close button triggers a confirmation before silently dismissing (second click required after warning).
+- "Copy to clipboard" changes to "Copied" for 2 seconds after click, then resets. Does not close the modal.
+- "Download .txt" downloads `tr-agent-key-{label}-{date}.txt` with key value and metadata.
+- "I've copied this key — close" is the primary dismiss path.
+- Do not dismiss on backdrop click.
+
+---
+
+#### Revoke Confirmation
+
+```
+┌──────────────────────────────────────────────┐
+│  Revoke agent key?                       [×] │
+├──────────────────────────────────────────────┤
+│                                              │
+│  Revoking "local-agent-v1" will immediately  │
+│  block any agent using this key from         │
+│  uploading to research-vault.                │
+│                                              │
+│  This cannot be undone.                      │
+│                                              │
+│              [Cancel]  [Revoke key]          │
+└──────────────────────────────────────────────┘
+```
+
+Notes: "Revoke key" is in a destructive color (Obsidian uses `--color-red`). No re-auth required. On success, the key row is removed immediately (optimistic UI).
+
+---
+
+### Auth Reuse
+
+**Where the JWT lives in plugin code:**
+
+The locally-minted HS256 JWT is stored in `RelayOnPremAuthStore` under localStorage key `evc-team-relay_onprem_auth_<vaultName>_<serverId>`. In memory, accessible via `RelayOnPremAuthProvider.token` (synchronous, possibly stale) or `RelayOnPremAuthProvider.getValidToken()` (async, refreshes if within 5-minute expiry window).
+
+The correct method for any outbound API call — including agent key CRUD — is `getValidToken()`. The existing refresh mechanism (`POST /v1/auth/refresh` with 3 retry attempts at 0s/1s/3s delays) handles token renewal transparently.
+
+**New methods to add to `RelayOnPremShareClient.ts`:**
+
+```typescript
+async createAgentKey(shareId: string, label: string, expiresAt?: string): Promise<AgentKeyCreateResponse> {
+    const headers = await this.getHeaders();
+    return this.customFetch(
+        `${this.baseUrl}/v1/web/shares/${shareId}/agent-keys`,
+        {
+            method: 'POST',
+            headers,
+            body: JSON.stringify({ label, ...(expiresAt ? { expires_at: expiresAt } : {}) }),
+        }
+    );
+}
+
+async listAgentKeys(shareId: string): Promise<AgentKeyListItem[]> {
+    const headers = await this.getHeaders();
+    return this.customFetch(
+        `${this.baseUrl}/v1/web/shares/${shareId}/agent-keys`,
+        { method: 'GET', headers }
+    );
+}
+
+async revokeAgentKey(shareId: string, keyId: string): Promise<void> {
+    const headers = await this.getHeaders();
+    return this.customFetch(
+        `${this.baseUrl}/v1/web/shares/${shareId}/agent-keys/${keyId}`,
+        { method: 'DELETE', headers }
+    );
+}
+```
+
+No changes to `RelayOnPremAuthProvider.ts`, `RelayOnPremAuthStore.ts`, or `IAuthProvider.ts`.
+
+**Soft re-auth implementation:**
+
+```typescript
+// In AgentKeysView.svelte, before opening create modal:
+
+async function checkSessionFreshness(): Promise<boolean> {
+    const token = authProvider.token;  // synchronous read
+    if (!token) return false;
+    try {
+        const payload = JSON.parse(atob(token.split('.')[1]));
+        const iatMs = (payload.iat ?? 0) * 1000;
+        return (Date.now() - iatMs) < 30 * 60 * 1000;  // 30 min window
+    } catch {
+        return false;  // malformed token → treat as stale
+    }
+}
+
+async function onCreateClick() {
+    const fresh = await checkSessionFreshness();
+    if (!fresh) {
+        await loginManager.reAuthForSensitiveAction();
+        // new token already in store on return
+    }
+    openCreateModal();
+}
+```
+
+`loginManager.reAuthForSensitiveAction()` is a new thin method — same OIDC redirect flow as the existing OAuth login, with `max_age=0` appended to the authorize URL query string. No new auth infrastructure needed.
+
+---
+
+### Mermaid Flow Diagram
+
+```mermaid
+flowchart TD
+    A([User opens Team Relay settings]) --> B{Authenticated?}
+    B -- No --> C[Login modal\nRelayOnPremLoginModal.ts]
+    C --> D{Login success?}
+    D -- No --> C
+    D -- Yes --> E
+    B -- Yes --> E[Agent Keys list view\nAgentKeysView.svelte]
+
+    E --> F{Keys exist?}
+    F -- No --> G[Empty state\n'Create your first agent key']
+    F -- Yes --> H[List view: label · share · created · Revoke]
+
+    G --> I[Click 'Create agent key']
+    H --> I
+
+    I --> J{Session fresh?\niet ≤30 min}
+    J -- No --> K[Re-auth prompt\n'Confirm your identity']
+    K --> L[OIDC authorize\nmax_age=0]
+    L --> M{Re-auth success?}
+    M -- No --> N[Error banner\nreturn to list]
+    M -- Yes --> O
+    J -- Yes --> O[Create key modal\nLabel · Share · Expiry]
+
+    O --> P{Form valid?}
+    P -- No --> O
+    P -- Yes --> Q[Click 'Create key']
+
+    Q --> R{Network OK?}
+    R -- No --> S[Error state\nRetry button in modal]
+    S --> Q
+    R -- Yes --> T[POST /v1/web/shares/id/agent-keys\nAuthorization: Bearer getValidToken]
+
+    T --> U{Response?}
+    U -- 401 Session expired --> V[Re-auth prompt\nthen retry]
+    V --> T
+    U -- 403 Not owner --> W[Error: 'You must be a share owner\nto create agent keys']
+    U -- 201 Created --> X[One-time reveal modal\nkey value · Copy · Download]
+
+    X --> Y{User action}
+    Y -- Copy to clipboard --> Z['Copied' 2s\nstay in modal]
+    Z --> Y
+    Y -- Download .txt --> AA[Save file\nstay in modal]
+    AA --> Y
+    Y -- 'I have copied this key' --> BB[Modal closes\nReturn to list]
+
+    BB --> CC[Key appears in list\nLabel · Share · Created · Revoke]
+
+    H --> DD[Click 'Revoke']
+    DD --> EE[Revoke confirmation modal]
+    EE -- Cancel --> H
+    EE -- 'Revoke key' --> FF[DELETE /v1/web/shares/id/agent-keys/kid]
+    FF --> GG{Response?}
+    GG -- Error --> HH[Error banner\nRow stays in list]
+    GG -- 200 OK --> II[Row removed from list\nOptimistic UI]
+```
+
+---
+
+### Edge Cases
+
+**1. User session expired while creating a key**
+
+The 401 response from the create call is caught in `RelayOnPremShareClient`. Plugin surfaces an inline error inside the create modal: "Your session has expired. Sign in again to continue." Two buttons: **Cancel** (closes modal, discards form) and **Sign in** (triggers login flow, returns user to the pre-filled modal on success — label and share selection are preserved in component state). Do not silently discard the form.
+
+**2. Network error during create**
+
+Create modal stays open (do not close on error). The "Create key" button returns to its enabled state. Inline error appears below the button: "Could not reach the server. Check your connection and try again." A **Retry** link re-submits immediately (same form state). No automatic retry loop — user-initiated only. The operation is not idempotent; silent retry would create duplicate keys.
+
+**3. Key list empty state**
+
+When `GET /v1/web/shares/{share_id}/agent-keys` returns empty arrays for all shares:
+
+```
+  No agent keys yet.
+
+  Agent keys let external tools write to your shares
+  without using your personal login credentials.
+
+              [Create your first agent key]
+```
+
+**4. Share has no keys yet (within a populated list)**
+
+```
+  Share: archive-2025
+  ╌╌ No agent keys for this share ╌╌     [+ Create key →]
+```
+
+The inline `[+ Create key →]` opens the create modal pre-filled to that share.
+
+**5. Share disappeared between list load and revoke**
+
+If a share is deleted between the key list fetch and the revoke action, the DELETE endpoint returns 404. Plugin handles this as a soft error: remove the key row from the UI (the underlying share is gone — the key is already inert) and show a brief notice: "This share has been removed. The key has been cleaned up."
+
+**6. Concurrent session (two Obsidian windows, same vault)**
+
+Both windows share the same localStorage auth store. The list view should refresh on visibility gain (`document.addEventListener('visibilitychange', ...)`) or on mount. Pull on focus is sufficient — no real-time push needed.
+
+---
+
+## Implementation Checklist
+
+- [ ] Backend: Fix `_require_share_owner_or_admin` — remove viewer-member fallback
+- [ ] Backend: Populate `created_by` on POST `/v1/.../agent-keys`
+- [ ] Backend: Update `last_used_at` on upload auth success (`web.py`)
+- [ ] Backend: Active key count cap (20 per share) before DB insert
+- [ ] Backend: Add `share_id`, `scopes`, `is_active` to response schemas
+- [ ] Backend: Structured audit log (create / revoke / use)
+- [ ] Backend: DB migration `202606010001` — partial index on `share_id WHERE revoked_at IS NULL`
+- [ ] Backend: `agent_key_max_per_share` config knob in `Settings`
+- [ ] Plugin: `AgentKeysView.svelte` — list view grouped by share
+- [ ] Plugin: Create key modal with label / share / expiry fields
+- [ ] Plugin: One-time reveal modal with copy + download
+- [ ] Plugin: Revoke confirmation modal
+- [ ] Plugin: Share detail view — "Agent Keys" shortcut button
+- [ ] Plugin: Soft re-auth check before create (`checkSessionFreshness`)
+- [ ] Plugin: `loginManager.reAuthForSensitiveAction()` method
+- [ ] Plugin: Three new methods on `RelayOnPremShareClient.ts`
+- [ ] Plugin: Visibility-change refresh on key list view
+- [ ] Tests: Backend unit — auth restriction, created_by population, count cap, audit log
+- [ ] Tests: Backend integration — full create/list/revoke flow
+- [ ] Tests: Plugin-level — modal states, error handling, optimistic revoke
+- [ ] Docs: Quickstart for users at `entire.vc/docs/agent-keys/`
+
+---
+
+## Acceptance Criteria
+
+**Backend (C1):**
+1. `POST /v1/web/shares/{share_id}/agent-keys` returns 403 for viewer-role members (not just non-members).
+2. Created key rows have `created_by` populated with the authenticated user's UUID.
+3. Uploading a file via `X-Agent-Key` sets `last_used_at` on the key row.
+4. Creating more than 20 active keys on one share returns 409.
+5. Create response includes `share_id` and `scopes` fields.
+6. List response includes `is_active` computed field.
+7. Audit log lines appear in container stdout for create / revoke / use events. Raw key value absent from all logs.
+8. Migration `202606010001` applies cleanly on a fresh DB and an existing DB with data.
+
+**Plugin UX (C2):**
+1. "Agent Keys" tab visible in server settings sidebar when authenticated.
+2. List view groups keys by share name; "Created" column shows relative time.
+3. Create modal: label required, share dropdown filtered to owned shares only, expiry optional.
+4. One-time reveal modal: key shown once, copy button works, download saves a .txt file, modal requires explicit dismiss.
+5. Revoke: confirmation modal shown; on confirm, row removed optimistically; 404 on missing share handled gracefully.
+6. Soft re-auth triggered when JWT `iat` is >30 min old before opening create modal.
+7. Session expired (401) during create: form preserved, re-auth prompt shown inline.
+8. Network error during create: modal stays open, retry available, no silent retry loop.
+9. List refreshes on window visibility gain.
+
+**Docs (C4):**
+1. User-facing quickstart covers: creating a key, using it in `relay_mcp.py`, revoking it.
+2. No mention of internal implementation details.


### PR DESCRIPTION
## Summary
- Research report: \`dev-docs/research-agent-keys-ux.md\` (378 lines) — full auth-layer analysis, Casdoor-only user gap, prior-art comparison
- Design doc: \`docs/design-agent-keys-plugin-ui.md\` (886 lines) — backend API spec + plugin UX design, mermaid sequence diagrams, implementation checklist

These docs are the deliverable for Phase A+B of Mesh task \`65dc5949\` (agent keys UX gap). Phase C implementation (backend endpoints + plugin UI) is in flight via separate subtasks.

## What changed
- New: \`dev-docs/research-agent-keys-ux.md\` — answers: can Casdoor-only user create agent key today? (gap confirmed), recommended placement, prior art table
- New: \`docs/design-agent-keys-plugin-ui.md\` — full backend API spec (POST/GET/DELETE endpoints), plugin UX flow (settings tab, one-time reveal modal), Casdoor JWT reuse design

No code changes — documentation only.