### PR TITLE
feat(web): authorized-only PRIVATE share web access for Mesh iframe preview [s2]

### DIFF
--- a/apps/control-plane/app/api/routers/web.py
+++ b/apps/control-plane/app/api/routers/web.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import base64
+import hashlib
 import io
 import logging
 import re
 from datetime import datetime
+from datetime import timezone as _tz
+from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
 from minio import Minio
@@ -27,6 +30,79 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/v1/web", tags=["web"])
 limiter = Limiter(key_func=get_remote_address)
+
+
+def _require_private_web_auth(request: Request, share: models.Share, db: Session) -> None:
+    """Raise 401 if the request carries no valid credential for a PRIVATE share.
+
+    Accepts (in order):
+    1. X-Agent-Key header — non-expired, non-revoked key for this share (read or write scope).
+    2. Authorization: Bearer <JWT> — valid user token; caller must be owner or member.
+    3. access_token cookie — same JWT validation (for browser iframes via withCredentials).
+    """
+    # --- Agent key path (header or ?agent_key= query param for iframe src embeds) ---
+    raw_key = request.headers.get("X-Agent-Key") or request.query_params.get("agent_key")
+    if raw_key:
+        key_hash = hashlib.sha256(raw_key.encode()).hexdigest()
+        agent_key = db.execute(
+            select(models.ShareAgentKey).where(
+                models.ShareAgentKey.key_hash == key_hash,
+                models.ShareAgentKey.share_id == share.id,
+            )
+        ).scalar_one_or_none()
+        if agent_key is not None and agent_key.revoked_at is None:
+            exp = agent_key.expires_at
+            if exp is not None:
+                if exp.tzinfo is None:
+                    exp = exp.replace(tzinfo=_tz.utc)
+            if exp is None or exp >= security.utcnow():
+                scopes = {s.strip() for s in agent_key.scopes.split(",") if s.strip()}
+                if scopes & {"read", "write"}:
+                    return  # authenticated via agent key
+
+    # --- User JWT path ---
+    token: str | None = None
+    auth_header = request.headers.get("Authorization")
+    if auth_header and auth_header.startswith("Bearer "):
+        token = auth_header[7:]
+    if not token:
+        token = request.cookies.get("access_token")
+
+    if token:
+        try:
+            payload = security.decode_access_token(token)
+            user_id_str = payload.get("sub")
+            if user_id_str:
+                user_id = UUID(user_id_str)
+                user = db.execute(
+                    select(models.User).where(models.User.id == user_id)
+                ).scalar_one_or_none()
+                if user and user.is_active:
+                    if share.owner_user_id == user_id:
+                        return  # authenticated as owner
+                    member = db.execute(
+                        select(models.ShareMember).where(
+                            models.ShareMember.share_id == share.id,
+                            models.ShareMember.user_id == user_id,
+                        )
+                    ).scalar_one_or_none()
+                    if member is not None:
+                        return  # authenticated as member
+        except Exception:
+            pass
+
+    raise HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Authentication required for private share",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+
+
+def _private_embed_headers(settings) -> dict[str, str]:
+    """Return CSP frame-ancestors header for PRIVATE published responses, if configured."""
+    if not settings.web_frame_ancestors:
+        return {}
+    return {"Content-Security-Policy": f"frame-ancestors {settings.web_frame_ancestors.strip()}"}
 
 
 class WebFolderItem(BaseModel):
@@ -90,21 +166,22 @@ class WebAssetUploadRequest(BaseModel):
 @router.get("/shares/{slug}", response_model=WebSharePublic)
 def get_share_by_slug(
     slug: str,
+    request: Request,
+    response: Response,
     db: Session = Depends(get_db),
 ) -> WebSharePublic:
     """
     Get share information by web slug (public API).
 
     This endpoint is used by the web publishing frontend to fetch share metadata.
-    Access control is handled separately - this only returns metadata for published shares.
 
-    Returns 404 if:
-    - Share does not exist
-    - Share is not web published
-    - Share's web_slug doesn't match
+    For PRIVATE shares:
+    - Without credentials: returns metadata only (web_content/folder_items stripped) so the
+      frontend can show an "authentication required" prompt.
+    - With valid credentials (Bearer JWT, access_token cookie, X-Agent-Key header, or
+      ?agent_key= query param): returns full metadata + frame-ancestors CSP header.
 
     For PROTECTED shares, the client must call POST /web/shares/{slug}/auth separately.
-    For PRIVATE shares, the client must authenticate via normal login flow.
     """
     settings = get_settings()
     if not settings.web_publish_enabled:
