### PR TITLE
[TR] S1: Listmonk team-relay-users list subscriber sync worker

### DIFF
--- a/apps/control-plane/app/core/config.py
+++ b/apps/control-plane/app/core/config.py
@@ -110,6 +110,17 @@ class Settings(BaseSettings):
         """Check if web publishing is enabled."""
         return bool(self.web_publish_domain)
 
+    # Listmonk email list sync
+    listmonk_url: str | None = Field(default=None, description="Listmonk base URL (e.g. https://lists.entire.host)")
+    listmonk_api_user: str = Field(default="api", description="Listmonk API username")
+    listmonk_api_password: str | None = Field(default=None, description="Listmonk API password")
+    listmonk_list_id: int = Field(default=8, description="Listmonk list ID for team-relay-users")
+    listmonk_sync_interval: int = Field(default=300, description="Listmonk sync poll interval in seconds")
+
+    @property
+    def listmonk_enabled(self) -> bool:
+        return bool(self.listmonk_url and self.listmonk_api_password)
+
     # MinIO / S3 settings for asset storage
     minio_endpoint: str = Field(default="localhost:9000", description="MinIO endpoint")
     minio_access_key: str = Field(default="minioadmin", description="MinIO access key")

--- a/apps/control-plane/app/services/listmonk_service.py
+++ b/apps/control-plane/app/services/listmonk_service.py
@@ -1,0 +1,256 @@
+"""Listmonk subscriber sync service for team-relay-users list.
+
+Syncs TR users to Listmonk list 8 (team-relay-users). Runs two modes:
+- Event-driven: polls users.created_at cursor for new registrations.
+- Nightly reconcile: full backfill of all active users.
+
+Subscribers are skipped if user_email_preferences.lifecycle_emails = false
+(missing row treated as true per lifecycle plan). Attributes stored per
+subscriber: casdoor (bool), registered_at (ISO), has_share (bool).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from typing import Any
+
+import httpx
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from app.core.config import get_settings
+from app.core.logging import get_logger
+
+logger = get_logger(__name__)
+
+_USERS_QUERY = text(
+    """
+    SELECT DISTINCT ON (u.id)
+        u.id::text,
+        u.email,
+        u.created_at AS registered_at,
+        (u.casdoor_id IS NOT NULL OR oa.user_id IS NOT NULL) AS casdoor,
+        EXISTS(
+            SELECT 1 FROM shares s WHERE s.owner_user_id = u.id
+        ) AS has_share,
+        COALESCE(oa.name, split_part(u.email, '@', 1)) AS name,
+        COALESCE(pref.lifecycle_emails, true) AS lifecycle_emails
+    FROM users u
+    LEFT JOIN user_oauth_accounts oa ON oa.user_id = u.id
+    LEFT JOIN user_email_preferences pref ON pref.user_id = u.id
+    WHERE u.is_active = true
+    ORDER BY u.id, oa.created_at DESC NULLS LAST
+    """
+)
+
+_NEW_USERS_SINCE_QUERY = text(
+    """
+    SELECT DISTINCT ON (u.id)
+        u.id::text,
+        u.email,
+        u.created_at AS registered_at,
+        (u.casdoor_id IS NOT NULL OR oa.user_id IS NOT NULL) AS casdoor,
+        EXISTS(
+            SELECT 1 FROM shares s WHERE s.owner_user_id = u.id
+        ) AS has_share,
+        COALESCE(oa.name, split_part(u.email, '@', 1)) AS name,
+        COALESCE(pref.lifecycle_emails, true) AS lifecycle_emails
+    FROM users u
+    LEFT JOIN user_oauth_accounts oa ON oa.user_id = u.id
+    LEFT JOIN user_email_preferences pref ON pref.user_id = u.id
+    WHERE u.is_active = true AND u.created_at > :since
+    ORDER BY u.id, oa.created_at DESC NULLS LAST
+    """
+)
+
+
+class ListmonkService:
+    def __init__(self) -> None:
+        self._settings = get_settings()
+        self._client: httpx.AsyncClient | None = None
+
+    def _client_or_raise(self) -> httpx.AsyncClient:
+        if self._client is None:
+            raise RuntimeError("ListmonkService not started — call start() first")
+        return self._client
+
+    async def start(self) -> None:
+        settings = self._settings
+        if not settings.listmonk_enabled:
+            logger.warning("Listmonk sync disabled — LISTMONK_URL or LISTMONK_API_PASSWORD not set")
+            return
+        self._client = httpx.AsyncClient(
+            base_url=settings.listmonk_url,
+            auth=(settings.listmonk_api_user, settings.listmonk_api_password),
+            timeout=15.0,
+        )
+
+    async def stop(self) -> None:
+        if self._client is not None:
+            await self._client.aclose()
+            self._client = None
+
+    # ------------------------------------------------------------------
+    # Core subscriber upsert
+    # ------------------------------------------------------------------
+
+    async def upsert_subscriber(
+        self,
+        email: str,
+        name: str,
+        casdoor: bool,
+        registered_at: datetime,
+        has_share: bool,
+        lifecycle_emails_on: bool,
+    ) -> bool:
+        """Upsert one subscriber into the Listmonk list.
+
+        Returns True if synced, False if skipped due to opt-out.
+        """
+        if not lifecycle_emails_on:
+            logger.debug("Skipping %s — lifecycle_emails=false", email)
+            return False
+
+        client = self._client_or_raise()
+        settings = self._settings
+
+        attribs: dict[str, Any] = {
+            "casdoor": casdoor,
+            "registered_at": registered_at.isoformat(),
+            "has_share": has_share,
+        }
+        payload = {
+            "email": email,
+            "name": name,
+            "status": "enabled",
+            "lists": [settings.listmonk_list_id],
+            "attribs": attribs,
+            "preconfirm_subscriptions": True,
+        }
+
+        resp = await client.post("/api/subscribers", json=payload)
+
+        if resp.status_code == 200:
+            return True
+
+        if resp.status_code == 409:
+            # Already exists — fetch by email and update attribs + list membership
+            return await self._update_existing(client, email, name, attribs)
+
+        resp.raise_for_status()
+        return False
+
+    async def _update_existing(
+        self,
+        client: httpx.AsyncClient,
+        email: str,
+        name: str,
+        attribs: dict[str, Any],
+    ) -> bool:
+        settings = self._settings
+        # Lookup subscriber by email
+        search = await client.get(
+            "/api/subscribers",
+            params={"query": f"subscribers.email = '{email}'", "per_page": 1},
+        )
+        search.raise_for_status()
+        results = search.json().get("data", {}).get("results", [])
+        if not results:
+            logger.warning("Subscriber %s returned 409 but not found in lookup — skipping", email)
+            return False
+
+        sub = results[0]
+        sub_id = sub["id"]
+        existing_lists = [lst["id"] for lst in sub.get("lists", [])]
+        if settings.listmonk_list_id not in existing_lists:
+            existing_lists.append(settings.listmonk_list_id)
+
+        # Merge attribs (keep any existing keys, overwrite ours)
+        merged_attribs = {**sub.get("attribs", {}), **attribs}
+
+        put_resp = await client.put(
+            f"/api/subscribers/{sub_id}",
+            json={
+                "email": email,
+                "name": name,
+                "status": sub.get("status", "enabled"),
+                "lists": existing_lists,
+                "attribs": merged_attribs,
+                "preconfirm_subscriptions": True,
+            },
+        )
+        put_resp.raise_for_status()
+        return True
+
+    # ------------------------------------------------------------------
+    # Batch sync methods called by the worker
+    # ------------------------------------------------------------------
+
+    async def sync_new_users(self, db: Session, since: datetime) -> tuple[int, datetime | None]:
+        """Sync users created after `since`. Returns (synced_count, max_created_at)."""
+        rows = db.execute(_NEW_USERS_SINCE_QUERY, {"since": since}).fetchall()
+        if not rows:
+            return 0, None
+
+        synced = 0
+        max_ts: datetime | None = None
+
+        for row in rows:
+            try:
+                ok = await self.upsert_subscriber(
+                    email=row.email,
+                    name=row.name,
+                    casdoor=bool(row.casdoor),
+                    registered_at=row.registered_at,
+                    has_share=bool(row.has_share),
+                    lifecycle_emails_on=bool(row.lifecycle_emails),
+                )
+                if ok:
+                    synced += 1
+                # Advance max_ts regardless (so cursor moves past opt-out users too)
+                if max_ts is None or row.registered_at > max_ts:
+                    max_ts = row.registered_at
+            except Exception:
+                logger.exception("Failed to upsert subscriber %s", row.email)
+
+        return synced, max_ts
+
+    async def backfill_all(self, db: Session) -> int:
+        """Full reconcile — upsert every active user. Returns count synced."""
+        rows = db.execute(_USERS_QUERY).fetchall()
+        synced = 0
+        skipped = 0
+
+        for row in rows:
+            try:
+                ok = await self.upsert_subscriber(
+                    email=row.email,
+                    name=row.name,
+                    casdoor=bool(row.casdoor),
+                    registered_at=row.registered_at,
+                    has_share=bool(row.has_share),
+                    lifecycle_emails_on=bool(row.lifecycle_emails),
+                )
+                if ok:
+                    synced += 1
+                else:
+                    skipped += 1
+            except Exception:
+                logger.exception("Failed to upsert subscriber %s", row.email)
+
+        logger.info("Backfill complete: synced=%d skipped=%d total=%d", synced, skipped, len(rows))
+        return synced
+
+    async def get_list_subscriber_count(self) -> int | None:
+        """Return current subscriber count from Listmonk API for acceptance check."""
+        client = self._client_or_raise()
+        resp = await client.get(f"/api/lists/{self._settings.listmonk_list_id}")
+        if resp.status_code != 200:
+            return None
+        data = resp.json().get("data", {})
+        return data.get("subscriber_count")
+
+
+def get_listmonk_service() -> ListmonkService:
+    return ListmonkService()

--- a/apps/control-plane/app/workers/listmonk_sync_worker.py
+++ b/apps/control-plane/app/workers/listmonk_sync_worker.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Listmonk subscriber sync worker for team-relay-users list.
+
+Polls for new TR registrations (via users.created_at cursor) and upserts them
+into Listmonk list 8. Also runs a nightly full backfill to catch any drift.
+
+Cursor is persisted in instance_settings.listmonk_sync_cursor so restarts
+are safe and don't re-send already-synced users.
+
+Usage:
+    python -m app.workers.listmonk_sync_worker
+
+Environment:
+    DATABASE_URL: PostgreSQL connection string
+    LISTMONK_URL: Listmonk base URL (e.g. https://lists.entire.host)
+    LISTMONK_API_USER: Listmonk API username (default: api)
+    LISTMONK_API_PASSWORD: Listmonk API password
+    LISTMONK_LIST_ID: List ID (default: 8)
+    LISTMONK_SYNC_INTERVAL: Poll interval in seconds (default: 300)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import signal
+import sys
+from datetime import datetime, timedelta, timezone
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+
+from sqlalchemy import text
+
+from app.core.config import get_settings
+from app.core.logging import get_logger
+from app.db.session import get_sessionmaker
+from app.services.listmonk_service import get_listmonk_service
+
+logger = get_logger(__name__)
+
+# How often to run the nightly reconcile full backfill
+_BACKFILL_INTERVAL_HOURS = 24
+
+_CURSOR_KEY = "listmonk_sync_cursor"
+_LAST_BACKFILL_KEY = "listmonk_last_backfill"
+
+shutdown_flag = False
+
+
+def _signal_handler(signum, frame) -> None:
+    global shutdown_flag
+    logger.info("Received signal %s — initiating graceful shutdown", signum)
+    shutdown_flag = True
+
+
+def _get_setting(db, key: str) -> str | None:
+    row = db.execute(
+        text("SELECT value FROM instance_settings WHERE key = :k"), {"k": key}
+    ).fetchone()
+    return row.value if row else None
+
+
+def _set_setting(db, key: str, value: str) -> None:
+    db.execute(
+        text(
+            """
+            INSERT INTO instance_settings (key, value)
+            VALUES (:k, :v)
+            ON CONFLICT (key) DO UPDATE SET value = :v, updated_at = NOW()
+            """
+        ),
+        {"k": key, "v": value},
+    )
+    db.commit()
+
+
+async def _run_incremental(svc, db, settings) -> None:
+    """Poll for new users since last cursor and sync them."""
+    cursor_str = _get_setting(db, _CURSOR_KEY)
+
+    if cursor_str:
+        since = datetime.fromisoformat(cursor_str)
+    else:
+        # First run: start from epoch so all existing users get picked up
+        since = datetime(1970, 1, 1, tzinfo=timezone.utc)
+
+    synced, new_cursor = await svc.sync_new_users(db, since)
+
+    if synced > 0 or new_cursor is not None:
+        logger.info("Incremental sync: synced=%d new users since %s", synced, since.isoformat())
+
+    if new_cursor is not None:
+        _set_setting(db, _CURSOR_KEY, new_cursor.isoformat())
+
+
+async def _run_backfill_if_due(svc, db) -> None:
+    """Run full backfill if it hasn't run in the last 24 hours."""
+    last_str = _get_setting(db, _LAST_BACKFILL_KEY)
+
+    if last_str:
+        last = datetime.fromisoformat(last_str)
+        if datetime.now(tz=timezone.utc) - last < timedelta(hours=_BACKFILL_INTERVAL_HOURS):
+            return
+
+    logger.info("Starting nightly full backfill to Listmonk")
+    count = await svc.backfill_all(db)
+
+    now_iso = datetime.now(tz=timezone.utc).isoformat()
+    _set_setting(db, _LAST_BACKFILL_KEY, now_iso)
+
+    # After backfill, advance cursor to now so incremental sync doesn't re-process
+    _set_setting(db, _CURSOR_KEY, now_iso)
+
+    # Log current list count for acceptance criteria verification
+    try:
+        list_count = await svc.get_list_subscriber_count()
+        logger.info(
+            "Backfill done: synced=%d, Listmonk list count=%s", count, list_count
+        )
+    except Exception:
+        logger.warning("Could not fetch list subscriber count after backfill")
+
+
+async def main() -> None:
+    global shutdown_flag
+
+    signal.signal(signal.SIGTERM, _signal_handler)
+    signal.signal(signal.SIGINT, _signal_handler)
+
+    settings = get_settings()
+
+    if not settings.listmonk_enabled:
+        logger.error(
+            "Listmonk sync disabled — set LISTMONK_URL and LISTMONK_API_PASSWORD. Exiting."
+        )
+        sys.exit(1)
+
+    svc = get_listmonk_service()
+    await svc.start()
+
+    logger.info(
+        "Listmonk sync worker started",
+        extra={
+            "listmonk_url": settings.listmonk_url,
+            "list_id": settings.listmonk_list_id,
+            "sync_interval": settings.listmonk_sync_interval,
+        },
+    )
+
+    try:
+        while not shutdown_flag:
+            db = get_sessionmaker()()
+            try:
+                await _run_backfill_if_due(svc, db)
+                await _run_incremental(svc, db, settings)
+            except Exception:
+                logger.exception("Error in Listmonk sync cycle")
+            finally:
+                db.close()
+
+            for _ in range(settings.listmonk_sync_interval):
+                if shutdown_flag:
+                    break
+                await asyncio.sleep(1)
+    finally:
+        await svc.stop()
+
+    logger.info("Listmonk sync worker stopped gracefully")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -170,6 +170,27 @@ services:
       control-plane-migrate:
         condition: service_completed_successfully
 
