### PR TITLE
[TR/C5-s2] Fix null agent key labels: min_length=1 + backfill migration

### DIFF
--- a/apps/control-plane/app/api/routers/agent_keys.py
+++ b/apps/control-plane/app/api/routers/agent_keys.py
@@ -9,7 +9,7 @@ import uuid
 from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, Field, field_validator
 from slowapi import Limiter
 from slowapi.util import get_remote_address
 from sqlalchemy import func, select
@@ -74,7 +74,7 @@ def _require_share_owner_or_admin(
 
 
 class AgentKeyCreateRequest(BaseModel):
-    label: str | None = None
+    label: str | None = Field(default=None, min_length=1)
     expires_at: datetime | None = None
 
     @field_validator("label")
@@ -82,9 +82,10 @@ class AgentKeyCreateRequest(BaseModel):
     def trim_label(cls, v: str | None) -> str | None:
         if v is not None:
             v = v.strip()
+            if not v:
+                raise ValueError("label must not be blank")
             if len(v) > 255:
                 raise ValueError("label must be 255 characters or fewer")
-            return v or None
         return v
 
 

--- a/apps/control-plane/app/db/migrations/versions/202606040001_backfill_null_agent_key_labels.py
+++ b/apps/control-plane/app/db/migrations/versions/202606040001_backfill_null_agent_key_labels.py
@@ -1,0 +1,31 @@
+"""Backfill NULL labels in share_agent_keys with 'legacy-<hash_prefix>'.
+
+Revision ID: 202606040001
+Revises: 202606010001
+Create Date: 2026-06-04 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "202606040001"
+down_revision: Union[str, None] = "202606010001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        UPDATE share_agent_keys
+        SET label = 'legacy-' || left(key_hash, 6)
+        WHERE label IS NULL
+        """
+    )
+
+
+def downgrade() -> None:
+    # Backfill is intentionally non-reversible — labels set here are cosmetic
+    pass

--- a/apps/control-plane/tests/test_agent_keys.py
+++ b/apps/control-plane/tests/test_agent_keys.py
@@ -99,6 +99,31 @@ def test_create_agent_key_with_expiry(client: TestClient) -> None:
     assert resp.json()["expires_at"] is not None
 
 
+def test_create_agent_key_empty_label_rejected(client: TestClient) -> None:
+    """Empty string label must be rejected with 422."""
+    token = login(client, "bootstrap@example.com", "super-secret")
+    share_id = create_share(client, token, path="vault/empty-label.md")
+
+    resp = client.post(
+        f"/v1/web/shares/{share_id}/agent-keys",
+        json={"label": ""},
+        headers=auth_headers(token),
+    )
+    assert resp.status_code == 422, resp.text
+
+
+def test_create_agent_key_blank_label_rejected(client: TestClient) -> None:
+    """Whitespace-only label must be rejected with 422."""
+    token = login(client, "bootstrap@example.com", "super-secret")
+    share_id = create_share(client, token, path="vault/blank-label.md")
+
+    resp = client.post(
+        f"/v1/web/shares/{share_id}/agent-keys",
+        json={"label": "   "},
+        headers=auth_headers(token),
+    )
+    assert resp.status_code == 422, resp.text
+
 
 def test_create_agent_key_past_expiry_rejected(client: TestClient) -> None:
     token = login(client, "bootstrap@example.com", "super-secret")


### PR DESCRIPTION
## Summary

- **Backend (`agent_keys.py`)**: add `Field(min_length=1)` to `AgentKeyCreateRequest.label` + update validator to reject blank labels with 422 (was silently converting `""` / `"   "` to `NULL`)
- **Migration `202606040001`**: backfill 10 existing NULL labels with `'legacy-<6-char key_hash prefix>'` — dry-run confirmed on prod, no keys revoked
- **Tests**: 2 new tests (`test_create_agent_key_empty_label_rejected`, `test_create_agent_key_blank_label_rejected`) — all 11 pass

## Root cause

Keys created via direct SQL (task #001672b1, 2026-05-31) had no label field → `label IS NULL` in DB. The API validator was silently converting empty strings to NULL rather than rejecting them.

## Test plan

- [x] `pytest tests/test_agent_keys.py` — 11/11 pass
- [x] Dry-run SELECT on prod confirmed 10 NULL rows before backfill
- [ ] Apply migration on tw-relay (`alembic upgrade head`) after PR merge