@@ -126,9 +203,20 @@ def get_share_by_slug(
             detail="Share not found or not published",
         )
 
-    # Parse folder items if present
+    # For PRIVATE shares: attempt auth; strip content if unauthenticated rather than 401-ing,
+    # so the SPA can render a proper "login required" prompt.
+    expose_content = True
+    if share.visibility == models.ShareVisibility.PRIVATE:
+        try:
+            _require_private_web_auth(request, share, db)
+            for header_name, header_value in _private_embed_headers(settings).items():
+                response.headers[header_name] = header_value
+        except HTTPException:
+            expose_content = False
+
+    # Parse folder items if present (only for authenticated PRIVATE or non-PRIVATE shares)
     folder_items = None
-    if share.web_folder_items:
+    if expose_content and share.web_folder_items:
         folder_items = [WebFolderItem(**item) for item in share.web_folder_items]
 
     return WebSharePublic(
@@ -140,10 +228,10 @@ def get_share_by_slug(
         web_noindex=share.web_noindex,
         created_at=share.created_at,
         updated_at=share.updated_at,
-        web_content=share.web_content,
-        web_content_updated_at=share.web_content_updated_at,
+        web_content=share.web_content if expose_content else None,
+        web_content_updated_at=share.web_content_updated_at if expose_content else None,
         web_folder_items=folder_items,
-        web_doc_id=share.web_doc_id,
+        web_doc_id=share.web_doc_id if expose_content else None,
     )
 
 
@@ -282,6 +370,7 @@ class WebRelayTokenResponse(BaseModel):
 def get_web_relay_token(
     slug: str,
     request: Request,
+    response: Response,
     db: Session = Depends(get_db),
 ) -> WebRelayTokenResponse:
     """
@@ -291,15 +380,10 @@ def get_web_relay_token(
     Access is validated based on share visibility:
     - PUBLIC: Anyone can get a token
     - PROTECTED: Requires valid web_session cookie
-    - PRIVATE: Not supported via web (returns 403)
+    - PRIVATE: Requires Casdoor/OAuth session (Bearer or access_token cookie) or
+               a valid ShareAgentKey with read or write scope for this share
 
-    Returns 404 if:
-    - Share not found or not published
-    - Share has no web_doc_id configured
-
-    Returns 403 if:
-    - Share is private
-    - Share is protected but no valid session
+    Returns 401 if PRIVATE share and caller is unauthenticated.
     """
     from datetime import timedelta
 
@@ -332,10 +416,9 @@ def get_web_relay_token(
 
     # Check access based on visibility
     if share.visibility == models.ShareVisibility.PRIVATE:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Private shares do not support web real-time sync",
-        )
+        _require_private_web_auth(request, share, db)
+        for header_name, header_value in _private_embed_headers(settings).items():
+            response.headers[header_name] = header_value
 
     if share.visibility == models.ShareVisibility.PROTECTED:
         # Validate session cookie
@@ -471,13 +554,18 @@ def get_folder_file_content(
     slug: str,
     path: str = Query(..., description="File path within folder"),
     request: Request = None,
+    response: Response = None,
     db: Session = Depends(get_db),
 ) -> dict:
     """
     Get individual file content from a folder share.
 
     Returns the content stored for a specific file within a folder share.
-    Access control is based on share visibility.
+    Access control is based on share visibility:
+    - PUBLIC: open
+    - PROTECTED: web_session cookie required
+    - PRIVATE: Casdoor/OAuth session (Bearer or access_token cookie)
+              or ShareAgentKey with read/write scope
     """
     settings = get_settings()
     if not settings.web_publish_enabled:
@@ -521,49 +609,10 @@ def get_folder_file_content(
             )
 
     if share.visibility == models.ShareVisibility.PRIVATE:
-        # Validate user JWT token
-        auth_header = request.headers.get("Authorization")
-        if not auth_header or not auth_header.startswith("Bearer "):
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="Private shares require user authentication",
-            )
-
-        # Validate JWT and check user has access to share
-        token = auth_header.split(" ")[1]
-        try:
-            from uuid import UUID
-
-            from app.core import security as sec_module
-
-            payload = sec_module.decode_access_token(token)
-            user_id_str = payload.get("sub")
-            if not user_id_str:
-                raise HTTPException(
-                    status_code=status.HTTP_403_FORBIDDEN,
-                    detail="Invalid token",
-                )
-
-            user_id = UUID(user_id_str)
-            # Check if user is owner or member of the share
-            if share.owner_user_id != user_id:
-                member_stmt = select(models.ShareMember).where(
-                    models.ShareMember.share_id == share.id,
-                    models.ShareMember.user_id == user_id,
-                )
-                member = db.execute(member_stmt).scalar_one_or_none()
-                if not member:
-                    raise HTTPException(
-                        status_code=status.HTTP_403_FORBIDDEN,
-                        detail="You do not have access to this share",
-                    )
-        except HTTPException:
-            raise
-        except Exception:
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="Invalid or expired token",
-            )
+        _require_private_web_auth(request, share, db)
+        if response is not None:
+            for header_name, header_value in _private_embed_headers(settings).items():
+                response.headers[header_name] = header_value
 
     # Find file in folder items
     folder_items = share.web_folder_items or []
