### PR TITLE
fix(tests): restore 9 silenced tests — rename dup TestPrivateShareWebAuth class

### DIFF
--- a/apps/control-plane/tests/test_web_publish.py
+++ b/apps/control-plane/tests/test_web_publish.py
@@ -1205,7 +1205,7 @@ def _web_enabled_settings(extra: dict | None = None):
     return type("Settings", (), base)()
 
 
-class TestPrivateShareWebAuth:
+class TestPrivateShareWebAuthMetadata:
     """PRIVATE share web access: token endpoint + metadata content gating."""
 
     @pytest.fixture


### PR DESCRIPTION
## Summary

- Duplicate class name `TestPrivateShareWebAuth` at line 1208 (first definition) was silently shadowed by the one at line 1446 — Python drops the first when both have the same name
- Renames line-1208 class to `TestPrivateShareWebAuthMetadata` so all 9 tests covering metadata content-stripping for PRIVATE shares now run
- No logic change — test-only rename

## Context

Follow-up to PR #55 ([TR web-publish] authorized-only PRIVATE share access). The duplicate was caught in review (`d16e0d5e`) but the merge landed before the fix was pushed.

## Test plan
- [ ] `test-python` passes with all 9 previously-silent tests now executing
- [ ] No logic changes