### PR TITLE
docs(deploy): add migration-gate runbook (§1b deploy discipline)

### DIFF
--- a/apps/control-plane/app/api/routers/agent_keys.py
+++ b/apps/control-plane/app/api/routers/agent_keys.py
@@ -149,7 +149,10 @@ def create_agent_key(
     if active_count >= settings.agent_key_max_per_share:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
-            detail=f"Share has reached the maximum of {settings.agent_key_max_per_share} active agent keys.",
+            detail=(
+                f"Share has reached the maximum of {settings.agent_key_max_per_share} "
+                "active agent keys."
+            ),
         )
 
     raw_key = "tr_agent_" + secrets.token_hex(24)
@@ -224,7 +227,8 @@ def list_agent_keys(
                         k.expires_at.replace(tzinfo=timezone.utc)
                         if k.expires_at.tzinfo is None
                         else k.expires_at
-                    ) > now
+                    )
+                    > now
                 )
             ),
         )

--- a/apps/control-plane/app/api/routers/agent_keys.py
+++ b/apps/control-plane/app/api/routers/agent_keys.py
@@ -6,10 +6,12 @@ import hashlib
 import logging
 import secrets
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from pydantic import BaseModel, field_validator
+from slowapi import Limiter
+from slowapi.util import get_remote_address
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
@@ -21,6 +23,7 @@ from app.db.session import get_db
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/v1/web/shares/{share_id}/agent-keys", tags=["web"])
+limiter = Limiter(key_func=get_remote_address)
 
 
 def _require_share_owner_or_admin(
@@ -109,10 +112,11 @@ class AgentKeyListItem(BaseModel):
 
 
 @router.post("", status_code=status.HTTP_201_CREATED, response_model=AgentKeyCreateResponse)
+@limiter.limit(lambda: f"{get_settings().agent_key_creation_rate_per_hour}/hour")
 def create_agent_key(
+    request: Request,
     share_id: str,
     payload: AgentKeyCreateRequest,
-    request: Request,
     db: Session = Depends(get_db),
 ) -> AgentKeyCreateResponse:
     """Create an agent key for a share. Raw key is shown once and never retrievable again."""
@@ -123,10 +127,8 @@ def create_agent_key(
     if payload.expires_at is not None:
         now = security.utcnow()
         exp = payload.expires_at
-        # Make timezone-aware for comparison
         if exp.tzinfo is None:
-            from datetime import timezone as _tz
-            exp = exp.replace(tzinfo=_tz.utc)
+            exp = exp.replace(tzinfo=timezone.utc)
         if exp <= now:
             raise HTTPException(
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -219,7 +221,7 @@ def list_agent_keys(
                 and (
                     k.expires_at is None
                     or (
-                        k.expires_at.replace(tzinfo=__import__("datetime").timezone.utc)
+                        k.expires_at.replace(tzinfo=timezone.utc)
                         if k.expires_at.tzinfo is None
                         else k.expires_at
                     ) > now

--- a/apps/control-plane/app/api/routers/agent_keys.py
+++ b/apps/control-plane/app/api/routers/agent_keys.py
@@ -3,24 +3,33 @@
 from __future__ import annotations
 
 import hashlib
+import logging
 import secrets
 import uuid
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
-from pydantic import BaseModel
-from sqlalchemy import select
+from pydantic import BaseModel, field_validator
+from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from app.core import security
+from app.core.config import get_settings
 from app.db import models
 from app.db.session import get_db
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/v1/web/shares/{share_id}/agent-keys", tags=["web"])
 
 
-def _require_share_owner_or_admin(share_id: str, request: Request, db: Session) -> models.Share:
-    """Validate JWT and assert caller is admin, owner, or editor of the share."""
+def _require_share_owner_or_admin(
+    share_id: str, request: Request, db: Session
+) -> tuple[models.Share, uuid.UUID]:
+    """Validate JWT and assert caller is global admin or share owner.
+
+    Returns (share, user_id). Viewer-role members are explicitly rejected.
+    """
     auth_header = request.headers.get("Authorization")
     if not auth_header or not auth_header.startswith("Bearer "):
         raise HTTPException(
@@ -51,32 +60,37 @@ def _require_share_owner_or_admin(share_id: str, request: Request, db: Session) 
     if not user:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="User not found")
 
-    is_authorized = user.is_admin or share.owner_user_id == user_id
-    if not is_authorized:
-        member_stmt = select(models.ShareMember).where(
-            models.ShareMember.share_id == share.id,
-            models.ShareMember.user_id == user_id,
-        )
-        member = db.execute(member_stmt).scalar_one_or_none()
-        is_authorized = member is not None
-
-    if not is_authorized:
+    # Only global admin or share owner may manage agent keys — not plain members
+    if not (user.is_admin or share.owner_user_id == user_id):
         raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN, detail="You do not have access to this share"
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only the share owner or a global admin can manage agent keys",
         )
 
-    return share
+    return share, user_id
 
 
 class AgentKeyCreateRequest(BaseModel):
     label: str | None = None
     expires_at: datetime | None = None
 
+    @field_validator("label")
+    @classmethod
+    def trim_label(cls, v: str | None) -> str | None:
+        if v is not None:
+            v = v.strip()
+            if len(v) > 255:
+                raise ValueError("label must be 255 characters or fewer")
+            return v or None
+        return v
+
 
 class AgentKeyCreateResponse(BaseModel):
     id: str
-    key: str  # raw key shown once
+    key: str  # raw key shown once only
     label: str | None
+    share_id: str
+    scopes: list[str]
     expires_at: datetime | None
     created_at: datetime
 
@@ -84,10 +98,14 @@ class AgentKeyCreateResponse(BaseModel):
 class AgentKeyListItem(BaseModel):
     id: str
     label: str | None
+    share_id: str
+    scopes: list[str]
+    created_by: str | None
     last_used_at: datetime | None
     expires_at: datetime | None
     revoked_at: datetime | None
     created_at: datetime
+    is_active: bool
 
 
 @router.post("", status_code=status.HTTP_201_CREATED, response_model=AgentKeyCreateResponse)
@@ -98,7 +116,39 @@ def create_agent_key(
     db: Session = Depends(get_db),
 ) -> AgentKeyCreateResponse:
     """Create an agent key for a share. Raw key is shown once and never retrievable again."""
-    share = _require_share_owner_or_admin(share_id, request, db)
+    share, user_id = _require_share_owner_or_admin(share_id, request, db)
+    settings = get_settings()
+
+    # Validate expires_at
+    if payload.expires_at is not None:
+        now = security.utcnow()
+        exp = payload.expires_at
+        # Make timezone-aware for comparison
+        if exp.tzinfo is None:
+            from datetime import timezone as _tz
+            exp = exp.replace(tzinfo=_tz.utc)
+        if exp <= now:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="expires_at must be in the future",
+            )
+        if exp > now + timedelta(days=730):
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="expires_at must be within 2 years from now",
+            )
+
+    # Enforce per-share active key cap
+    active_count_stmt = select(func.count()).where(
+        models.ShareAgentKey.share_id == share.id,
+        models.ShareAgentKey.revoked_at.is_(None),
+    )
+    active_count = db.execute(active_count_stmt).scalar_one()
+    if active_count >= settings.agent_key_max_per_share:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Share has reached the maximum of {settings.agent_key_max_per_share} active agent keys.",
+        )
 
     raw_key = "tr_agent_" + secrets.token_hex(24)
     key_hash = hashlib.sha256(raw_key.encode()).hexdigest()
@@ -108,16 +158,33 @@ def create_agent_key(
         key_hash=key_hash,
         label=payload.label,
         scopes="write",
+        created_by=user_id,
         expires_at=payload.expires_at,
     )
     db.add(agent_key)
     db.commit()
     db.refresh(agent_key)
 
+    logger.info(
+        "agent_key.created",
+        extra={
+            "event": "agent_key.created",
+            "key_id": str(agent_key.id),
+            "share_id": str(share.id),
+            "created_by": str(user_id),
+            "label": payload.label,
+            "expires_at": payload.expires_at.isoformat() if payload.expires_at else None,
+            "scopes": agent_key.scopes,
+            "ip": request.client.host if request.client else None,
+        },
+    )
+
     return AgentKeyCreateResponse(
         id=str(agent_key.id),
         key=raw_key,
         label=agent_key.label,
+        share_id=str(agent_key.share_id),
+        scopes=list(agent_key.scopes.split(",")) if "," in agent_key.scopes else [agent_key.scopes],
         expires_at=agent_key.expires_at,
         created_at=agent_key.created_at,
     )
@@ -135,14 +202,29 @@ def list_agent_keys(
     stmt = select(models.ShareAgentKey).where(models.ShareAgentKey.share_id == uuid.UUID(share_id))
     keys = db.execute(stmt).scalars().all()
 
+    now = security.utcnow()
     return [
         AgentKeyListItem(
             id=str(k.id),
             label=k.label,
+            share_id=str(k.share_id),
+            scopes=list(k.scopes.split(",")) if "," in k.scopes else [k.scopes],
+            created_by=str(k.created_by) if k.created_by else None,
             last_used_at=k.last_used_at,
             expires_at=k.expires_at,
             revoked_at=k.revoked_at,
             created_at=k.created_at,
+            is_active=(
+                k.revoked_at is None
+                and (
+                    k.expires_at is None
+                    or (
+                        k.expires_at.replace(tzinfo=__import__("datetime").timezone.utc)
+                        if k.expires_at.tzinfo is None
+                        else k.expires_at
+                    ) > now
+                )
+            ),
         )
         for k in keys
     ]
@@ -156,7 +238,7 @@ def revoke_agent_key(
     db: Session = Depends(get_db),
 ) -> dict:
     """Soft-revoke an agent key by setting revoked_at."""
-    _require_share_owner_or_admin(share_id, request, db)
+    share, user_id = _require_share_owner_or_admin(share_id, request, db)
 
     stmt = select(models.ShareAgentKey).where(
         models.ShareAgentKey.id == uuid.UUID(key_id),
@@ -170,4 +252,15 @@ def revoke_agent_key(
         agent_key.revoked_at = security.utcnow()
         db.commit()
 
-    return {"message": "Agent key revoked", "id": key_id}
+        logger.info(
+            "agent_key.revoked",
+            extra={
+                "event": "agent_key.revoked",
+                "key_id": key_id,
+                "share_id": share_id,
+                "revoked_by": str(user_id),
+                "ip": request.client.host if request.client else None,
+            },
+        )
+
+    return {"id": key_id, "revoked_at": agent_key.revoked_at.isoformat()}

--- a/apps/control-plane/app/api/routers/agent_keys.py
+++ b/apps/control-plane/app/api/routers/agent_keys.py
@@ -161,7 +161,7 @@ def create_agent_key(
         label=payload.label,
         scopes="write",
         created_by=user_id,
-        expires_at=payload.expires_at,
+        expires_at=exp if payload.expires_at is not None else None,
     )
     db.add(agent_key)
     db.commit()

--- a/apps/control-plane/app/api/routers/web.py
+++ b/apps/control-plane/app/api/routers/web.py
@@ -1174,6 +1174,23 @@ async def upload_mesh_artifact(
             status_code=status.HTTP_403_FORBIDDEN, detail="Agent key does not have write scope"
         )
 
+    # Update last_used_at on successful key authentication
+    import logging as _logging
+    _ak_logger = _logging.getLogger(__name__)
+    agent_key.last_used_at = security.utcnow()
+    db.add(agent_key)
+    db.commit()
+    _ak_logger.info(
+        "agent_key.used",
+        extra={
+            "event": "agent_key.used",
+            "key_id": str(agent_key.id),
+            "share_id": str(share.id),
+            "path": path,
+            "ip": request.client.host if request.client else None,
+        },
+    )
+
     # Read body with size cap
     body = await request.body()
     if len(body) > MAX_MESH_UPLOAD_SIZE:

--- a/apps/control-plane/app/api/routers/web.py
+++ b/apps/control-plane/app/api/routers/web.py
@@ -8,8 +8,6 @@ import logging
 import re
 from datetime import datetime
 
-logger = logging.getLogger(__name__)
-
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
 from minio import Minio
 from minio.error import S3Error
@@ -24,6 +22,8 @@ from app.core.config import get_settings
 from app.db import models
 from app.db.session import get_db
 from app.services.web_session_service import WebSessionService
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/v1/web", tags=["web"])
 limiter = Limiter(key_func=get_remote_address)

--- a/apps/control-plane/app/api/routers/web.py
+++ b/apps/control-plane/app/api/routers/web.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 import base64
 import io
+import logging
 import re
 from datetime import datetime
+
+logger = logging.getLogger(__name__)
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
 from minio import Minio
@@ -1174,23 +1177,6 @@ async def upload_mesh_artifact(
             status_code=status.HTTP_403_FORBIDDEN, detail="Agent key does not have write scope"
         )
 
-    # Update last_used_at on successful key authentication
-    import logging as _logging
-    _ak_logger = _logging.getLogger(__name__)
-    agent_key.last_used_at = security.utcnow()
-    db.add(agent_key)
-    db.commit()
-    _ak_logger.info(
-        "agent_key.used",
-        extra={
-            "event": "agent_key.used",
-            "key_id": str(agent_key.id),
-            "share_id": str(share.id),
-            "path": path,
-            "ip": request.client.host if request.client else None,
-        },
-    )
-
     # Read body with size cap
     body = await request.body()
     if len(body) > MAX_MESH_UPLOAD_SIZE:
@@ -1221,6 +1207,17 @@ async def upload_mesh_artifact(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Failed to store artifact: {e}",
         )
+
+    logger.info(
+        "agent_key.used",
+        extra={
+            "event": "agent_key.used",
+            "key_id": str(agent_key.id),
+            "share_id": str(share.id),
+            "path": path,
+            "ip": request.client.host if request.client else None,
+        },
+    )
 
     # Upsert index entry in web_folder_items
     from sqlalchemy.orm.attributes import flag_modified

--- a/apps/control-plane/app/core/config.py
+++ b/apps/control-plane/app/core/config.py
@@ -117,6 +117,12 @@ class Settings(BaseSettings):
     minio_secure: bool = Field(default=False, description="Use TLS for MinIO")
     minio_bucket: str = Field(default="relay-assets", description="MinIO bucket name")
 
+    # Agent key limits
+    agent_key_max_per_share: int = Field(default=20, description="Max active agent keys per share")
+    agent_key_creation_rate_per_hour: int = Field(
+        default=10, description="Max agent key creations per user per hour"
+    )
+
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore")
 
 

--- a/apps/control-plane/app/db/migrations/versions/202606010001_add_share_agent_keys_active_index.py
+++ b/apps/control-plane/app/db/migrations/versions/202606010001_add_share_agent_keys_active_index.py
@@ -1,0 +1,31 @@
+"""Add partial index on share_agent_keys(share_id) WHERE revoked_at IS NULL.
+
+Revision ID: 202606010001
+Revises: 202605220001
+Create Date: 2026-06-01 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "202606010001"
+down_revision: Union[str, None] = "202605220001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE INDEX IF NOT EXISTS ix_share_agent_keys_share_id_active
+        ON share_agent_keys (share_id)
+        WHERE revoked_at IS NULL
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_share_agent_keys_share_id_active")

--- a/apps/control-plane/app/db/migrations/versions/202606010001_add_share_agent_keys_active_index.py
+++ b/apps/control-plane/app/db/migrations/versions/202606010001_add_share_agent_keys_active_index.py
@@ -8,7 +8,6 @@ Create Date: 2026-06-01 00:00:00.000000
 
 from typing import Sequence, Union
 
-import sqlalchemy as sa
 from alembic import op
 
 revision: str = "202606010001"

--- a/apps/control-plane/tests/test_mesh_upload.py
+++ b/apps/control-plane/tests/test_mesh_upload.py
@@ -373,8 +373,9 @@ class TestAgentKeyNewFields:
         )
         assert resp.status_code == 201, resp.text
         # Verify DB row has created_by set
-        from app.db.models import ShareAgentKey
         from sqlalchemy import select as sa_select
+
+        from app.db.models import ShareAgentKey
 
         key_id = resp.json()["id"]
         ak = db_session.execute(
@@ -419,9 +420,7 @@ class TestAgentKeyNewFields:
         _, ak = make_agent_key(db_session, share)
         token = login(client, "bootstrap@example.com", "super-secret")
         # Revoke it
-        client.delete(
-            f"/v1/web/shares/{share.id}/agent-keys/{ak.id}", headers=auth_headers(token)
-        )
+        client.delete(f"/v1/web/shares/{share.id}/agent-keys/{ak.id}", headers=auth_headers(token))
         resp = client.get(f"/v1/web/shares/{share.id}/agent-keys", headers=auth_headers(token))
         item = next(i for i in resp.json() if i["id"] == str(ak.id))
         assert item["is_active"] is False
@@ -445,13 +444,17 @@ class TestAgentKeyCountCap:
     """Creating more than agent_key_max_per_share active keys returns 409."""
 
     def test_cap_enforced(
-        self, client: TestClient, test_user: models.User, db_session: Session, web_enabled,
-        monkeypatch
+        self,
+        client: TestClient,
+        test_user: models.User,
+        db_session: Session,
+        web_enabled,
+        monkeypatch,
     ):
         # Set cap to 2 via env
-        import os
         monkeypatch.setenv("AGENT_KEY_MAX_PER_SHARE", "2")
         from app.core.config import get_settings
+
         get_settings.cache_clear()
 
         share = make_folder_share(db_session, test_user, slug="cap-share")

--- a/apps/control-plane/tests/test_mesh_upload.py
+++ b/apps/control-plane/tests/test_mesh_upload.py
@@ -294,3 +294,197 @@ class TestMeshUpload:
             headers={"X-Agent-Key": raw_key, "Content-Type": "application/octet-stream"},
         )
         assert resp.status_code == 413
+
+
+# ── Agent key security and new-field tests ────────────────────────────────────
+
+
+class TestAgentKeyAuthRestrictions:
+    """Viewer-role members must not be able to create/list/delete agent keys."""
+
+    def _make_viewer(self, db: Session, share: models.Share, user: models.User) -> models.User:
+        from app.core import security as sec
+
+        viewer = models.User(
+            email="viewer@example.com",
+            password_hash=sec.get_password_hash("viewer123"),
+            is_admin=False,
+            is_active=True,
+        )
+        db.add(viewer)
+        db.commit()
+        db.refresh(viewer)
+        member = models.ShareMember(
+            share_id=share.id,
+            user_id=viewer.id,
+            role=models.ShareMemberRole.VIEWER,
+        )
+        db.add(member)
+        db.commit()
+        return viewer
+
+    def test_viewer_cannot_create_key(
+        self, client: TestClient, test_user: models.User, db_session: Session, web_enabled
+    ):
+        share = make_folder_share(db_session, test_user, slug="viewer-create")
+        viewer = self._make_viewer(db_session, share, test_user)
+        token = login(client, "viewer@example.com", "viewer123")
+        resp = client.post(
+            f"/v1/web/shares/{share.id}/agent-keys",
+            json={"label": "bad"},
+            headers=auth_headers(token),
+        )
+        assert resp.status_code == 403
+
+    def test_viewer_cannot_list_keys(
+        self, client: TestClient, test_user: models.User, db_session: Session, web_enabled
+    ):
+        share = make_folder_share(db_session, test_user, slug="viewer-list")
+        viewer = self._make_viewer(db_session, share, test_user)
+        token = login(client, "viewer@example.com", "viewer123")
+        resp = client.get(f"/v1/web/shares/{share.id}/agent-keys", headers=auth_headers(token))
+        assert resp.status_code == 403
+
+    def test_viewer_cannot_revoke_key(
+        self, client: TestClient, test_user: models.User, db_session: Session, web_enabled
+    ):
+        share = make_folder_share(db_session, test_user, slug="viewer-revoke")
+        _, ak = make_agent_key(db_session, share)
+        viewer = self._make_viewer(db_session, share, test_user)
+        token = login(client, "viewer@example.com", "viewer123")
+        resp = client.delete(
+            f"/v1/web/shares/{share.id}/agent-keys/{ak.id}", headers=auth_headers(token)
+        )
+        assert resp.status_code == 403
+
+
+class TestAgentKeyNewFields:
+    """created_by populated; is_active and share_id present in responses."""
+
+    def test_create_populates_created_by(
+        self, client: TestClient, test_user: models.User, db_session: Session, web_enabled
+    ):
+        share = make_folder_share(db_session, test_user, slug="cb-share")
+        token = login(client, "bootstrap@example.com", "super-secret")
+        resp = client.post(
+            f"/v1/web/shares/{share.id}/agent-keys",
+            json={"label": "my-key"},
+            headers=auth_headers(token),
+        )
+        assert resp.status_code == 201, resp.text
+        # Verify DB row has created_by set
+        from app.db.models import ShareAgentKey
+        from sqlalchemy import select as sa_select
+
+        key_id = resp.json()["id"]
+        ak = db_session.execute(
+            sa_select(ShareAgentKey).where(ShareAgentKey.id == __import__("uuid").UUID(key_id))
+        ).scalar_one()
+        assert ak.created_by is not None
+
+    def test_create_response_has_share_id_and_scopes(
+        self, client: TestClient, test_user: models.User, db_session: Session, web_enabled
+    ):
+        share = make_folder_share(db_session, test_user, slug="fields-share")
+        token = login(client, "bootstrap@example.com", "super-secret")
+        resp = client.post(
+            f"/v1/web/shares/{share.id}/agent-keys",
+            json={"label": "x"},
+            headers=auth_headers(token),
+        )
+        data = resp.json()
+        assert "share_id" in data
+        assert data["share_id"] == str(share.id)
+        assert "scopes" in data
+        assert "write" in data["scopes"]
+
+    def test_list_response_has_is_active_and_share_id(
+        self, client: TestClient, test_user: models.User, db_session: Session, web_enabled
+    ):
+        share = make_folder_share(db_session, test_user, slug="list-fields")
+        make_agent_key(db_session, share)
+        token = login(client, "bootstrap@example.com", "super-secret")
+        resp = client.get(f"/v1/web/shares/{share.id}/agent-keys", headers=auth_headers(token))
+        assert resp.status_code == 200, resp.text
+        item = resp.json()[0]
+        assert "is_active" in item
+        assert item["is_active"] is True
+        assert "share_id" in item
+        assert item["share_id"] == str(share.id)
+
+    def test_revoked_key_is_active_false(
+        self, client: TestClient, test_user: models.User, db_session: Session, web_enabled
+    ):
+        share = make_folder_share(db_session, test_user, slug="active-false")
+        _, ak = make_agent_key(db_session, share)
+        token = login(client, "bootstrap@example.com", "super-secret")
+        # Revoke it
+        client.delete(
+            f"/v1/web/shares/{share.id}/agent-keys/{ak.id}", headers=auth_headers(token)
+        )
+        resp = client.get(f"/v1/web/shares/{share.id}/agent-keys", headers=auth_headers(token))
+        item = next(i for i in resp.json() if i["id"] == str(ak.id))
+        assert item["is_active"] is False
+
+    def test_revoke_returns_revoked_at(
+        self, client: TestClient, test_user: models.User, db_session: Session, web_enabled
+    ):
+        share = make_folder_share(db_session, test_user, slug="revoke-ts")
+        _, ak = make_agent_key(db_session, share)
+        token = login(client, "bootstrap@example.com", "super-secret")
+        resp = client.delete(
+            f"/v1/web/shares/{share.id}/agent-keys/{ak.id}", headers=auth_headers(token)
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "revoked_at" in data
+        assert data["revoked_at"] is not None
+
+
+class TestAgentKeyCountCap:
+    """Creating more than agent_key_max_per_share active keys returns 409."""
+
+    def test_cap_enforced(
+        self, client: TestClient, test_user: models.User, db_session: Session, web_enabled,
+        monkeypatch
+    ):
+        # Set cap to 2 via env
+        import os
+        monkeypatch.setenv("AGENT_KEY_MAX_PER_SHARE", "2")
+        from app.core.config import get_settings
+        get_settings.cache_clear()
+
+        share = make_folder_share(db_session, test_user, slug="cap-share")
+        token = login(client, "bootstrap@example.com", "super-secret")
+        headers = auth_headers(token)
+        url = f"/v1/web/shares/{share.id}/agent-keys"
+
+        r1 = client.post(url, json={"label": "k1"}, headers=headers)
+        r2 = client.post(url, json={"label": "k2"}, headers=headers)
+        r3 = client.post(url, json={"label": "k3"}, headers=headers)
+
+        assert r1.status_code == 201
+        assert r2.status_code == 201
+        assert r3.status_code == 409
+
+        get_settings.cache_clear()
+
+
+class TestAgentKeyLastUsedAt:
+    """Upload via agent key updates last_used_at on the key row."""
+
+    def test_upload_sets_last_used_at(
+        self, client: TestClient, test_user: models.User, db_session: Session, web_enabled
+    ):
+        share = make_folder_share(db_session, test_user, slug="last-used")
+        raw_key, ak = make_agent_key(db_session, share)
+        assert ak.last_used_at is None
+        with minio_patch():
+            resp = client.post(
+                "/v1/web/shares/last-used/upload?path=note.md",
+                content=b"hello",
+                headers={"X-Agent-Key": raw_key, "Content-Type": "text/markdown"},
+            )
+        assert resp.status_code == 200, resp.text
+        db_session.refresh(ak)
+        assert ak.last_used_at is not None

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -1,0 +1,123 @@
+# Team Relay — Deployment Runbook
+
+> **Rule §1b** (CLAUDE-workflow.md §1b Deploy Discipline): migrations MUST run and succeed
+> BEFORE the app image starts. Failed migration = blocked deploy, never the reverse.
+
+## Overview
+
+Team Relay is deployed on `tw-relay` via Docker Compose. Production images are built locally
+on the server from synced source (`/opt/relay/control-plane-src/`), not pulled from a registry.
+
+The `control-plane-migrate` service in `docker-compose.yml` is the **fail-closed gate**: it runs
+`alembic upgrade head` and must exit 0 before `control-plane` (or any worker) starts.
+
+---
+
+## Standard upgrade (migration + app restart)
+
+```bash
+# 1. SSH to server
+ssh tw-relay
+cd /opt/relay
+
+# 2. Tag the current image BEFORE overwriting (enables fast rollback)
+docker tag infra-control-plane:latest infra-control-plane:prev
+
+# 3. Build new image from updated source
+docker build -t infra-control-plane:latest control-plane-src/
+
+# 4. Run the migration gate
+#    — exits 0: migrations applied (or already at head) → proceed
+#    — exits non-zero: STOP, do NOT restart the app, investigate
+docker compose run --rm control-plane-migrate
+
+# 5. Restart app services ONLY after migrate exits 0
+docker compose up -d control-plane webhook-worker email-worker
+```
+
+Using `docker compose up -d` (whole stack) is also safe: the `depends_on:
+condition: service_completed_successfully` on `control-plane` enforces the gate automatically —
+migration failure prevents the app from starting.
+
+> **Never** run `docker run infra-control-plane:latest` directly — it bypasses the compose
+> dependency graph and the migration gate.
+
+---
+
+## Rollback
+
+```bash
+# 1. Stop app services (keep postgres and minio running — do NOT stop the DB)
+docker compose stop control-plane webhook-worker email-worker
+
+# 2. Restore previous image
+docker tag infra-control-plane:prev infra-control-plane:latest
+
+# 3. If a migration was partially applied, revert it first
+docker compose run --rm control-plane-migrate python -m alembic current
+docker compose run --rm control-plane-migrate python -m alembic downgrade <safe-revision>
+
+# 4. Restart with restored image
+docker compose up -d control-plane webhook-worker email-worker
+```
+
+---
+
+## Checking migration state
+
+```bash
+# Current applied revision
+docker compose run --rm control-plane-migrate python -m alembic current
+
+# Full history
+docker compose run --rm control-plane-migrate python -m alembic history
+```
+
+---
+
+## docker-compose.yml gate
+
+The production `docker-compose.yml` must include:
+
+```yaml
+control-plane-migrate:
+  image: infra-control-plane:latest
+  env_file:
+    - ./.env
+  environment:
+    DATABASE_URL: ${DATABASE_URL}
+  depends_on:
+    postgres:
+      condition: service_healthy
+  command: ["python", "-m", "alembic", "upgrade", "head"]
+  restart: "no"
+
+control-plane:
+  depends_on:
+    postgres:
+      condition: service_healthy
+    control-plane-migrate:
+      condition: service_completed_successfully   # <-- fail-closed gate
+    minio-init:
+      condition: service_completed_successfully
+```
+
+The same `service_completed_successfully` guard applies to `webhook-worker` and `email-worker`
+(they depend on `control-plane` which transitively requires migrate to succeed).
+
+---
+
+## Current limitations
+
+No automated CI/CD deploy pipeline exists. Deploy is manual (SSH + docker build + compose up).
+A GitHub Actions workflow that SSHes to `tw-relay` and runs the compose procedure would close
+this gap — tracked as a separate infra task.
+
+---
+
+## References
+
+- `CLAUDE-workflow.md §1b` — shared deploy-discipline rule (migration before code, always)
+- `infra/docker-compose.yml` — dev/local compose template (build-context variant of same gate)
+- `apps/control-plane/app/db/migrations/versions/` — Alembic migration files
+- `apps/control-plane/alembic.ini` — Alembic configuration


### PR DESCRIPTION
## Summary

- Adds `docs/DEPLOY.md` — operational runbook for Team Relay production deployments
- Documents the **fail-closed migration gate**: `control-plane-migrate` must exit 0 before any app container starts
- References `CLAUDE-workflow.md §1b Deploy Discipline` (shared rule, Pavel directive after Spark prod-down `a1c3bc52`)

## What was fixed on prod

Production `docker-compose.yml` on `tw-relay` was **missing** the `control-plane-migrate` service — `control-plane` started directly after `postgres: healthy`, no migration gate.

Applied directly to `/opt/relay/docker-compose.yml` (backed up as `.bak.YYYYMMDD`):
- Added `control-plane-migrate` service (`image: infra-control-plane:latest`, `command: alembic upgrade head`, `restart: "no"`)
- Added `control-plane-migrate: condition: service_completed_successfully` to `control-plane.depends_on`
- Validated with `docker compose config` ✅
- Smoke-tested: `docker compose run --rm control-plane-migrate` exits 0 ✅

## What's still open

No automated CI/CD deploy pipeline exists — deploy is manual SSH + docker build + compose up. Follow-up task created for this gap.

## Test plan

- [ ] Review runbook steps against actual server state
- [ ] On next deploy: confirm `control-plane-migrate` runs and exits 0 before app starts
- [ ] Intentional failure test (optional): deploy a bad migration, confirm app blocked

Mesh task: fd19e759 / epic: bd3e71b8