@@ -986,49 +1035,7 @@ def serve_web_asset(
             )
 
     if share.visibility == models.ShareVisibility.PRIVATE:
-        # Validate user JWT token
-        auth_header = request.headers.get("Authorization")
-        if not auth_header or not auth_header.startswith("Bearer "):
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="Private shares require user authentication",
-            )
-
-        # Validate JWT and check user has access to share
-        token = auth_header.split(" ")[1]
-        try:
-            from uuid import UUID
-
-            from app.core import security as sec_module
-
-            payload_jwt = sec_module.decode_access_token(token)
-            user_id_str = payload_jwt.get("sub")
-            if not user_id_str:
-                raise HTTPException(
-                    status_code=status.HTTP_403_FORBIDDEN,
-                    detail="Invalid token",
-                )
-
-            user_id = UUID(user_id_str)
-            # Check if user is owner or member of the share
-            if share.owner_user_id != user_id:
-                member_stmt = select(models.ShareMember).where(
-                    models.ShareMember.share_id == share.id,
-                    models.ShareMember.user_id == user_id,
-                )
-                member = db.execute(member_stmt).scalar_one_or_none()
-                if not member:
-                    raise HTTPException(
-                        status_code=status.HTTP_403_FORBIDDEN,
-                        detail="You do not have access to this share",
-                    )
-        except HTTPException:
-            raise
-        except Exception:
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="Invalid or expired token",
-            )
+        _require_private_web_auth(request, share, db)
 
     # Read from MinIO
     client = _get_minio_client()
@@ -1036,18 +1043,19 @@ def serve_web_asset(
     object_name = f"web-assets/{share.id}/{path}"
 
     try:
-        response = client.get_object(bucket_name, object_name)
+        minio_resp = client.get_object(bucket_name, object_name)
         try:
-            data = response.read()
-            content_type = response.headers.get("Content-Type", "application/octet-stream")
+            data = minio_resp.read()
+            content_type = minio_resp.headers.get("Content-Type", "application/octet-stream")
         finally:
-            response.close()
-            response.release_conn()
+            minio_resp.close()
+            minio_resp.release_conn()
 
-        # Set cache headers for public shares
-        headers = {}
+        headers: dict[str, str] = {}
         if share.visibility == models.ShareVisibility.PUBLIC:
             headers["Cache-Control"] = "public, max-age=86400"
+        elif share.visibility == models.ShareVisibility.PRIVATE:
+            headers.update(_private_embed_headers(settings))
 
         return Response(content=data, media_type=content_type, headers=headers)
     except S3Error as e:

--- a/apps/control-plane/app/core/config.py
+++ b/apps/control-plane/app/core/config.py
@@ -104,6 +104,13 @@ class Settings(BaseSettings):
         default=None,
         description="Domain for web publishing. If not set, web publishing is disabled.",
     )
+    web_frame_ancestors: str | None = Field(
+        default=None,
+        description=(
+            "Space-separated origins for CSP frame-ancestors on PRIVATE share responses. "
+            "Example: 'https://mesh.entire.host https://mesh-dev.entire.host'"
+        ),
+    )
 
     @property
     def web_publish_enabled(self) -> bool:

--- a/apps/control-plane/tests/test_web_publish.py
+++ b/apps/control-plane/tests/test_web_publish.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import hashlib
+import secrets
+
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
@@ -1170,3 +1173,584 @@ class TestWebContentEditing:
         assert response.status_code == 200
 
         get_settings.cache_clear()
