### PR TITLE
fix(metrics): add db_connections_active/idle pool gauges

### DIFF
--- a/apps/control-plane/app/core/metrics.py
+++ b/apps/control-plane/app/core/metrics.py
@@ -63,6 +63,16 @@ DB_HEALTH_STATUS = Gauge(
     "Database health status (1 = healthy, 0 = unhealthy)",
 )
 
+DB_CONNECTIONS_ACTIVE = Gauge(
+    "db_connections_active",
+    "Number of database connections currently checked out (in use) from the pool",
+)
+
+DB_CONNECTIONS_IDLE = Gauge(
+    "db_connections_idle",
+    "Number of database connections currently idle (checked in) in the pool",
+)
+
 # =============================================================================
 # Business Metrics
 # =============================================================================

--- a/apps/control-plane/app/workers/metrics_worker.py
+++ b/apps/control-plane/app/workers/metrics_worker.py
@@ -17,6 +17,8 @@ from app.core.config import get_settings
 from app.core.logging import get_logger
 from app.core.metrics import (
     AGENT_KEYS_TOTAL,
+    DB_CONNECTIONS_ACTIVE,
+    DB_CONNECTIONS_IDLE,
     DB_HEALTH_STATUS,
     METRICS_COLLECTION_ERRORS_TOTAL,
     MINIO_BUCKET_SIZE_BYTES,
@@ -30,7 +32,7 @@ from app.core.metrics import (
     USERS_TOTAL,
 )
 from app.db import models
-from app.db.session import get_sessionmaker
+from app.db.session import get_engine, get_sessionmaker
 
 logger = get_logger(__name__)
 
@@ -54,9 +56,25 @@ def _init_gauge_labels() -> None:
         AGENT_KEYS_TOTAL.labels(status=s).set(0)
     SESSIONS_ACTIVE_TOTAL.set(0)
     DB_HEALTH_STATUS.set(0)
+    DB_CONNECTIONS_ACTIVE.set(0)
+    DB_CONNECTIONS_IDLE.set(0)
 
 
 _init_gauge_labels()
+
+
+def _collect_pool_metrics() -> None:
+    """Read SQLAlchemy connection-pool stats and update db_connections_* gauges.
+
+    Uses the pool's in-memory counters — no DB round-trip needed.
+    Silently skips for SQLite (StaticPool has no checkedout/checkedin).
+    """
+    try:
+        pool = get_engine().pool
+        DB_CONNECTIONS_ACTIVE.set(pool.checkedout())
+        DB_CONNECTIONS_IDLE.set(pool.checkedin())
+    except AttributeError:
+        pass  # SQLite StaticPool — skip without error
 
 
 def _collect_db_metrics() -> None:
@@ -229,6 +247,7 @@ async def run_metrics_collector() -> None:
         try:
             loop = asyncio.get_running_loop()
             await loop.run_in_executor(None, _collect_db_metrics)
+            await loop.run_in_executor(None, _collect_pool_metrics)
             await asyncio.wait_for(
                 loop.run_in_executor(None, _collect_minio_metrics),
                 timeout=30.0,

--- a/apps/control-plane/tests/test_metrics.py
+++ b/apps/control-plane/tests/test_metrics.py
@@ -117,6 +117,18 @@ def test_db_metrics_collection_runs_without_error(client: TestClient) -> None:
     assert response.status_code == 200
 
 
+def test_pool_metrics_collection_runs_without_error(client: TestClient) -> None:
+    """Test that _collect_pool_metrics runs without raising (SQLite StaticPool silently skips)."""
+    from app.workers.metrics_worker import _collect_pool_metrics
+
+    _collect_pool_metrics()
+
+    response = client.get("/metrics")
+    assert response.status_code == 200
+    assert "db_connections_active" in response.text
+    assert "db_connections_idle" in response.text
+
+
 def test_gauge_reflects_seeded_user(client: TestClient, db_session) -> None:
     """Assert users_total gauge value matches seeded active-user fixture count."""
     from app.db import models


### PR DESCRIPTION
## Summary

- Adds `db_connections_active` and `db_connections_idle` Prometheus Gauges collected from SQLAlchemy `QueuePool` every 60s
- These two metrics feed the **DB connection pool saturation** panel and `tr-db-pool-saturation` alert in the TR Overview Grafana dashboard — both were dark (`NoData`) until this metric begins flowing
- SQLite `StaticPool` (test env) silently skips via `AttributeError` guard — test suite unaffected

Fixes the dark panel from the TR Overview dashboard review.

## Test plan

- [x] `test_pool_metrics_collection_runs_without_error` — new test confirms no raise and gauge names appear in `/metrics` output
- [x] All 11 existing `test_metrics.py` tests pass
- [ ] After deploy to tw-relay: verify `db_connections_active{job="tr-control-plane"}` appears in Prometheus on tw-mon, TR Overview DB pool panel goes live