### PR TITLE
feat(metrics): emit db_connections_* pool gauges from control-plane

### DIFF
--- a/apps/control-plane/app/core/metrics.py
+++ b/apps/control-plane/app/core/metrics.py
@@ -63,6 +63,21 @@ DB_HEALTH_STATUS = Gauge(
     "Database health status (1 = healthy, 0 = unhealthy)",
 )
 
+DB_CONNECTIONS_ACTIVE = Gauge(
+    "db_connections_active",
+    "Active (checked-out) SQLAlchemy pool connections",
+)
+
+DB_CONNECTIONS_IDLE = Gauge(
+    "db_connections_idle",
+    "Idle (checked-in) SQLAlchemy pool connections",
+)
+
+DB_CONNECTIONS_TOTAL = Gauge(
+    "db_connections_total",
+    "Total SQLAlchemy pool connections (active + idle)",
+)
+
 # =============================================================================
 # Business Metrics
 # =============================================================================

--- a/apps/control-plane/app/workers/metrics_worker.py
+++ b/apps/control-plane/app/workers/metrics_worker.py
@@ -17,6 +17,9 @@ from app.core.config import get_settings
 from app.core.logging import get_logger
 from app.core.metrics import (
     AGENT_KEYS_TOTAL,
+    DB_CONNECTIONS_ACTIVE,
+    DB_CONNECTIONS_IDLE,
+    DB_CONNECTIONS_TOTAL,
     DB_HEALTH_STATUS,
     METRICS_COLLECTION_ERRORS_TOTAL,
     MINIO_BUCKET_SIZE_BYTES,
@@ -30,7 +33,7 @@ from app.core.metrics import (
     USERS_TOTAL,
 )
 from app.db import models
-from app.db.session import get_sessionmaker
+from app.db.session import get_engine, get_sessionmaker
 
 logger = get_logger(__name__)
 
@@ -54,6 +57,9 @@ def _init_gauge_labels() -> None:
         AGENT_KEYS_TOTAL.labels(status=s).set(0)
     SESSIONS_ACTIVE_TOTAL.set(0)
     DB_HEALTH_STATUS.set(0)
+    DB_CONNECTIONS_ACTIVE.set(0)
+    DB_CONNECTIONS_IDLE.set(0)
+    DB_CONNECTIONS_TOTAL.set(0)
 
 
 _init_gauge_labels()
@@ -76,6 +82,20 @@ def _collect_db_metrics() -> None:
 def _do_collect_db(db) -> None:  # noqa: ANN001
     now = datetime.now(timezone.utc)
     thirty_days_ago = now - timedelta(days=30)
+
+    # ── db_connections (SQLAlchemy pool stats) ────────────────────────────────
+    # Read in its own try/except so a pool introspection failure neither aborts
+    # the rest of DB collection nor flips db_health_status to 0.
+    try:
+        pool = get_engine().pool
+        active = pool.checkedout()
+        idle = pool.checkedin()
+        DB_CONNECTIONS_ACTIVE.set(active)
+        DB_CONNECTIONS_IDLE.set(idle)
+        DB_CONNECTIONS_TOTAL.set(active + idle)
+    except Exception as exc:
+        METRICS_COLLECTION_ERRORS_TOTAL.labels(collector="pool").inc()
+        logger.warning("metrics_worker: pool stat error", extra={"error": str(exc)})
 
     # ── users_total (active / inactive) ──────────────────────────────────────
     user_rows = db.execute(

--- a/apps/control-plane/tests/test_metrics.py
+++ b/apps/control-plane/tests/test_metrics.py
@@ -117,6 +117,33 @@ def test_db_metrics_collection_runs_without_error(client: TestClient) -> None:
     assert response.status_code == 200
 
 
+def test_db_connections_pool_gauges_emitted(client: TestClient) -> None:
+    """db_connections_* pool gauges are present and total == active + idle."""
+    from app.workers.metrics_worker import _collect_db_metrics
+
+    _collect_db_metrics()
+
+    response = client.get("/metrics")
+    assert response.status_code == 200
+    content = response.text
+    assert "db_connections_active" in content
+    assert "db_connections_idle" in content
+    assert "db_connections_total" in content
+
+    def _val(name: str) -> float:
+        lines = [
+            ln
+            for ln in content.splitlines()
+            if ln.startswith(name + " ") and not ln.startswith("#")
+        ]
+        assert lines, f"{name} metric not found"
+        return float(lines[0].split()[-1])
+
+    assert _val("db_connections_total") == _val("db_connections_active") + _val(
+        "db_connections_idle"
+    )
+
+
 def test_gauge_reflects_seeded_user(client: TestClient, db_session) -> None:
     """Assert users_total gauge value matches seeded active-user fixture count."""
     from app.db import models


### PR DESCRIPTION
The TR Overview Grafana dashboard (DB-connection-pool panel + `tr-db-pool-saturation` alert) queries `db_connections_active{job="tr-control-plane"}` / `_idle` / `_total`, but those gauges were never defined or collected — so the panel and alert stayed dark.

## Change
- Define `DB_CONNECTIONS_ACTIVE` / `DB_CONNECTIONS_IDLE` / `DB_CONNECTIONS_TOTAL` gauges in `app/core/metrics.py`.
- Collect SQLAlchemy `QueuePool` stats (`pool.checkedout()` / `pool.checkedin()`) in the metrics-worker DB cycle, in their own `try/except` so a pool-read failure neither aborts the rest of DB collection nor flips `db_health_status` to 0.
- Pre-initialise the gauges to 0 in `_init_gauge_labels()` so they appear in `/metrics` immediately.
- Test: pool gauges present in `/metrics` and `total == active + idle`.

## Verification
- `uv run pytest tests/test_metrics.py` → 11 passed.
- `ruff check` + `ruff format --check` clean.

After deploy, `curl http://localhost:8000/metrics | grep db_connections` returns non-zero values within one 60s collection cycle, then `db_connections_active{job="tr-control-plane"}` returns rows in Prometheus (~60s later) and the dashboard DB-pool panel populates.