+  listmonk-sync-worker:
+    build:
+      context: ../apps/control-plane
+      dockerfile: Dockerfile
+    env_file:
+      - ./.env
+    environment:
+      DATABASE_URL: ${DATABASE_URL}
+      LISTMONK_URL: ${LISTMONK_URL:-}
+      LISTMONK_API_USER: ${LISTMONK_API_USER:-api}
+      LISTMONK_API_PASSWORD: ${LISTMONK_API_PASSWORD:-}
+      LISTMONK_LIST_ID: ${LISTMONK_LIST_ID:-8}
+      LISTMONK_SYNC_INTERVAL: ${LISTMONK_SYNC_INTERVAL:-300}
+    command: ["python", "-m", "app.workers.listmonk_sync_worker"]
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+      control-plane-migrate:
+        condition: service_completed_successfully
+
   # placeholder: relay server (будет подключён/собран агентом)
   relay-server:
     build:


### PR DESCRIPTION
## Summary

- Adds `listmonk_sync_worker` that keeps the `team-relay-users` Listmonk list (ID=8) in sync with TR users
- Cursor-based incremental sync every 5 min; nightly full-backfill every 24h; cursors persisted in `instance_settings`
- Subscriber attributes: `email`, `name`, `casdoor` (bool), `registered_at`, `has_share` (bool)
- Users with `lifecycle_emails=false` are skipped (opt-out respected)
- `casdoor` detection covers both `users.casdoor_id` (legacy) and `user_oauth_accounts` (OAuth-linked)

## Changes

- `app/core/config.py` — 5 new `LISTMONK_*` settings
- `app/services/listmonk_service.py` — async httpx client; POST→409→search→PUT upsert; backfill_all / sync_new_users
- `app/workers/listmonk_sync_worker.py` — main loop with cursor + nightly reconcile
- `infra/docker-compose.yml` — `listmonk-sync-worker` service

## Test plan

- [x] API validated manually: POST/409/search/PUT all return 200 against `lists.entire.host`
- [ ] Deploy to prod: add `LISTMONK_*` env vars to `/opt/relay/.env`, `docker compose up -d --build listmonk-sync-worker`
- [ ] First run triggers backfill → verify list count == 29 via `GET /api/lists/8`
- [ ] Smoke: new user registration appears in list within 5 min
- [ ] Daedalus verify before close

Part of TR lifecycle engine Block-1 (captain #794cf317, Mesh task c2ae9169).