### PR TITLE
feat(lifecycle): lifecycle_state table + lifecycle_emails opt-out pref [S2]

### DIFF
--- a/apps/control-plane/app/db/migrations/versions/202606070001_add_lifecycle_state_and_email_prefs.py
+++ b/apps/control-plane/app/db/migrations/versions/202606070001_add_lifecycle_state_and_email_prefs.py
@@ -1,0 +1,85 @@
+"""Add lifecycle_state table and lifecycle_emails pref.
+
+Revision ID: 202606070001
+Revises: 202606040001
+Create Date: 2026-06-07 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "202606070001"
+down_revision: Union[str, None] = "202606040001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # lifecycle_state — idempotency-keyed trigger tracker for the email lifecycle engine.
+    # unique(user_id, trigger_key) is the core idempotency constraint; the worker uses it
+    # to upsert state without ever double-sending for a given (user, trigger) pair.
+    op.create_table(
+        "lifecycle_state",
+        sa.Column(
+            "id",
+            sa.UUID(),
+            nullable=False,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("user_id", sa.UUID(), nullable=False),
+        sa.Column("trigger_key", sa.String(length=64), nullable=False),
+        sa.Column(
+            "state",
+            sa.String(length=32),
+            nullable=False,
+            server_default=sa.text("'pending'"),
+        ),
+        sa.Column("scheduled_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("sent_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("suppressed_reason", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("user_id", "trigger_key", name="uq_lifecycle_state_user_trigger"),
+    )
+    op.create_index("idx_lifecycle_state_user_id", "lifecycle_state", ["user_id"], unique=False)
+    op.create_index(
+        "idx_lifecycle_state_scheduled",
+        "lifecycle_state",
+        ["scheduled_at"],
+        unique=False,
+        postgresql_where=sa.text("state = 'pending'"),
+    )
+
+    # lifecycle_emails opt-out: missing row is treated as all-on (DEFAULT true).
+    # Current DB has 0 rows in user_email_preferences, so no backfill needed.
+    op.add_column(
+        "user_email_preferences",
+        sa.Column(
+            "lifecycle_emails",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("true"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("user_email_preferences", "lifecycle_emails")
+    op.drop_index("idx_lifecycle_state_scheduled", table_name="lifecycle_state")
+    op.drop_index("idx_lifecycle_state_user_id", table_name="lifecycle_state")
+    op.drop_table("lifecycle_state")

--- a/apps/control-plane/app/db/models.py
+++ b/apps/control-plane/app/db/models.py
@@ -131,6 +131,10 @@ class User(Base, TimestampMixin):
         uselist=False,
         cascade="all, delete-orphan",
     )
+    lifecycle_states: Mapped[list["LifecycleState"]] = relationship(
+        back_populates="user",
+        cascade="all, delete-orphan",
+    )
 
 
 class Share(Base, TimestampMixin):
@@ -547,7 +551,49 @@ class UserEmailPreferences(Base):
         nullable=False,
     )
 
+    lifecycle_emails: Mapped[bool] = mapped_column(default=True, nullable=False)
+
     user: Mapped["User"] = relationship(back_populates="email_preferences")
+
+
+class LifecycleState(Base):
+    """Idempotency-keyed state tracker for the email lifecycle engine.
+
+    One row per (user_id, trigger_key) pair. The worker upserts this table to
+    advance state and prevent double-sending. The unique constraint on
+    (user_id, trigger_key) is the primary idempotency guard.
+    """
+
+    __tablename__ = "lifecycle_state"
+    __table_args__ = (
+        UniqueConstraint("user_id", "trigger_key", name="uq_lifecycle_state_user_trigger"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    trigger_key: Mapped[str] = mapped_column(String(64), nullable=False)
+    state: Mapped[str] = mapped_column(String(32), nullable=False, default="pending")
+    scheduled_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    sent_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    suppressed_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    user: Mapped["User"] = relationship(back_populates="lifecycle_states")
 
 
 class InstanceSetting(Base):


### PR DESCRIPTION
## Summary

- New `lifecycle_state` table — idempotency-keyed tracker for the email lifecycle engine. Unique constraint on `(user_id, trigger_key)` prevents double-sends.
- `user_email_preferences.lifecycle_emails boolean NOT NULL DEFAULT true` — pre-send opt-out gate for the S3 trigger worker. Missing row = all-on.
- `LifecycleState` SQLAlchemy model + `lifecycle_emails` field added to `UserEmailPreferences`.
- Migration `202606070001` → `down_revision 202606040001`, backward-compatible additive (no DROP, no NOT NULL without DEFAULT).

## Acceptance outputs (captured post-apply on production)

**`alembic upgrade head`:**
```
INFO  [alembic.runtime.migration] Running upgrade 202606040001 -> 202606070001, Add lifecycle_state table and lifecycle_emails pref.
```

**`\d lifecycle_state`:**
```
id|uuid||not null|gen_random_uuid()
user_id|uuid||not null|
trigger_key|character varying(64)||not null|
state|character varying(32)||not null|'pending'::character varying
scheduled_at|timestamp with time zone|||
sent_at|timestamp with time zone|||
suppressed_reason|text|||
created_at|timestamp with time zone||not null|now()
updated_at|timestamp with time zone||not null|now()
```

**Unique constraint present:**
```
uq_lifecycle_state_user_trigger|UNIQUE
```

**`lifecycle_emails` column default:**
```
true
```

**Control-plane health post-migration:** `Up 44 hours (healthy)` ✅

## Depends on / blocks

- Part of captain `#794cf317` (TR lifecycle engine)
- S3 trigger-state worker (`b8c0ec63`) depends on this being applied first (deploy discipline: migration before worker code)

## Test plan

- [ ] Review migration + model changes
- [ ] CI passes (schema additive, no existing tests broken)
- [ ] `alembic downgrade -1` tested locally if rollback needed