### PR TITLE
ci(deploy): gated CI/CD deploy pipeline for tw-relay (fail-closed migrate gate)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,91 @@
+name: Deploy
+
+# Automated deploy to tw-relay with a fail-closed migration gate.
+#
+# Sequence (CLAUDE-workflow.md §1b Deploy Discipline):
+#   1. rsync apps/control-plane/ -> tw-relay:/opt/relay/control-plane-src/
+#   2. build image on the server
+#   3. run `control-plane-migrate` (alembic upgrade head) — FAIL-CLOSED
+#   4. only on migrate exit 0: `docker compose up -d` the app services
+#
+# A failed migration fails the job BEFORE any app container is restarted; prod is
+# left running the previous image. See scripts/deploy.sh for the on-server logic
+# and docs/DEPLOY.md for the runbook + required repository secrets.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/control-plane/**'
+      - 'scripts/deploy.sh'
+      - '.github/workflows/deploy.yml'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Run the migration gate but do NOT restart the app (rehearsal)'
+        type: boolean
+        default: false
+
+# Never run two deploys to the same host concurrently. Do not cancel an
+# in-progress deploy — a half-applied migration is worse than a queued one.
+concurrency:
+  group: deploy-tw-relay
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Load SSH key
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.TW_RELAY_SSH_KEY }}
+
+      - name: Trust tw-relay host key
+        env:
+          HOST: ${{ secrets.TW_RELAY_HOST }}
+          PORT: ${{ secrets.TW_RELAY_PORT || '22' }}
+          KNOWN_HOSTS: ${{ secrets.TW_RELAY_KNOWN_HOSTS }}
+        run: |
+          mkdir -p ~/.ssh && chmod 700 ~/.ssh
+          if [ -n "$KNOWN_HOSTS" ]; then
+            # Pinned host key (preferred — resistant to MITM).
+            printf '%s\n' "$KNOWN_HOSTS" >> ~/.ssh/known_hosts
+          else
+            # Fallback: TOFU via ssh-keyscan. Set TW_RELAY_KNOWN_HOSTS to pin.
+            ssh-keyscan -p "$PORT" -H "$HOST" >> ~/.ssh/known_hosts 2>/dev/null
+          fi
+          chmod 600 ~/.ssh/known_hosts
+
+      - name: Sync control-plane source to tw-relay
+        env:
+          HOST: ${{ secrets.TW_RELAY_HOST }}
+          USER: ${{ secrets.TW_RELAY_USER }}
+          PORT: ${{ secrets.TW_RELAY_PORT || '22' }}
+          RELAY_DIR: ${{ secrets.TW_RELAY_PATH || '/opt/relay' }}
+        run: |
+          # --delete keeps the server source in lock-step with the repo; never
+          # touches the server-managed docker-compose.yml / .env (outside src dir).
+          rsync -az --delete \
+            -e "ssh -p ${PORT}" \
+            apps/control-plane/ \
+            "${USER}@${HOST}:${RELAY_DIR}/control-plane-src/"
+
+      - name: Build, migrate (fail-closed), and restart
+        env:
+          HOST: ${{ secrets.TW_RELAY_HOST }}
+          USER: ${{ secrets.TW_RELAY_USER }}
+          PORT: ${{ secrets.TW_RELAY_PORT || '22' }}
+          RELAY_DIR: ${{ secrets.TW_RELAY_PATH || '/opt/relay' }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+        run: |
+          # Run the on-server deploy script over stdin. Its exit code propagates
+          # back here: a failed migration gate (set -e + explicit exit) fails this
+          # step BEFORE `compose up`, so the app is never restarted on a bad migration.
+          ssh -p "${PORT}" "${USER}@${HOST}" \
+            "RELAY_DIR='${RELAY_DIR}' DRY_RUN='${DRY_RUN}' bash -s" \
+            < scripts/deploy.sh

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -11,9 +11,75 @@ on the server from synced source (`/opt/relay/control-plane-src/`), not pulled f
 The `control-plane-migrate` service in `docker-compose.yml` is the **fail-closed gate**: it runs
 `alembic upgrade head` and must exit 0 before `control-plane` (or any worker) starts.
 
+Two ways to deploy:
+- **[Automated (GitHub Actions)](#automated-deploy-github-actions)** — the default path. Push to
+  `main` (or manual dispatch) runs the gated sequence on `tw-relay`.
+- **[Manual (SSH)](#manual-upgrade-fallback)** — the emergency fallback, also the underlying
+  procedure the pipeline automates.
+
 ---
 
-## Standard upgrade (migration + app restart)
+## Automated deploy (GitHub Actions)
+
+Workflow: [`.github/workflows/deploy.yml`](../.github/workflows/deploy.yml).
+On-server logic: [`scripts/deploy.sh`](../scripts/deploy.sh).
+
+**Triggers**
+- `push` to `main` touching `apps/control-plane/**`, `scripts/deploy.sh`, or the workflow itself.
+- `workflow_dispatch` (manual), with a `dry_run` boolean input.
+
+**What it does** (one job, `environment: production`):
+1. Loads an SSH key and trusts the `tw-relay` host key.
+2. `rsync -az --delete apps/control-plane/ → tw-relay:/opt/relay/control-plane-src/`
+   (syncs only the app source; never touches the server-managed `docker-compose.yml` / `.env`).
+3. Runs `scripts/deploy.sh` over SSH, which on the server: tags the current image as
+   `:prev`, builds `infra-control-plane:latest`, runs the **migration gate**, and — only on
+   gate success — `docker compose up -d control-plane webhook-worker email-worker`.
+
+**Fail-closed guarantee.** `scripts/deploy.sh` runs under `set -euo pipefail` and the migration
+gate is an explicit check:
+
+```bash
+if ! docker compose run --rm control-plane-migrate; then
+  die "MIGRATION GATE FAILED — app NOT restarted ..."   # exits non-zero
+fi
+docker compose up -d control-plane webhook-worker email-worker   # unreachable on failure
+```
+
+A non-zero exit from `alembic upgrade head` ends the script (and fails the workflow step)
+**before** `compose up` is ever reached. Production keeps running the previous image.
+
+**Rehearsing the gate without restarting the app.** Trigger the workflow manually with
+`dry_run: true` (Actions → Deploy → Run workflow). The pipeline builds the image and runs the
+migration gate, then **stops** — it never issues `compose up`. Use this to confirm a migration
+applies cleanly before a real deploy, or to verify the fail-closed behaviour: a deliberately
+broken migration makes the `dry_run` run fail at the gate step with the app untouched.
+
+### Required repository secrets
+
+Set these under **Settings → Secrets and variables → Actions** (or scoped to the `production`
+environment, which also lets you add a manual-approval protection rule):
+
+| Secret | Required | Description |
+|--------|----------|-------------|
+| `TW_RELAY_SSH_KEY` | ✅ | Private SSH key (PEM) whose public half is in `tw-relay:~/.ssh/authorized_keys`. Use a dedicated deploy key, not a personal one. |
+| `TW_RELAY_HOST` | ✅ | `tw-relay` address (e.g. `64.188.59.168`). |
+| `TW_RELAY_USER` | ✅ | SSH user with permission to run `docker` (e.g. `root`). |
+| `TW_RELAY_PORT` | — | SSH port. Defaults to `22`. |
+| `TW_RELAY_PATH` | — | Deploy root on the server. Defaults to `/opt/relay`. |
+| `TW_RELAY_KNOWN_HOSTS` | — | Pinned host key line(s) from `ssh-keyscan tw-relay`. If unset, the workflow falls back to TOFU `ssh-keyscan` at run time. **Pinning is recommended.** |
+
+> **Network note.** The workflow runs on GitHub-hosted runners and SSHes to `tw-relay` over its
+> public IP. If the server's firewall restricts inbound SSH to known source IPs, GitHub's dynamic
+> runner ranges will be blocked — in that case add a `tailscale/github-action` step before the
+> SSH steps (the fleet's standard), or move the job to a self-hosted runner on the tailnet.
+
+---
+
+## Manual upgrade (fallback)
+
+Use this when CI is unavailable or for an emergency hotfix. It is the same sequence the
+automated pipeline runs.
 
 ```bash
 # 1. SSH to server
@@ -107,17 +173,25 @@ The same `service_completed_successfully` guard applies to `webhook-worker` and 
 
 ---
 
-## Current limitations
+## Notes & limitations
 
-No automated CI/CD deploy pipeline exists. Deploy is manual (SSH + docker build + compose up).
-A GitHub Actions workflow that SSHes to `tw-relay` and runs the compose procedure would close
-this gap — tracked as a separate infra task.
+- **Server-managed compose.** The production `docker-compose.yml` lives on `tw-relay`
+  (`/opt/relay/`) and uses `image: infra-control-plane:latest` (built locally), whereas the
+  repo's `infra/docker-compose.yml` is the `build:`-context variant of the same gate. The deploy
+  pipeline deliberately syncs **only** `apps/control-plane/` → `control-plane-src/` and leaves
+  the server's compose file and `.env` alone.
+- **web-publish / relay-server** are not (re)built by the deploy pipeline — it covers the
+  control-plane and its workers only. Rebuild those manually if their source changes.
+- **Firewall.** See the network note under [Automated deploy](#required-repository-secrets) if
+  GitHub-hosted runners can't reach `tw-relay`.
 
 ---
 
 ## References
 
 - `CLAUDE-workflow.md §1b` — shared deploy-discipline rule (migration before code, always)
+- `.github/workflows/deploy.yml` — automated deploy pipeline (gated)
+- `scripts/deploy.sh` — on-server build → migrate-gate → restart logic
 - `infra/docker-compose.yml` — dev/local compose template (build-context variant of same gate)
 - `apps/control-plane/app/db/migrations/versions/` — Alembic migration files
 - `apps/control-plane/alembic.ini` — Alembic configuration

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# Team Relay — remote deploy script (runs ON tw-relay)
+#
+# Enforces CLAUDE-workflow.md §1b Deploy Discipline: the migration gate runs and
+# must succeed BEFORE any app container is (re)started. A failed migration aborts
+# the deploy — the running app is left untouched. Fail-closed, never the reverse.
+#
+# Invoked by .github/workflows/deploy.yml as:  ssh <host> 'bash -s' < scripts/deploy.sh
+# after the workflow has rsynced apps/control-plane/ -> $RELAY_DIR/control-plane-src/.
+#
+# Env (all optional, sane prod defaults):
+#   RELAY_DIR   deploy root on the server                (default /opt/relay)
+#   IMAGE       local image tag built from the source    (default infra-control-plane:latest)
+#   DRY_RUN     if "true", run the migrate gate but DO NOT restart the app (rehearsal)
+#
+set -euo pipefail
+
+RELAY_DIR="${RELAY_DIR:-/opt/relay}"
+IMAGE="${IMAGE:-infra-control-plane:latest}"
+DRY_RUN="${DRY_RUN:-false}"
+
+log() { printf '\n\033[1;36m==> %s\033[0m\n' "$*"; }
+die() { printf '\n\033[1;31m!! %s\033[0m\n' "$*" >&2; exit 1; }
+
+cd "$RELAY_DIR" || die "deploy root $RELAY_DIR not found on this host"
+[ -d control-plane-src ] || die "control-plane-src/ missing in $RELAY_DIR — source sync did not run"
+[ -f docker-compose.yml ] || die "docker-compose.yml missing in $RELAY_DIR"
+
+# 1. Tag the current image for fast rollback (skip on first-ever deploy).
+if docker image inspect "$IMAGE" >/dev/null 2>&1; then
+  log "tagging current image -> infra-control-plane:prev (rollback point)"
+  docker tag "$IMAGE" infra-control-plane:prev
+else
+  log "no existing $IMAGE — first deploy, nothing to tag for rollback"
+fi
+
+# 2. Build the new image from the freshly-synced source.
+log "building $IMAGE from control-plane-src/"
+docker build -t "$IMAGE" control-plane-src/
+
+# 3. Migration gate — FAIL-CLOSED.
+#    docker compose run returns the migrate container's exit code; alembic failure
+#    => non-zero => we abort here and the app is NEVER restarted.
+log "running migration gate (alembic upgrade head)"
+if ! docker compose run --rm control-plane-migrate; then
+  die "MIGRATION GATE FAILED — app NOT restarted, prod left on previous image. Investigate before retrying."
+fi
+log "migration gate passed (schema at head)"
+
+# 4. Restart app services — only reachable when migrate exited 0.
+if [ "$DRY_RUN" = "true" ]; then
+  log "DRY_RUN=true — gate passed, skipping 'compose up -d' (rehearsal only)"
+  exit 0
+fi
+
+log "restarting app services"
+docker compose up -d control-plane webhook-worker email-worker
+
+# 5. Post-deploy health check (best-effort, non-fatal — restart already issued).
+log "waiting for control-plane health"
+for i in $(seq 1 20); do
+  status="$(docker compose ps --format '{{.Health}}' control-plane 2>/dev/null || true)"
+  case "$status" in
+    healthy) log "control-plane healthy"; break ;;
+    *) sleep 3 ;;
+  esac
+  if [ "$i" -eq 20 ]; then
+    printf '\n\033[1;33m## control-plane not reporting healthy after ~60s — check `docker compose logs control-plane`\033[0m\n' >&2
+  fi
+done
+
+log "deploy complete — image $IMAGE live, prev image retained as infra-control-plane:prev"


### PR DESCRIPTION
## Summary

Wires the **automated deploy pipeline** that `docs/DEPLOY.md` (#39) flagged as a follow-up. Enforces the fail-closed migration gate from the §1b deploy-discipline rule — migrations run and must succeed **before** any app container restarts.

## What's added

- **`.github/workflows/deploy.yml`** — one job (`environment: production`):
  1. push to `main` (paths: `apps/control-plane/**`, `scripts/deploy.sh`, the workflow) **or** manual `workflow_dispatch` with a `dry_run` boolean.
  2. loads an SSH key (`webfactory/ssh-agent`), trusts the host key (pinned `TW_RELAY_KNOWN_HOSTS` or `ssh-keyscan` fallback).
  3. `rsync -az --delete apps/control-plane/ -> tw-relay:/opt/relay/control-plane-src/` — **source only**, never touches the server-managed compose / `.env`.
  4. runs `scripts/deploy.sh` over SSH.
  - `concurrency: deploy-tw-relay`, `cancel-in-progress: false` — never abandon a half-applied migration.
- **`scripts/deploy.sh`** — on-server logic under `set -euo pipefail`: tag current image `:prev` -> build `infra-control-plane:latest` -> **migration gate** -> restart `control-plane webhook-worker email-worker` -> best-effort health poll.
- **`docs/DEPLOY.md`** — automated path, required secrets table, fail-closed guarantee, `dry_run` rehearsal, firewall/Tailscale note; manual SSH procedure retained as the emergency fallback.

## Fail-closed guarantee

```bash
if ! docker compose run --rm control-plane-migrate; then
  die "MIGRATION GATE FAILED — app NOT restarted ..."   # exits non-zero
fi
docker compose up -d control-plane webhook-worker email-worker   # unreachable on failure
```

A non-zero `alembic upgrade head` ends the script (and fails the workflow step) **before** `compose up` is reached -> prod keeps running the previous image. Rehearse without touching the app via **Run workflow -> `dry_run: true`** (builds + gates, then stops).

## Required repository secrets

`TW_RELAY_SSH_KEY`, `TW_RELAY_HOST`, `TW_RELAY_USER` (required); `TW_RELAY_PORT`, `TW_RELAY_PATH`, `TW_RELAY_KNOWN_HOSTS` (optional, sane defaults). Full table in `docs/DEPLOY.md`. **Set these before the first push-triggered run** — otherwise the deploy step fails fast (no partial deploy).

## Acceptance checklist
- [x] `deploy.yml` in `.github/workflows/`
- [x] Failed migration fails the workflow before app restart (`set -e` + explicit gate; `dry_run` lets you verify safely)
- [x] `docs/DEPLOY.md` references the automated pipeline
- [x] Manual fallback procedure still documented

## Notes
- **Stacked on #39** (base = `fix/ci-migrate-gate-deploy-runbook`) because the DEPLOY.md edits build on that runbook. **Retarget to `main` once #39 merges.**
- Validated: `bash -n scripts/deploy.sh` ok, `yaml.safe_load(deploy.yml)` ok. Not yet run live (needs secrets) — first real run should use `dry_run: true`.
