### PR TITLE
fix(lint): resolve ruff F401 and format failures from S1/S2 merges

### DIFF
--- a/apps/control-plane/app/api/routers/web.py
+++ b/apps/control-plane/app/api/routers/web.py
@@ -1135,9 +1135,7 @@ async def upload_mesh_artifact(
         )
     share = db.execute(stmt).scalar_one_or_none()
     if not share:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="Share not found"
-        )
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Share not found")
     if share.kind != models.ShareKind.FOLDER:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/apps/control-plane/app/core/config.py
+++ b/apps/control-plane/app/core/config.py
@@ -111,11 +111,15 @@ class Settings(BaseSettings):
         return bool(self.web_publish_domain)
 
     # Listmonk email list sync
-    listmonk_url: str | None = Field(default=None, description="Listmonk base URL (e.g. https://lists.entire.host)")
+    listmonk_url: str | None = Field(
+        default=None, description="Listmonk base URL (e.g. https://lists.entire.host)"
+    )
     listmonk_api_user: str = Field(default="api", description="Listmonk API username")
     listmonk_api_password: str | None = Field(default=None, description="Listmonk API password")
     listmonk_list_id: int = Field(default=8, description="Listmonk list ID for team-relay-users")
-    listmonk_sync_interval: int = Field(default=300, description="Listmonk sync poll interval in seconds")
+    listmonk_sync_interval: int = Field(
+        default=300, description="Listmonk sync poll interval in seconds"
+    )
 
     @property
     def listmonk_enabled(self) -> bool:

--- a/apps/control-plane/app/db/migrations/versions/202602190001_stub_prod_head.py
+++ b/apps/control-plane/app/db/migrations/versions/202602190001_stub_prod_head.py
@@ -16,8 +16,6 @@ No upgrade or downgrade actions — prod schema already reflects this state.
 
 from typing import Sequence, Union
 
-from alembic import op
-
 revision: str = "202602190001"
 down_revision: Union[str, None] = "202602030003"
 branch_labels: Union[str, Sequence[str], None] = None

--- a/apps/control-plane/app/services/listmonk_service.py
+++ b/apps/control-plane/app/services/listmonk_service.py
@@ -11,8 +11,7 @@ subscriber: casdoor (bool), registered_at (ISO), has_share (bool).
 
 from __future__ import annotations
 
-import asyncio
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Any
 
 import httpx

--- a/apps/control-plane/app/workers/listmonk_sync_worker.py
+++ b/apps/control-plane/app/workers/listmonk_sync_worker.py
@@ -114,9 +114,7 @@ async def _run_backfill_if_due(svc, db) -> None:
     # Log current list count for acceptance criteria verification
     try:
         list_count = await svc.get_list_subscriber_count()
-        logger.info(
-            "Backfill done: synced=%d, Listmonk list count=%s", count, list_count
-        )
+        logger.info("Backfill done: synced=%d, Listmonk list count=%s", count, list_count)
     except Exception:
         logger.warning("Could not fetch list subscriber count after backfill")
 


### PR DESCRIPTION
## Summary

- Remove unused `asyncio` and `timezone` imports in `listmonk_service.py` (F401)
- Remove unused `alembic.op` import in `202602190001_stub_prod_head.py` (F401)
- Reformat long `Field()` definitions in `config.py` to stay within 100 chars (E501)
- Reformat `web.py` and `listmonk_sync_worker.py` per ruff format

CI `lint-python` was red on main after S1 (Listmonk) and S2 (lifecycle) merges. All 4 ruff errors and 3 format issues are now resolved — `ruff check app/` and `ruff format --check app/` both pass locally.

## Test plan

- [ ] CI `lint-python` step goes green on this PR
- [ ] No logic changes — pure lint/format fixes, all imports removed were confirmed unused by ruff