### PR TITLE
feat(metrics): add db_connections_* pool gauges to control-plane

### DIFF
--- a/apps/control-plane/app/core/metrics.py
+++ b/apps/control-plane/app/core/metrics.py
@@ -63,6 +63,21 @@ DB_HEALTH_STATUS = Gauge(
     "Database health status (1 = healthy, 0 = unhealthy)",
 )
 
+DB_CONNECTIONS_ACTIVE = Gauge(
+    "db_connections_active",
+    "Active (checked-out) SQLAlchemy pool connections",
+)
+
+DB_CONNECTIONS_IDLE = Gauge(
+    "db_connections_idle",
+    "Idle (checked-in) SQLAlchemy pool connections",
+)
+
+DB_CONNECTIONS_TOTAL = Gauge(
+    "db_connections_total",
+    "Total SQLAlchemy pool connections (active + idle)",
+)
+
 # =============================================================================
 # Business Metrics
 # =============================================================================

--- a/apps/control-plane/app/workers/metrics_worker.py
+++ b/apps/control-plane/app/workers/metrics_worker.py
@@ -17,6 +17,9 @@ from app.core.config import get_settings
 from app.core.logging import get_logger
 from app.core.metrics import (
     AGENT_KEYS_TOTAL,
+    DB_CONNECTIONS_ACTIVE,
+    DB_CONNECTIONS_IDLE,
+    DB_CONNECTIONS_TOTAL,
     DB_HEALTH_STATUS,
     METRICS_COLLECTION_ERRORS_TOTAL,
     MINIO_BUCKET_SIZE_BYTES,
@@ -30,7 +33,7 @@ from app.core.metrics import (
     USERS_TOTAL,
 )
 from app.db import models
-from app.db.session import get_sessionmaker
+from app.db.session import get_engine, get_sessionmaker
 
 logger = get_logger(__name__)
 
@@ -54,6 +57,9 @@ def _init_gauge_labels() -> None:
         AGENT_KEYS_TOTAL.labels(status=s).set(0)
     SESSIONS_ACTIVE_TOTAL.set(0)
     DB_HEALTH_STATUS.set(0)
+    DB_CONNECTIONS_ACTIVE.set(0)
+    DB_CONNECTIONS_IDLE.set(0)
+    DB_CONNECTIONS_TOTAL.set(0)
 
 
 _init_gauge_labels()
@@ -76,6 +82,18 @@ def _collect_db_metrics() -> None:
 def _do_collect_db(db) -> None:  # noqa: ANN001
     now = datetime.now(timezone.utc)
     thirty_days_ago = now - timedelta(days=30)
+
+    # ── db_connections (SQLAlchemy pool stats) ────────────────────────────────
+    try:
+        pool = get_engine().pool
+        active = pool.checkedout()
+        idle = pool.checkedin()
+        DB_CONNECTIONS_ACTIVE.set(active)
+        DB_CONNECTIONS_IDLE.set(idle)
+        DB_CONNECTIONS_TOTAL.set(active + idle)
+    except Exception as exc:
+        METRICS_COLLECTION_ERRORS_TOTAL.labels(collector="pool").inc()
+        logger.warning("metrics_worker: pool stat error", extra={"error": str(exc)})
 
     # ── users_total (active / inactive) ──────────────────────────────────────
     user_rows = db.execute(

--- a/apps/control-plane/tests/test_metrics.py
+++ b/apps/control-plane/tests/test_metrics.py
@@ -117,6 +117,17 @@ def test_db_metrics_collection_runs_without_error(client: TestClient) -> None:
     assert response.status_code == 200
 
 
+def test_metrics_contains_db_connections_gauges(client: TestClient) -> None:
+    """Test that db_connections_* pool gauges appear in /metrics output."""
+    response = client.get("/metrics")
+    assert response.status_code == 200
+
+    content = response.text
+    assert "db_connections_active" in content
+    assert "db_connections_idle" in content
+    assert "db_connections_total" in content
+
+
 def test_gauge_reflects_seeded_user(client: TestClient, db_session) -> None:
     """Assert users_total gauge value matches seeded active-user fixture count."""
     from app.db import models


### PR DESCRIPTION
## Summary

- Adds `db_connections_active`, `db_connections_idle`, `db_connections_total` Prometheus gauges to `app/core/metrics.py`
- Collects SQLAlchemy pool stats (`checkedout()` / `checkedin()`) at the top of each `_do_collect_db()` cycle in `app/workers/metrics_worker.py`
- Gauges are zero-initialized at startup so they appear in `/metrics` before the first collection cycle
- Pool errors are counted under `metrics_collection_errors_total{collector="pool"}` — no unhandled exceptions
- Adds test `test_metrics_contains_db_connections_gauges` to verify presence in `/metrics` output

**Closes:** Gap 1 from the parent Grafana TR-Overview DB-pool panel + `tr-db-pool-saturation` alert (subtask of #6d4cf97e). Gap 2 (pg-exporter) was already fixed.

## Test plan

- [x] `pytest tests/test_metrics.py` — 11/11 pass (was 10/10 before)
- [ ] After merge + deploy: `curl http://localhost:8000/metrics | grep db_connections` shows non-zero values 60 s post startup
- [ ] Prometheus scrape: `db_connections_active{job="tr-control-plane"}` returns ≥1 row within 60 s of deploy