### PR TITLE
Fix flaky OAuth CI tests (background metrics collector races on shared test DB)

### DIFF
--- a/apps/control-plane/app/core/config.py
+++ b/apps/control-plane/app/core/config.py
@@ -99,6 +99,16 @@ class Settings(BaseSettings):
         description="Block relay token issuance for users with unverified email",
     )
 
+    # Background metrics collector
+    metrics_collector_enabled: bool = Field(
+        default=True,
+        description=(
+            "Run the in-process background metrics collector (60 s loop). "
+            "Disable in tests — its executor-thread session shares the single "
+            "in-memory SQLite connection and corrupts request transactions."
+        ),
+    )
+
     # Web publishing settings
     web_publish_domain: str | None = Field(
         default=None,

--- a/apps/control-plane/app/main.py
+++ b/apps/control-plane/app/main.py
@@ -236,6 +236,9 @@ Get a token by calling `POST /auth/login` with valid credentials.
     @app.on_event("startup")
     async def _start_metrics_collector() -> None:
         """Launch background metrics collection loop (60 s interval)."""
+        if not get_settings().metrics_collector_enabled:
+            logger.info("metrics_worker: disabled via settings, not starting")
+            return
         app.state.metrics_task = asyncio.create_task(metrics_worker.run_metrics_collector())
 
     @app.on_event("shutdown")

--- a/apps/control-plane/tests/conftest.py
+++ b/apps/control-plane/tests/conftest.py
@@ -32,6 +32,11 @@ def test_env():
     os.environ["BOOTSTRAP_ADMIN_EMAIL"] = "bootstrap@example.com"
     os.environ["BOOTSTRAP_ADMIN_PASSWORD"] = "super-secret"
     os.environ["RELAY_PUBLIC_URL"] = "wss://relay.test"
+    # The background metrics collector runs its DB session on a worker thread,
+    # sharing the single in-memory StaticPool SQLite connection with request
+    # handlers. That concurrent access intermittently rolls back a request's
+    # just-committed rows → flaky 404 / empty-list failures. Off in tests.
+    os.environ["METRICS_COLLECTOR_ENABLED"] = "false"
 
     get_settings.cache_clear()
     yield


### PR DESCRIPTION
## Problem

Two tests in `apps/control-plane/tests/test_oauth.py` fail intermittently on CI:

- `test_authorize_localhost_stays_http` — `assert 404 == 200` (the just-created provider isn't found by the request)
- `test_list_providers_with_env_config` — `assert 0 == 1` (provider list comes back empty)

Both pass in isolation; they only fail under the full-suite run, which is why it reads as flaky.

## Root cause

The in-process metrics collector (`app/workers/metrics_worker.py::run_metrics_collector`) is launched on app startup and runs `_collect_db_metrics` via `loop.run_in_executor(...)` — i.e. **on a thread-pool worker thread**. That function opens its own SQLAlchemy session on the global engine.

In tests the engine is a single shared in-memory SQLite connection (`StaticPool`, `check_same_thread=False`). So the collector's session and the request handler's session hit the **same connection from two threads concurrently**. When the collector's transaction lands in the middle of a test request, it rolls back / re-snapshots the connection's transaction state, and the request's just-committed `OAuthProvider` row vanishes → 404 / empty list. Timing-dependent ⇒ flaky.

## Fix

- Add a `metrics_collector_enabled` setting (default **True** — production behaviour unchanged).
- Gate the startup task on it.
- Disable it in the test environment (`conftest.py`), so tests never spin the background collector against the shared in-memory connection.

No production code path changes; the collector still runs everywhere it did before. The fix is test-isolation only.

## Verification (local)

- `test_oauth.py` — **32 passed**, run 3× back-to-back, deterministic (previously flaked under full-module order).
- Both target tests pass explicitly.
- `test_metrics.py` — 10 passed (it exercises the collector function directly, not the background task, so it's unaffected).
- `test -k "metric or startup or main or health"` — 11 passed.
- `ruff check` on changed files — clean.
- Full suite running; CI on this PR is the authoritative gate.

Side benefit: the OAuth suite runs ~6× faster without the executor churn.