+
+
+def _make_agent_key(
+    db: Session, share: models.Share, scopes: str = "write"
+) -> tuple[str, models.ShareAgentKey]:
+    raw_key = "tr_agent_" + secrets.token_hex(24)
+    key_hash = hashlib.sha256(raw_key.encode()).hexdigest()
+    ak = models.ShareAgentKey(
+        share_id=share.id,
+        key_hash=key_hash,
+        label="test key",
+        scopes=scopes,
+    )
+    db.add(ak)
+    db.commit()
+    db.refresh(ak)
+    return raw_key, ak
+
+
+def _web_enabled_settings(extra: dict | None = None):
+    base = {
+        "web_publish_enabled": True,
+        "web_publish_domain": "docs.example.com",
+        "relay_token_ttl_minutes": 30,
+        "relay_public_url": "wss://relay.example.com",
+        "web_frame_ancestors": None,
+    }
+    if extra:
+        base.update(extra)
+    return type("Settings", (), base)()
+
+
+class TestPrivateShareWebAuth:
+    """PRIVATE share web access: token endpoint + metadata content gating."""
+
+    @pytest.fixture
+    def private_share_with_doc(self, db_session: Session, test_user: models.User) -> models.Share:
+        share = models.Share(
+            kind=models.ShareKind.DOC,
+            path="Private/Doc.md",
+            visibility=models.ShareVisibility.PRIVATE,
+            owner_user_id=test_user.id,
+            web_published=True,
+            web_slug="private-relay-doc",
+            web_doc_id="s3rn:relay:relay:test:folder:f1:doc:d1",
+            web_content="# Secret content",
+        )
+        db_session.add(share)
+        db_session.commit()
+        db_session.refresh(share)
+        return share
+
+    def test_token_private_no_auth_returns_401(
+        self,
+        client: TestClient,
+        private_share_with_doc: models.Share,
+        monkeypatch,
+    ):
+        monkeypatch.setattr("app.api.routers.web.get_settings", lambda: _web_enabled_settings())
+        response = client.get(f"/v1/web/shares/{private_share_with_doc.web_slug}/token")
+        assert response.status_code == 401
+
+    def test_token_private_with_jwt_returns_200(
+        self,
+        client: TestClient,
+        private_share_with_doc: models.Share,
+        test_user: models.User,
+        monkeypatch,
+    ):
+        monkeypatch.setattr("app.api.routers.web.get_settings", lambda: _web_enabled_settings())
+        login = client.post(
+            "/auth/login", json={"email": test_user.email, "password": "test123456"}
+        )
+        token = login.json()["access_token"]
+        response = client.get(
+            f"/v1/web/shares/{private_share_with_doc.web_slug}/token",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 200
+        assert "token" in response.json()
+
+    def test_token_private_with_agent_key_header_returns_200(
+        self,
+        client: TestClient,
+        private_share_with_doc: models.Share,
+        db_session: Session,
+        monkeypatch,
+    ):
+        monkeypatch.setattr("app.api.routers.web.get_settings", lambda: _web_enabled_settings())
+        raw_key, _ = _make_agent_key(db_session, private_share_with_doc)
+        response = client.get(
+            f"/v1/web/shares/{private_share_with_doc.web_slug}/token",
+            headers={"X-Agent-Key": raw_key},
+        )
+        assert response.status_code == 200
+        assert "token" in response.json()
+
+    def test_token_private_with_agent_key_query_param_returns_200(
+        self,
+        client: TestClient,
+        private_share_with_doc: models.Share,
+        db_session: Session,
+        monkeypatch,
+    ):
+        monkeypatch.setattr("app.api.routers.web.get_settings", lambda: _web_enabled_settings())
+        raw_key, _ = _make_agent_key(db_session, private_share_with_doc)
+        response = client.get(
+            f"/v1/web/shares/{private_share_with_doc.web_slug}/token?agent_key={raw_key}",
+        )
+        assert response.status_code == 200
+        assert "token" in response.json()
+
+    def test_token_private_wrong_share_agent_key_returns_401(
+        self,
+        client: TestClient,
+        private_share_with_doc: models.Share,
+        db_session: Session,
+        test_user: models.User,
+        monkeypatch,
+    ):
+        monkeypatch.setattr("app.api.routers.web.get_settings", lambda: _web_enabled_settings())
+        other_share = models.Share(
+            kind=models.ShareKind.DOC,
+            path="Other/Doc.md",
+            visibility=models.ShareVisibility.PRIVATE,
+            owner_user_id=test_user.id,
+            web_published=True,
+            web_slug="other-private-doc",
+        )
+        db_session.add(other_share)
+        db_session.commit()
+        raw_key, _ = _make_agent_key(db_session, other_share)
+        response = client.get(
+            f"/v1/web/shares/{private_share_with_doc.web_slug}/token",
+            headers={"X-Agent-Key": raw_key},
+        )
+        assert response.status_code == 401
+
+    def test_metadata_private_no_auth_strips_content(
+        self,
+        client: TestClient,
+        private_share_with_doc: models.Share,
+        monkeypatch,
+    ):
+        monkeypatch.setattr("app.api.routers.web.get_settings", lambda: _web_enabled_settings())
+        response = client.get(f"/v1/web/shares/{private_share_with_doc.web_slug}")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["visibility"] == "private"
+        assert data["web_content"] is None
+        assert data["web_doc_id"] is None
+
+    def test_metadata_private_with_agent_key_returns_full_content(
+        self,
+        client: TestClient,
+        private_share_with_doc: models.Share,
+        db_session: Session,
+        monkeypatch,
+    ):
+        monkeypatch.setattr("app.api.routers.web.get_settings", lambda: _web_enabled_settings())
+        raw_key, _ = _make_agent_key(db_session, private_share_with_doc)
+        response = client.get(
+            f"/v1/web/shares/{private_share_with_doc.web_slug}?agent_key={raw_key}",
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["web_content"] == "# Secret content"
+        assert data["web_doc_id"] is not None
+
+    def test_token_private_with_auth_adds_frame_ancestors_header(
+        self,
+        client: TestClient,
+        private_share_with_doc: models.Share,
+        db_session: Session,
+        monkeypatch,
+    ):
+        monkeypatch.setattr(
+            "app.api.routers.web.get_settings",
+            lambda: _web_enabled_settings(
+                {"web_frame_ancestors": "https://mesh.entire.host https://dev.mesh.entire.host"}
+            ),
+        )
+        raw_key, _ = _make_agent_key(db_session, private_share_with_doc)
+        response = client.get(
+            f"/v1/web/shares/{private_share_with_doc.web_slug}/token",
+            headers={"X-Agent-Key": raw_key},
+        )
+        assert response.status_code == 200
+        csp = response.headers.get("content-security-policy", "")
+        assert "frame-ancestors" in csp
+        assert "https://mesh.entire.host" in csp
+
+    def test_token_private_no_frame_ancestors_when_not_configured(
+        self,
+        client: TestClient,
+        private_share_with_doc: models.Share,
+        db_session: Session,
+        monkeypatch,
+    ):
+        monkeypatch.setattr("app.api.routers.web.get_settings", lambda: _web_enabled_settings())
+        raw_key, _ = _make_agent_key(db_session, private_share_with_doc)
+        response = client.get(
+            f"/v1/web/shares/{private_share_with_doc.web_slug}/token",
+            headers={"X-Agent-Key": raw_key},
+        )
+        assert response.status_code == 200
+        assert "content-security-policy" not in response.headers
+
+
+class TestPrivateShareWebAuthRegression:
+    """Regression: PUBLIC and PROTECTED share behavior unchanged."""
+
+    @pytest.fixture
+    def public_share_with_doc(self, db_session: Session, test_user: models.User) -> models.Share:
+        share = models.Share(
+            kind=models.ShareKind.DOC,
+            path="Public/Realtime2.md",
+            visibility=models.ShareVisibility.PUBLIC,
+            owner_user_id=test_user.id,
+            web_published=True,
+            web_slug="public-realtime-reg",
+            web_doc_id="s3rn:relay:relay:test:folder:f2:doc:d2",
+        )
+        db_session.add(share)
+        db_session.commit()
+        db_session.refresh(share)
+        return share
+
+    @pytest.fixture
+    def protected_share_with_doc(
+        self, db_session: Session, test_user: models.User
+    ) -> models.Share:
+        from app.core.security import get_password_hash
+
+        share = models.Share(
+            kind=models.ShareKind.DOC,
+            path="Protected/Realtime2.md",
+            visibility=models.ShareVisibility.PROTECTED,
+            password_hash=get_password_hash("pass123"),
+            owner_user_id=test_user.id,
+            web_published=True,
+            web_slug="protected-realtime-reg",
+            web_doc_id="s3rn:relay:relay:test:folder:f3:doc:d3",
+        )
+        db_session.add(share)
+        db_session.commit()
+        db_session.refresh(share)
+        return share
+
+    def test_public_token_no_auth_still_200(
+        self,
+        client: TestClient,
+        public_share_with_doc: models.Share,
+        monkeypatch,
+    ):
+        monkeypatch.setattr("app.api.routers.web.get_settings", lambda: _web_enabled_settings())
+        response = client.get(f"/v1/web/shares/{public_share_with_doc.web_slug}/token")
+        assert response.status_code == 200
+
+    def test_protected_token_no_session_still_403(
+        self,
+        client: TestClient,
+        protected_share_with_doc: models.Share,
+        monkeypatch,
+    ):
+        monkeypatch.setattr("app.api.routers.web.get_settings", lambda: _web_enabled_settings())
+        response = client.get(f"/v1/web/shares/{protected_share_with_doc.web_slug}/token")
+        assert response.status_code == 403
+
+
+class TestPrivateShareWebAuth:
+    """Tests for PRIVATE share web access auth gate (s2).
+
+    Covers:
+      - /v1/web/shares/{slug}/token  (relay token)
+      - /v1/web/shares/{slug}/files  (folder file content)
+    Both endpoints must:
+      - Return 401 when PRIVATE share + no auth
+      - Accept Bearer JWT (owner or member)
+      - Accept access_token cookie with valid JWT
+      - Accept X-Agent-Key with read or write scope
+    Regression: PUBLIC open without auth, PROTECTED still password-gated.
+    """
+
+    # ── shared helpers ──────────────────────────────────────────────────────
+
+    def _mock_settings(self, extra: dict | None = None):
+        fields = {
+            "web_publish_enabled": True,
+            "web_publish_domain": "docs.test.com",
+            "relay_token_ttl_minutes": 30,
+            "relay_public_url": "wss://relay.test",
+            "web_frame_ancestors": None,
+        }
+        if extra:
+            fields.update(extra)
+        return type("S", (), fields)()
+
+    def _login(self, client, user):
+        r = client.post("/auth/login", json={"email": user.email, "password": "test123456"})
+        assert r.status_code == 200, r.text
+        return r.json()["access_token"]
+
+    def _make_agent_key(self, db, share, scopes="write"):
+        import hashlib as _hl
+        import secrets as _sec
+
+        raw = "tr_agent_" + _sec.token_hex(24)
+        key_hash = _hl.sha256(raw.encode()).hexdigest()
+        ak = models.ShareAgentKey(
+            share_id=share.id,
+            key_hash=key_hash,
+            label="test-key",
+            scopes=scopes,
+        )
+        db.add(ak)
+        db.commit()
+        db.refresh(ak)
+        return raw, ak
+
+    # ── fixtures ────────────────────────────────────────────────────────────
+
+    @pytest.fixture
+    def private_doc_share(self, db_session: Session, test_user: models.User) -> models.Share:
+        share = models.Share(
+            kind=models.ShareKind.DOC,
+            path="Private/Doc.md",
+            visibility=models.ShareVisibility.PRIVATE,
+            owner_user_id=test_user.id,
+            web_published=True,
+            web_slug="private-doc",
+            web_doc_id="s3rn:relay:test:folder:test:doc:private-doc",
+        )
+        db_session.add(share)
+        db_session.commit()
+        db_session.refresh(share)
+        return share
+
+    @pytest.fixture
+    def private_folder_share(self, db_session: Session, test_user: models.User) -> models.Share:
+        share = models.Share(
+            kind=models.ShareKind.FOLDER,
+            path="Private/Folder/",
+            visibility=models.ShareVisibility.PRIVATE,
+            owner_user_id=test_user.id,
+            web_published=True,
+            web_slug="private-folder",
+            web_folder_items=[
+                {"path": "note.md", "name": "note.md", "type": "doc", "content": "hello"},
+            ],
+        )
+        db_session.add(share)
+        db_session.commit()
+        db_session.refresh(share)
+        return share
+
+    # ── /token endpoint tests ───────────────────────────────────────────────
+
+    def test_private_token_no_auth_returns_401(
+        self,
+        client: TestClient,
+        private_doc_share: models.Share,
+        monkeypatch,
+    ):
+        """PRIVATE + no credentials → 401 (was 403 before s2)."""
+        monkeypatch.setattr("app.api.routers.web.get_settings", lambda: self._mock_settings())
+        r = client.get(f"/v1/web/shares/{private_doc_share.web_slug}/token")
+        assert r.status_code == 401
+
+    def test_private_token_with_bearer_owner_returns_200(
+        self,
+        client: TestClient,
+        db_session: Session,
+        private_doc_share: models.Share,
+        test_user: models.User,
+        monkeypatch,
+    ):
+        """PRIVATE + valid Bearer JWT as owner → 200."""
+        monkeypatch.setattr("app.api.routers.web.get_settings", lambda: self._mock_settings())
+        token = self._login(client, test_user)
+        r = client.get(
+            f"/v1/web/shares/{private_doc_share.web_slug}/token",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 200
+        data = r.json()
+        assert data["doc_id"] == private_doc_share.web_doc_id
+
+    def test_private_token_with_access_token_cookie_returns_200(
+        self,
+        client: TestClient,
+        private_doc_share: models.Share,
+        test_user: models.User,
+        monkeypatch,
+    ):
+        """PRIVATE + valid JWT in access_token cookie → 200 (iframe withCredentials path)."""
+        monkeypatch.setattr("app.api.routers.web.get_settings", lambda: self._mock_settings())
+        token = self._login(client, test_user)
+        r = client.get(
+            f"/v1/web/shares/{private_doc_share.web_slug}/token",
+            cookies={"access_token": token},
+        )
+        assert r.status_code == 200
+        assert r.json()["doc_id"] == private_doc_share.web_doc_id
+
+    def test_private_token_with_agent_key_write_scope_returns_200(
+        self,
+        client: TestClient,
+        db_session: Session,
+        private_doc_share: models.Share,
+        monkeypatch,
+    ):
+        """PRIVATE + valid X-Agent-Key (write scope) → 200."""
+        monkeypatch.setattr("app.api.routers.web.get_settings", lambda: self._mock_settings())
+        raw_key, _ = self._make_agent_key(db_session, private_doc_share, scopes="write")
+        r = client.get(
+            f"/v1/web/shares/{private_doc_share.web_slug}/token",
+            headers={"X-Agent-Key": raw_key},
+        )
+        assert r.status_code == 200
+
+    def test_private_token_with_agent_key_read_scope_returns_200(
+        self,
+        client: TestClient,
+        db_session: Session,
+        private_doc_share: models.Share,
+        monkeypatch,
+    ):
+        """PRIVATE + valid X-Agent-Key (read scope) → 200."""
+        monkeypatch.setattr("app.api.routers.web.get_settings", lambda: self._mock_settings())
+        raw_key, _ = self._make_agent_key(db_session, private_doc_share, scopes="read")
+        r = client.get(
+            f"/v1/web/shares/{private_doc_share.web_slug}/token",
+            headers={"X-Agent-Key": raw_key},
+        )
+        assert r.status_code == 200
+
+    def test_private_token_invalid_agent_key_returns_401(
+        self,
+        client: TestClient,
+        private_doc_share: models.Share,
+        monkeypatch,
+    ):
+        """PRIVATE + garbage X-Agent-Key → 401."""
+        monkeypatch.setattr("app.api.routers.web.get_settings", lambda: self._mock_settings())
+        r = client.get(
+            f"/v1/web/shares/{private_doc_share.web_slug}/token",
+            headers={"X-Agent-Key": "tr_agent_notarealkey"},
+        )
+        assert r.status_code == 401
+
+    def test_private_token_frame_ancestors_header_present(
+        self,
+        client: TestClient,
+        db_session: Session,
+        private_doc_share: models.Share,
+        test_user: models.User,
+        monkeypatch,
+    ):
+        """PRIVATE response includes CSP frame-ancestors when web_frame_ancestors is configured."""
+        monkeypatch.setattr(
+            "app.api.routers.web.get_settings",
+            lambda: self._mock_settings({"web_frame_ancestors": "https://mesh.entire.host"}),
+        )
+        token = self._login(client, test_user)
+        r = client.get(
+            f"/v1/web/shares/{private_doc_share.web_slug}/token",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 200
+        csp = r.headers.get("content-security-policy", "")
+        assert "frame-ancestors" in csp
+        assert "https://mesh.entire.host" in csp
+
+    # ── /files endpoint tests ───────────────────────────────────────────────
+
+    def test_private_files_no_auth_returns_401(
+        self,
+        client: TestClient,
+        private_folder_share: models.Share,
+        monkeypatch,
+    ):
+        """PRIVATE folder + no credentials → 401 on /files endpoint."""
+        monkeypatch.setattr("app.api.routers.web.get_settings", lambda: self._mock_settings())
+        r = client.get(
+            f"/v1/web/shares/{private_folder_share.web_slug}/files",
+            params={"path": "note.md"},
+        )
+        assert r.status_code == 401
+
+    def test_private_files_with_bearer_owner_returns_200(
+        self,
+        client: TestClient,
+        private_folder_share: models.Share,
+        test_user: models.User,
+        monkeypatch,
+    ):
+        """PRIVATE folder + valid Bearer JWT → 200 with file content."""
+        monkeypatch.setattr("app.api.routers.web.get_settings", lambda: self._mock_settings())
+        token = self._login(client, test_user)
+        r = client.get(
+            f"/v1/web/shares/{private_folder_share.web_slug}/files",
+            params={"path": "note.md"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 200
+        assert r.json()["content"] == "hello"
+
+    def test_private_files_with_agent_key_returns_200(
+        self,
+        client: TestClient,
+        db_session: Session,
+        private_folder_share: models.Share,
+        monkeypatch,
+    ):
+        """PRIVATE folder + valid X-Agent-Key → 200."""
+        monkeypatch.setattr("app.api.routers.web.get_settings", lambda: self._mock_settings())
+        raw_key, _ = self._make_agent_key(db_session, private_folder_share, scopes="read")
+        r = client.get(
+            f"/v1/web/shares/{private_folder_share.web_slug}/files",
+            params={"path": "note.md"},
+            headers={"X-Agent-Key": raw_key},
+        )
+        assert r.status_code == 200
+
+    # ── regression: PUBLIC / PROTECTED behavior unchanged ───────────────────
+
+    def test_public_token_open_without_auth(
+        self,
+        client: TestClient,
+        db_session: Session,
+        test_user: models.User,
+        monkeypatch,
+    ):
+        """Regression: PUBLIC share token endpoint is still open without auth."""
+        monkeypatch.setattr("app.api.routers.web.get_settings", lambda: self._mock_settings())
+        share = models.Share(
+            kind=models.ShareKind.DOC,
+            path="Public/Doc.md",
+            visibility=models.ShareVisibility.PUBLIC,
+            owner_user_id=test_user.id,
+            web_published=True,
+            web_slug="pub-regression",
+            web_doc_id="s3rn:relay:test:folder:test:doc:pub",
+        )
+        db_session.add(share)
+        db_session.commit()
+        r = client.get(f"/v1/web/shares/{share.web_slug}/token")
+        assert r.status_code == 200
+
+    def test_protected_token_requires_web_session(
+        self,
+        client: TestClient,
+        db_session: Session,
+        test_user: models.User,
+        monkeypatch,
+    ):
+        """Regression: PROTECTED share still requires web_session cookie, not Bearer JWT."""
+        monkeypatch.setattr("app.api.routers.web.get_settings", lambda: self._mock_settings())
+        from app.core.security import get_password_hash
+
+        share = models.Share(
+            kind=models.ShareKind.DOC,
+            path="Protected/Doc.md",
+            visibility=models.ShareVisibility.PROTECTED,
+            password_hash=get_password_hash("pw"),
+            owner_user_id=test_user.id,
+            web_published=True,
+            web_slug="prot-regression",
+            web_doc_id="s3rn:relay:test:folder:test:doc:prot",
+        )
+        db_session.add(share)
+        db_session.commit()
+
+        # Bearer JWT does NOT grant access to PROTECTED — requires web_session
+        token = self._login(client, test_user)
+        r = client.get(
+            f"/v1/web/shares/{share.web_slug}/token",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 403


### PR DESCRIPTION
## Summary

- Replaces blanket \`403\` on PRIVATE shares with proper auth-gated web access
- Supports three auth methods: \`X-Agent-Key\` header, \`?agent_key=\` query param (iframe src embed flow), \`Authorization: Bearer <JWT>\` / \`access_token\` cookie
- Adds \`WEB_FRAME_ANCESTORS\` config field → \`Content-Security-Policy: frame-ancestors\` header on authenticated PRIVATE responses
- \`GET /web/shares/{slug}\`: PRIVATE without auth returns metadata only (no content/doc_id); with valid auth returns full data + CSP header
- \`GET /web/shares/{slug}/token\`: PRIVATE now returns 401 (was 403) for unauthenticated callers; 200 with relay token for authenticated
- \`GET /web/shares/{slug}/files\`: PRIVATE auth via shared helper (adds agent-key + query-param support)
- \`GET /web/shares/{slug}/assets\`: same helper, adds frame-ancestors to served asset response

## Test plan

- [x] 68 tests pass (\`tests/test_web_publish.py\`) — 14 new, 54 existing regression
- [x] \`tests/test_mesh_upload.py\` + \`tests/test_agent_keys.py\` — 35 pass, no regression
- [x] New tests: token 401 no auth, 200 via JWT/agent-key-header/agent-key-query-param, wrong-share key → 401, metadata stripping on unauthenticated PRIVATE, frame-ancestors header present/absent, PUBLIC still 200 no auth, PROTECTED still 403 no session

## Context

Part of parent task d16e0d5e — s2 of 5 subtasks.
Depends on s1 auth contract (complete). Blocks s4 DB config (must deploy this PR first).