### PR TITLE
feat(agent-keys): add read scope + files-index/download endpoints

### DIFF
--- a/apps/control-plane/app/api/routers/agent_keys.py
+++ b/apps/control-plane/app/api/routers/agent_keys.py
@@ -73,9 +73,13 @@ def _require_share_owner_or_admin(
     return share, user_id
 
 
+_VALID_SCOPES = {"read", "write"}
+
+
 class AgentKeyCreateRequest(BaseModel):
     label: str | None = Field(default=None, min_length=1)
     expires_at: datetime | None = None
+    scopes: list[str] = Field(default_factory=lambda: ["write"])
 
     @field_validator("label")
     @classmethod
@@ -87,6 +91,16 @@ class AgentKeyCreateRequest(BaseModel):
             if len(v) > 255:
                 raise ValueError("label must be 255 characters or fewer")
         return v
+
+    @field_validator("scopes")
+    @classmethod
+    def validate_scopes(cls, v: list[str]) -> list[str]:
+        if not v:
+            raise ValueError("scopes must not be empty")
+        invalid = set(v) - _VALID_SCOPES
+        if invalid:
+            raise ValueError(f"invalid scopes: {invalid}; allowed: {_VALID_SCOPES}")
+        return sorted(set(v))
 
 
 class AgentKeyCreateResponse(BaseModel):
@@ -163,7 +177,7 @@ def create_agent_key(
         share_id=share.id,
         key_hash=key_hash,
         label=payload.label,
-        scopes="write",
+        scopes=",".join(payload.scopes),
         created_by=user_id,
         expires_at=exp if payload.expires_at is not None else None,
     )

--- a/apps/control-plane/app/api/routers/web.py
+++ b/apps/control-plane/app/api/routers/web.py
@@ -1179,7 +1179,7 @@ async def upload_mesh_artifact(
                 status_code=status.HTTP_403_FORBIDDEN, detail="Agent key has expired"
             )
 
-    if "write" not in agent_key.scopes:
+    if "write" not in set(agent_key.scopes.split(",")):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN, detail="Agent key does not have write scope"
         )
@@ -1295,3 +1295,193 @@ async def upload_mesh_artifact(
         "modified_at": now_iso,
         "public_url": public_url,
     }
+
+
+def _resolve_share_for_agent(share_identifier: str, db: Session) -> models.Share:
+    """Resolve share by UUID (private/sync) or slug (web-published only).
+
+    Raises 404 if not found or not a folder share.
+    """
+    import uuid as _uuid_mod
+
+    try:
+        _uuid = _uuid_mod.UUID(share_identifier)
+        stmt = select(models.Share).where(models.Share.id == _uuid)
+    except ValueError:
+        stmt = select(models.Share).where(
+            models.Share.web_slug == share_identifier,
+            models.Share.web_published == True,  # noqa: E712
+        )
+    share = db.execute(stmt).scalar_one_or_none()
+    if not share:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Share not found")
+    if share.kind != models.ShareKind.FOLDER:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Agent-key operations only supported for folder shares",
+        )
+    return share
+
+
+def _auth_agent_key(
+    share: models.Share, request: Request, db: Session, required_scope: str | None = None
+) -> models.ShareAgentKey:
+    """Validate X-Agent-Key header against the given share.
+
+    Returns the ShareAgentKey row on success; raises HTTPException on failure.
+    If required_scope is given, the key must have that scope (e.g. "read" or "write").
+    """
+    import hashlib
+
+    raw_key = request.headers.get("X-Agent-Key")
+    if not raw_key:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="X-Agent-Key header required"
+        )
+
+    key_hash = hashlib.sha256(raw_key.encode()).hexdigest()
+    agent_key = db.execute(
+        select(models.ShareAgentKey).where(models.ShareAgentKey.key_hash == key_hash)
+    ).scalar_one_or_none()
+
+    if agent_key is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid agent key")
+    if agent_key.share_id != share.id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Agent key not valid for this share"
+        )
+    if agent_key.revoked_at is not None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Agent key has been revoked"
+        )
+    if agent_key.expires_at is not None:
+        from datetime import timezone as _tz
+
+        exp = agent_key.expires_at
+        if exp.tzinfo is None:
+            exp = exp.replace(tzinfo=_tz.utc)
+        if exp < security.utcnow():
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN, detail="Agent key has expired"
+            )
+    if required_scope and required_scope not in set(agent_key.scopes.split(",")):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"Agent key does not have {required_scope} scope",
+        )
+    return agent_key
+
+
+@router.get("/shares/{share_identifier}/files-index")
+def list_mesh_files(
+    request: Request,
+    share_identifier: str,
+    db: Session = Depends(get_db),
+) -> dict:
+    """
+    List files in a folder share using agent-key auth.
+
+    Returns the share's file index: mapping path → {type, mime, size, modified_at, source}.
+    Content is never included; use /download to fetch individual file content.
+
+    Auth: X-Agent-Key header.
+    share_identifier: folder UUID (private/sync shares) or web_slug (web-published only).
+    """
+    settings = get_settings()
+    if not settings.web_publish_enabled:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Web publishing is not enabled on this server",
+        )
+
+    share = _resolve_share_for_agent(share_identifier, db)
+    agent_key = _auth_agent_key(share, request, db, required_scope="read")
+
+    folder_items = share.web_folder_items or []
+    files = {
+        item["path"]: {
+            "type": item.get("type", "doc"),
+            "mime": item.get("mime"),
+            "size": item.get("size"),
+            "modified_at": item.get("modified_at"),
+            "source": item.get("source"),
+        }
+        for item in folder_items
+        if item.get("path")
+    }
+
+    agent_key.last_used_at = security.utcnow()
+    db.commit()
+
+    return {"share_id": str(share.id), "files": files}
+
+
+@router.get("/shares/{share_identifier}/download")
+def download_mesh_artifact(
+    request: Request,
+    share_identifier: str,
+    path: str = Query(..., description="Relative file path within share"),
+    db: Session = Depends(get_db),
+) -> Response:
+    """
+    Download a file artifact from a folder share using agent-key auth.
+
+    Resolution order: inline content in JSONB index → MinIO storage.
+
+    Auth: X-Agent-Key header.
+    share_identifier: folder UUID (private/sync shares) or web_slug (web-published only).
+    """
+    settings = get_settings()
+    if not settings.web_publish_enabled:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Web publishing is not enabled on this server",
+        )
+
+    _validate_upload_path(path)
+
+    share = _resolve_share_for_agent(share_identifier, db)
+    agent_key = _auth_agent_key(share, request, db, required_scope="read")
+
+    folder_items = share.web_folder_items or []
+    for item in folder_items:
+        if item.get("path") != path:
+            continue
+
+        content_str = item.get("content")
+        if content_str is not None:
+            mime = item.get("mime", "text/plain; charset=utf-8")
+            content_bytes = (
+                content_str.encode("utf-8") if isinstance(content_str, str) else content_str
+            )
+            agent_key.last_used_at = security.utcnow()
+            db.commit()
+            return Response(content=content_bytes, media_type=mime)
+
+        storage_key = item.get("storage_key")
+        if storage_key:
+            minio_client = _get_minio_client()
+            try:
+                resp = minio_client.get_object(settings.minio_bucket, storage_key)
+                try:
+                    data = resp.read()
+                finally:
+                    resp.close()
+                    resp.release_conn()
+            except S3Error as e:
+                if e.code == "NoSuchKey":
+                    raise HTTPException(
+                        status_code=status.HTTP_404_NOT_FOUND, detail="File not found in storage"
+                    )
+                raise HTTPException(
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    detail=f"Failed to retrieve file: {e}",
+                )
+            mime = item.get("mime", "application/octet-stream")
+            agent_key.last_used_at = security.utcnow()
+            db.commit()
+            return Response(content=data, media_type=mime)
+
+    raise HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND, detail=f"File not found: {path}"
+    )

--- a/apps/control-plane/app/api/routers/web.py
+++ b/apps/control-plane/app/api/routers/web.py
@@ -1135,9 +1135,7 @@ async def upload_mesh_artifact(
         )
     share = db.execute(stmt).scalar_one_or_none()
     if not share:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="Share not found"
-        )
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Share not found")
     if share.kind != models.ShareKind.FOLDER:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -1482,6 +1480,4 @@ def download_mesh_artifact(
             db.commit()
             return Response(content=data, media_type=mime)
 
-    raise HTTPException(
-        status_code=status.HTTP_404_NOT_FOUND, detail=f"File not found: {path}"
-    )
+    raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"File not found: {path}")

--- a/apps/control-plane/app/db/migrations/versions/202602190001_stub_prod_head.py
+++ b/apps/control-plane/app/db/migrations/versions/202602190001_stub_prod_head.py
@@ -16,8 +16,6 @@ No upgrade or downgrade actions — prod schema already reflects this state.
 
 from typing import Sequence, Union
 
-from alembic import op
-
 revision: str = "202602190001"
 down_revision: Union[str, None] = "202602030003"
 branch_labels: Union[str, Sequence[str], None] = None

--- a/apps/control-plane/tests/test_mesh_upload.py
+++ b/apps/control-plane/tests/test_mesh_upload.py
@@ -39,14 +39,16 @@ def make_folder_share(db: Session, user: models.User, slug: str = "test-share") 
     return share
 
 
-def make_agent_key(db: Session, share: models.Share) -> tuple[str, models.ShareAgentKey]:
+def make_agent_key(
+    db: Session, share: models.Share, scopes: str = "write"
+) -> tuple[str, models.ShareAgentKey]:
     raw_key = "tr_agent_" + secrets.token_hex(24)
     key_hash = hashlib.sha256(raw_key.encode()).hexdigest()
     ak = models.ShareAgentKey(
         share_id=share.id,
         key_hash=key_hash,
         label="test key",
-        scopes="write",
+        scopes=scopes,
     )
     db.add(ak)
     db.commit()
@@ -491,3 +493,133 @@ class TestAgentKeyLastUsedAt:
         assert resp.status_code == 200, resp.text
         db_session.refresh(ak)
         assert ak.last_used_at is not None
+
+
+# ── Read scope isolation ──────────────────────────────────────────────────────
+
+
+class TestAgentKeyReadScope:
+    """Verify scope enforcement on files-index and download endpoints."""
+
+    def _upload_file(
+        self, client: TestClient, slug: str, raw_key: str, path: str = "note.md"
+    ) -> None:
+        with minio_patch():
+            client.post(
+                f"/v1/web/shares/{slug}/upload?path={path}",
+                content=b"# hello",
+                headers={"X-Agent-Key": raw_key, "Content-Type": "text/markdown"},
+            )
+
+    def test_read_write_key_can_files_index(
+        self, client: TestClient, test_user: models.User, db_session: Session, web_enabled
+    ):
+        share = make_folder_share(db_session, test_user, slug="rw-index")
+        write_key, _ = make_agent_key(db_session, share, scopes="write")
+        read_write_key, _ = make_agent_key(db_session, share, scopes="read,write")
+        self._upload_file(client, "rw-index", write_key)
+        resp = client.get(
+            "/v1/web/shares/rw-index/files-index",
+            headers={"X-Agent-Key": read_write_key},
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert "files" in data
+        assert "note.md" in data["files"]
+
+    def test_write_only_key_cannot_files_index(
+        self, client: TestClient, test_user: models.User, db_session: Session, web_enabled
+    ):
+        share = make_folder_share(db_session, test_user, slug="wo-index")
+        raw_key, _ = make_agent_key(db_session, share, scopes="write")
+        resp = client.get(
+            "/v1/web/shares/wo-index/files-index",
+            headers={"X-Agent-Key": raw_key},
+        )
+        assert resp.status_code == 403, resp.text
+
+    def test_read_write_key_can_download(
+        self, client: TestClient, test_user: models.User, db_session: Session, web_enabled
+    ):
+        share = make_folder_share(db_session, test_user, slug="rw-download")
+        write_key, _ = make_agent_key(db_session, share, scopes="write")
+        read_write_key, _ = make_agent_key(db_session, share, scopes="read,write")
+        self._upload_file(client, "rw-download", write_key)
+        resp = client.get(
+            "/v1/web/shares/rw-download/download?path=note.md",
+            headers={"X-Agent-Key": read_write_key},
+        )
+        assert resp.status_code == 200, resp.text
+        assert b"hello" in resp.content
+
+    def test_write_only_key_cannot_download(
+        self, client: TestClient, test_user: models.User, db_session: Session, web_enabled
+    ):
+        share = make_folder_share(db_session, test_user, slug="wo-download")
+        raw_key, _ = make_agent_key(db_session, share, scopes="write")
+        resp = client.get(
+            "/v1/web/shares/wo-download/download?path=note.md",
+            headers={"X-Agent-Key": raw_key},
+        )
+        assert resp.status_code == 403, resp.text
+
+    def test_read_only_key_cannot_upload(
+        self, client: TestClient, test_user: models.User, db_session: Session, web_enabled
+    ):
+        share = make_folder_share(db_session, test_user, slug="ro-upload")
+        raw_key, _ = make_agent_key(db_session, share, scopes="read")
+        with minio_patch():
+            resp = client.post(
+                "/v1/web/shares/ro-upload/upload?path=file.md",
+                content=b"data",
+                headers={"X-Agent-Key": raw_key, "Content-Type": "text/plain"},
+            )
+        assert resp.status_code == 403, resp.text
+
+    def test_wrong_share_key_returns_403_on_files_index(
+        self, client: TestClient, test_user: models.User, db_session: Session, web_enabled
+    ):
+        share1 = make_folder_share(db_session, test_user, slug="rs-one")
+        share2 = make_folder_share(db_session, test_user, slug="rs-two")
+        raw_key, _ = make_agent_key(db_session, share1, scopes="read,write")
+        resp = client.get(
+            "/v1/web/shares/rs-two/files-index",
+            headers={"X-Agent-Key": raw_key},
+        )
+        assert resp.status_code == 403, resp.text
+
+    def test_invalid_key_returns_401_on_files_index(
+        self, client: TestClient, test_user: models.User, db_session: Session, web_enabled
+    ):
+        make_folder_share(db_session, test_user, slug="bad-key-index")
+        resp = client.get(
+            "/v1/web/shares/bad-key-index/files-index",
+            headers={"X-Agent-Key": "tr_agent_totallywrong"},
+        )
+        assert resp.status_code == 401, resp.text
+
+    def test_create_key_with_read_write_scopes(
+        self, client: TestClient, test_user: models.User, db_session: Session, web_enabled
+    ):
+        share = make_folder_share(db_session, test_user, slug="create-rw")
+        token = login(client, "bootstrap@example.com", "super-secret")
+        resp = client.post(
+            f"/v1/web/shares/{share.id}/agent-keys",
+            json={"label": "rw-key", "scopes": ["read", "write"]},
+            headers=auth_headers(token),
+        )
+        assert resp.status_code == 201, resp.text
+        data = resp.json()
+        assert set(data["scopes"]) == {"read", "write"}
+
+    def test_create_key_invalid_scope_rejected(
+        self, client: TestClient, test_user: models.User, db_session: Session, web_enabled
+    ):
+        share = make_folder_share(db_session, test_user, slug="bad-scope")
+        token = login(client, "bootstrap@example.com", "super-secret")
+        resp = client.post(
+            f"/v1/web/shares/{share.id}/agent-keys",
+            json={"label": "bad", "scopes": ["admin"]},
+            headers=auth_headers(token),
+        )
+        assert resp.status_code == 422, resp.text


### PR DESCRIPTION
## Summary

- `AgentKeyCreateRequest` now accepts a `scopes` param (`["write"]` by default); unknown scope values return 422
- `create_agent_key` stores caller-supplied scopes instead of hardcoding `"write"` — existing write-only keys unchanged
- Extracted `_resolve_share_for_agent` / `_auth_agent_key` helpers in `web.py`; `_auth_agent_key` accepts `required_scope` param
- **`GET /v1/web/shares/{share_identifier}/files-index`** — `X-Agent-Key` + `read` scope required; returns `{share_id, files: {path → {type, mime, size, modified_at, source}}}`
- **`GET /v1/web/shares/{share_identifier}/download?path=`** — `X-Agent-Key` + `read` scope required; resolves inline JSONB content first, falls back to MinIO
- `POST /upload` still enforces `write` scope; read-only keys get 403

## Context

Backend blocker for `evc-team-relay-mcp` PR #15. That PR added read tools (`list_files`, `read_file`, `tr_search`) that call these exact endpoints (`files-index`, `download`) with `X-Agent-Key`. Live diagnosis on tw-relay confirmed those endpoints and the `read` scope didn't exist — this PR adds them.

Once merged and deployed:
1. Issue a `read,write` agent key for the `knowledge` share
2. Switch reads off the shared `in@` credential
3. Verify PR #15 read path green → merge as v1.0.3

## Test plan

`TestAgentKeyReadScope` — 9 new tests:
- [x] `read,write` key → files-index 200 + files listed
- [x] write-only key → files-index 403
- [x] `read,write` key → download 200 + content returned
- [x] write-only key → download 403
- [x] read-only key → upload 403 (scope isolation)
- [x] wrong-share key → files-index 403
- [x] invalid key → files-index 401
- [x] create key with `["read","write"]` → response scopes correct
- [x] create key with `["admin"]` → 422

All 33 tests in `test_mesh_upload.py` green.