### PR TITLE
feat(web): POST /v1/web/shares/{id}/sync-upload — ADR-0045 Approach C

### DIFF
--- a/apps/control-plane/app/api/routers/web.py
+++ b/apps/control-plane/app/api/routers/web.py
@@ -1303,3 +1303,200 @@ async def upload_mesh_artifact(
         "modified_at": now_iso,
         "public_url": public_url,
     }
+
+
+@router.post("/shares/{share_id}/sync-upload", status_code=status.HTTP_200_OK)
+@limiter.limit("30/minute")
+async def sync_upload(
+    request: Request,
+    share_id: str,
+    path: str = Query(..., description="Relative file path within share"),
+    db: Session = Depends(get_db),
+) -> dict:
+    """
+    Upload a file from a Mesh agent into the relay CAS and register it for sync.
+
+    Auth: X-Agent-Key header — non-revoked, non-expired key with write scope for this share.
+    Body: raw bytes. Max 25 MB.
+    Storage: MinIO under sync-uploads/{share_id}/{sha256} (CAS-style, same bucket as relay-server).
+    Index: upserted into share.web_folder_items with source=sync-artifact.
+    Sync trigger: bumps share.web_content_updated_at so plugin pulls on next cycle.
+
+    Returns sync_url (relay WebSocket URL for the share) and web_url (web-publish URL) so the
+    caller knows where the file will be reachable after the next plugin sync cycle.
+    """
+    import hashlib
+    import uuid as _uuid_mod
+
+    settings = get_settings()
+    if not settings.web_publish_enabled:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Web publishing is not enabled on this server",
+        )
+
+    _validate_upload_path(path)
+
+    # Resolve share by UUID only (sync endpoint is for private/authenticated access).
+    try:
+        _share_uuid = _uuid_mod.UUID(share_id)
+    except ValueError:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Share not found")
+
+    share = db.execute(
+        select(models.Share).where(models.Share.id == _share_uuid)
+    ).scalar_one_or_none()
+    if not share:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Share not found")
+    if share.kind != models.ShareKind.FOLDER:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="sync-upload only supported for folder shares",
+        )
+
+    # Agent-key auth: two-step lookup so wrong-share key → 403, missing key → 401.
+    raw_key = request.headers.get("X-Agent-Key")
+    if not raw_key:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="X-Agent-Key header required"
+        )
+
+    key_hash = hashlib.sha256(raw_key.encode()).hexdigest()
+    agent_key = db.execute(
+        select(models.ShareAgentKey).where(models.ShareAgentKey.key_hash == key_hash)
+    ).scalar_one_or_none()
+
+    if agent_key is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid agent key")
+    if agent_key.share_id != share.id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Agent key not valid for this share"
+        )
+    if agent_key.revoked_at is not None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Agent key has been revoked"
+        )
+    if agent_key.expires_at is not None:
+        from datetime import timezone as _tz
+
+        exp = agent_key.expires_at
+        if exp.tzinfo is None:
+            exp = exp.replace(tzinfo=_tz.utc)
+        if exp < security.utcnow():
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN, detail="Agent key has expired"
+            )
+    if "write" not in agent_key.scopes:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Agent key does not have write scope"
+        )
+
+    body = await request.body()
+    if len(body) > MAX_MESH_UPLOAD_SIZE:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=f"File too large. Max size: {MAX_MESH_UPLOAD_SIZE // (1024 * 1024)}MB",
+        )
+
+    mime = request.headers.get("Content-Type", "application/octet-stream").split(";")[0].strip()
+    sha256 = hashlib.sha256(body).hexdigest()
+
+    # CAS storage: key is content-addressed by SHA256, stored alongside relay-server's data.
+    minio_client = _get_minio_client()
+    bucket_name = settings.minio_bucket
+    _ensure_minio_bucket(minio_client, bucket_name)
+
+    cas_key = f"sync-uploads/{share.id}/{sha256}"
+    try:
+        minio_client.put_object(
+            bucket_name,
+            cas_key,
+            io.BytesIO(body),
+            length=len(body),
+            content_type=mime,
+        )
+    except S3Error as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to store artifact: {e}",
+        )
+
+    logger.info(
+        "agent_key.used",
+        extra={
+            "event": "sync_upload",
+            "key_id": str(agent_key.id),
+            "share_id": str(share.id),
+            "path": path,
+            "sha256": sha256,
+            "ip": request.client.host if request.client else None,
+        },
+    )
+
+    # Upsert into web_folder_items with sync-artifact source.
+    from sqlalchemy.orm.attributes import flag_modified
+
+    now_iso = security.utcnow().isoformat()
+    is_text = mime.startswith("text/") or mime in ("application/json", "application/xml")
+    inline_content = (
+        body.decode("utf-8", errors="replace") if (is_text and len(body) < 256 * 1024) else None
+    )
+
+    folder_items = list(share.web_folder_items or [])
+    updated = False
+    for item in folder_items:
+        if item.get("path") == path:
+            item.update(
+                {
+                    "name": path.split("/")[-1],
+                    "type": "doc" if is_text else "asset",
+                    "source": "sync-artifact",
+                    "mime": mime,
+                    "size": len(body),
+                    "sha256": sha256,
+                    "modified_at": now_iso,
+                    "storage_key": cas_key,
+                    "content": inline_content,
+                }
+            )
+            updated = True
+            break
+
+    if not updated:
+        folder_items.append(
+            {
+                "path": path,
+                "name": path.split("/")[-1],
+                "type": "doc" if is_text else "asset",
+                "source": "sync-artifact",
+                "mime": mime,
+                "size": len(body),
+                "sha256": sha256,
+                "modified_at": now_iso,
+                "storage_key": cas_key,
+                "content": inline_content,
+            }
+        )
+
+    share.web_folder_items = folder_items
+    flag_modified(share, "web_folder_items")
+    share.web_content_updated_at = security.utcnow()
+    agent_key.last_used_at = security.utcnow()
+    db.commit()
+
+    # Build response URLs.
+    relay_base = str(settings.relay_public_url).rstrip("/")
+    sync_url = f"{relay_base}/{share.id}"
+
+    web_url = None
+    if share.web_published and share.web_slug and settings.web_publish_domain:
+        domain = settings.web_publish_domain
+        if not domain.startswith("http"):
+            domain = f"https://{domain}"
+        web_url = f"{domain.rstrip('/')}/{share.web_slug}/{path}"
+
+    return {
+        "sync_url": sync_url,
+        "web_url": web_url,
+        "path": path,
+    }

--- a/apps/control-plane/tests/test_sync_upload.py
+++ b/apps/control-plane/tests/test_sync_upload.py
@@ -1,0 +1,400 @@
+"""Tests for POST /v1/web/shares/{share_id}/sync-upload endpoint."""
+
+from __future__ import annotations
+
+import hashlib
+import secrets
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.db import models
+
+
+def login(client: TestClient, email: str, password: str) -> str:
+    response = client.post("/auth/login", json={"email": email, "password": password})
+    assert response.status_code == 200, response.text
+    return response.json()["access_token"]
+
+
+def make_folder_share(
+    db: Session,
+    user: models.User,
+    slug: str = "sync-share",
+    published: bool = True,
+) -> models.Share:
+    share = models.Share(
+        kind=models.ShareKind.FOLDER,
+        path="SyncFolder/",
+        visibility=models.ShareVisibility.PRIVATE,
+        owner_user_id=user.id,
+        web_published=published,
+        web_slug=slug if published else None,
+        web_folder_items=[],
+    )
+    db.add(share)
+    db.commit()
+    db.refresh(share)
+    return share
+
+
+def make_agent_key(
+    db: Session,
+    share: models.Share,
+    scopes: str = "write",
+    expires_at: datetime | None = None,
+) -> tuple[str, models.ShareAgentKey]:
+    raw_key = "tr_agent_" + secrets.token_hex(24)
+    key_hash = hashlib.sha256(raw_key.encode()).hexdigest()
+    ak = models.ShareAgentKey(
+        share_id=share.id,
+        key_hash=key_hash,
+        label="sync-test key",
+        scopes=scopes,
+        expires_at=expires_at,
+    )
+    db.add(ak)
+    db.commit()
+    db.refresh(ak)
+    return raw_key, ak
+
+
+@pytest.fixture
+def web_enabled(monkeypatch):
+    monkeypatch.setenv("WEB_PUBLISH_DOMAIN", "docs.test.com")
+    from app.core.config import get_settings
+
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+def minio_patch():
+    mock_client = MagicMock()
+    mock_client.bucket_exists.return_value = True
+    mock_client.put_object.return_value = None
+    return patch("app.api.routers.web._get_minio_client", return_value=mock_client)
+
+
+BASE = "/v1/web/shares"
+
+
+class TestSyncUploadBasic:
+    def test_valid_upload_returns_sync_and_web_url(
+        self, client: TestClient, test_user: models.User, db_session: Session, web_enabled
+    ):
+        share = make_folder_share(db_session, test_user, slug="su-basic")
+        raw_key, _ = make_agent_key(db_session, share)
+        with minio_patch():
+            resp = client.post(
+                f"{BASE}/{share.id}/sync-upload?path=notes/hello.md",
+                content=b"# Hello",
+                headers={"X-Agent-Key": raw_key, "Content-Type": "text/markdown"},
+            )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert "sync_url" in data
+        assert str(share.id) in data["sync_url"]
+        assert data["web_url"] is not None
+        assert "su-basic" in data["web_url"]
+        assert data["path"] == "notes/hello.md"
+
+    def test_web_url_none_when_not_published(
+        self, client: TestClient, test_user: models.User, db_session: Session, web_enabled
+    ):
+        share = make_folder_share(db_session, test_user, published=False)
+        raw_key, _ = make_agent_key(db_session, share)
+        with minio_patch():
+            resp = client.post(
+                f"{BASE}/{share.id}/sync-upload?path=note.md",
+                content=b"content",
+                headers={"X-Agent-Key": raw_key, "Content-Type": "text/markdown"},
+            )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["web_url"] is None
+
+    def test_item_in_folder_items_with_sync_artifact_source(
+        self, client: TestClient, test_user: models.User, db_session: Session, web_enabled
+    ):
+        share = make_folder_share(db_session, test_user, slug="su-index")
+        raw_key, _ = make_agent_key(db_session, share)
+        with minio_patch():
+            client.post(
+                f"{BASE}/{share.id}/sync-upload?path=doc.md",
+                content=b"# Doc",
+                headers={"X-Agent-Key": raw_key, "Content-Type": "text/markdown"},
+            )
+        db_session.refresh(share)
+        items = share.web_folder_items or []
+        assert any(i["path"] == "doc.md" for i in items)
+        item = next(i for i in items if i["path"] == "doc.md")
+        assert item["source"] == "sync-artifact"
+        assert "sha256" in item
+        assert item["storage_key"].startswith("sync-uploads/")
+
+    def test_sha256_matches_content(
+        self, client: TestClient, test_user: models.User, db_session: Session, web_enabled
+    ):
+        share = make_folder_share(db_session, test_user, slug="su-hash")
+        raw_key, _ = make_agent_key(db_session, share)
+        body = b"checksum content"
+        expected_hash = hashlib.sha256(body).hexdigest()
+        with minio_patch():
+            client.post(
+                f"{BASE}/{share.id}/sync-upload?path=file.md",
+                content=body,
+                headers={"X-Agent-Key": raw_key, "Content-Type": "text/markdown"},
+            )
+        db_session.refresh(share)
+        item = next(i for i in share.web_folder_items if i["path"] == "file.md")
+        assert item["sha256"] == expected_hash
+
+    def test_idempotent_overwrite(
+        self, client: TestClient, test_user: models.User, db_session: Session, web_enabled
+    ):
+        share = make_folder_share(db_session, test_user, slug="su-idem")
+        raw_key, _ = make_agent_key(db_session, share)
+        with minio_patch():
+            client.post(
+                f"{BASE}/{share.id}/sync-upload?path=note.md",
+                content=b"v1",
+                headers={"X-Agent-Key": raw_key, "Content-Type": "text/markdown"},
+            )
+            client.post(
+                f"{BASE}/{share.id}/sync-upload?path=note.md",
+                content=b"v2 updated",
+                headers={"X-Agent-Key": raw_key, "Content-Type": "text/markdown"},
+            )
+        db_session.refresh(share)
+        matching = [i for i in share.web_folder_items if i["path"] == "note.md"]
+        assert len(matching) == 1
+        assert matching[0]["size"] == len(b"v2 updated")
+
+    def test_bumps_web_content_updated_at(
+        self, client: TestClient, test_user: models.User, db_session: Session, web_enabled
+    ):
+        share = make_folder_share(db_session, test_user, slug="su-bump")
+        raw_key, _ = make_agent_key(db_session, share)
+        before = share.web_content_updated_at
+        with minio_patch():
+            client.post(
+                f"{BASE}/{share.id}/sync-upload?path=bump.md",
+                content=b"data",
+                headers={"X-Agent-Key": raw_key, "Content-Type": "text/markdown"},
+            )
+        db_session.refresh(share)
+        assert share.web_content_updated_at != before
+
+    def test_updates_last_used_at(
+        self, client: TestClient, test_user: models.User, db_session: Session, web_enabled
+    ):
+        share = make_folder_share(db_session, test_user, slug="su-lastused")
+        raw_key, ak = make_agent_key(db_session, share)
+        assert ak.last_used_at is None
+        with minio_patch():
+            client.post(
+                f"{BASE}/{share.id}/sync-upload?path=note.md",
+                content=b"data",
+                headers={"X-Agent-Key": raw_key, "Content-Type": "text/markdown"},
+            )
+        db_session.refresh(ak)
+        assert ak.last_used_at is not None
+
+    def test_minio_cas_key_format(
+        self, client: TestClient, test_user: models.User, db_session: Session, web_enabled
+    ):
+        share = make_folder_share(db_session, test_user, slug="su-cas-key")
+        raw_key, _ = make_agent_key(db_session, share)
+        body = b"cas content"
+        sha = hashlib.sha256(body).hexdigest()
+        with minio_patch() as mock_get_client:
+            client.post(
+                f"{BASE}/{share.id}/sync-upload?path=file.md",
+                content=body,
+                headers={"X-Agent-Key": raw_key, "Content-Type": "text/markdown"},
+            )
+            mock_client = mock_get_client.return_value
+        call_args = mock_client.put_object.call_args
+        assert call_args is not None
+        object_name = call_args[0][1] if call_args[0] else call_args.kwargs.get("object_name")
+        assert object_name == f"sync-uploads/{share.id}/{sha}"
+
+
+class TestSyncUploadAuth:
+    def test_missing_key_returns_401(
+        self, client: TestClient, test_user: models.User, db_session: Session, web_enabled
+    ):
+        share = make_folder_share(db_session, test_user, slug="su-no-key")
+        resp = client.post(
+            f"{BASE}/{share.id}/sync-upload?path=file.md",
+            content=b"data",
+            headers={"Content-Type": "text/plain"},
+        )
+        assert resp.status_code == 401
+
+    def test_invalid_key_returns_401(
+        self, client: TestClient, test_user: models.User, db_session: Session, web_enabled
+    ):
+        share = make_folder_share(db_session, test_user, slug="su-bad-key")
+        resp = client.post(
+            f"{BASE}/{share.id}/sync-upload?path=file.md",
+            content=b"data",
+            headers={"X-Agent-Key": "tr_agent_invalid", "Content-Type": "text/plain"},
+        )
+        assert resp.status_code == 401
+
+    def test_key_for_wrong_share_returns_403(
+        self, client: TestClient, test_user: models.User, db_session: Session, web_enabled
+    ):
+        share1 = make_folder_share(db_session, test_user, slug="su-s1")
+        share2 = make_folder_share(db_session, test_user, slug="su-s2")
+        raw_key, _ = make_agent_key(db_session, share1)
+        with minio_patch():
+            resp = client.post(
+                f"{BASE}/{share2.id}/sync-upload?path=file.md",
+                content=b"data",
+                headers={"X-Agent-Key": raw_key, "Content-Type": "text/plain"},
+            )
+        assert resp.status_code == 403
+
+    def test_revoked_key_returns_403(
+        self, client: TestClient, test_user: models.User, db_session: Session, web_enabled
+    ):
+        share = make_folder_share(db_session, test_user, slug="su-revoked")
+        raw_key, ak = make_agent_key(db_session, share)
+        ak.revoked_at = datetime.now(timezone.utc)
+        db_session.commit()
+        with minio_patch():
+            resp = client.post(
+                f"{BASE}/{share.id}/sync-upload?path=file.md",
+                content=b"data",
+                headers={"X-Agent-Key": raw_key, "Content-Type": "text/plain"},
+            )
+        assert resp.status_code == 403
+
+    def test_expired_key_returns_403(
+        self, client: TestClient, test_user: models.User, db_session: Session, web_enabled
+    ):
+        share = make_folder_share(db_session, test_user, slug="su-expired")
+        raw_key, ak = make_agent_key(
+            db_session, share, expires_at=datetime.now(timezone.utc) - timedelta(hours=1)
+        )
+        with minio_patch():
+            resp = client.post(
+                f"{BASE}/{share.id}/sync-upload?path=file.md",
+                content=b"data",
+                headers={"X-Agent-Key": raw_key, "Content-Type": "text/plain"},
+            )
+        assert resp.status_code == 403
+
+    def test_read_only_key_returns_403(
+        self, client: TestClient, test_user: models.User, db_session: Session, web_enabled
+    ):
+        share = make_folder_share(db_session, test_user, slug="su-readonly")
+        raw_key, _ = make_agent_key(db_session, share, scopes="read")
+        with minio_patch():
+            resp = client.post(
+                f"{BASE}/{share.id}/sync-upload?path=file.md",
+                content=b"data",
+                headers={"X-Agent-Key": raw_key, "Content-Type": "text/plain"},
+            )
+        assert resp.status_code == 403
+
+
+class TestSyncUploadValidation:
+    def test_path_traversal_returns_400(
+        self, client: TestClient, test_user: models.User, db_session: Session, web_enabled
+    ):
+        share = make_folder_share(db_session, test_user, slug="su-traverse")
+        raw_key, _ = make_agent_key(db_session, share)
+        resp = client.post(
+            f"{BASE}/{share.id}/sync-upload?path=../etc/passwd",
+            content=b"data",
+            headers={"X-Agent-Key": raw_key, "Content-Type": "text/plain"},
+        )
+        assert resp.status_code == 400
+
+    def test_leading_slash_returns_400(
+        self, client: TestClient, test_user: models.User, db_session: Session, web_enabled
+    ):
+        share = make_folder_share(db_session, test_user, slug="su-slash")
+        raw_key, _ = make_agent_key(db_session, share)
+        resp = client.post(
+            f"{BASE}/{share.id}/sync-upload?path=/etc/passwd",
+            content=b"data",
+            headers={"X-Agent-Key": raw_key, "Content-Type": "text/plain"},
+        )
+        assert resp.status_code == 400
+
+    def test_large_file_returns_413(
+        self, client: TestClient, test_user: models.User, db_session: Session, web_enabled
+    ):
+        share = make_folder_share(db_session, test_user, slug="su-large")
+        raw_key, _ = make_agent_key(db_session, share)
+        big_body = b"x" * (26 * 1024 * 1024)
+        resp = client.post(
+            f"{BASE}/{share.id}/sync-upload?path=big.bin",
+            content=big_body,
+            headers={"X-Agent-Key": raw_key, "Content-Type": "application/octet-stream"},
+        )
+        assert resp.status_code == 413
+
+    def test_doc_share_returns_400(
+        self, client: TestClient, test_user: models.User, db_session: Session, web_enabled
+    ):
+        doc_share = models.Share(
+            kind=models.ShareKind.DOC,
+            path="note.md",
+            visibility=models.ShareVisibility.PRIVATE,
+            owner_user_id=test_user.id,
+            web_published=False,
+            web_folder_items=None,
+        )
+        db_session.add(doc_share)
+        db_session.commit()
+        raw_key, _ = make_agent_key(db_session, doc_share)
+        resp = client.post(
+            f"{BASE}/{doc_share.id}/sync-upload?path=note.md",
+            content=b"data",
+            headers={"X-Agent-Key": raw_key, "Content-Type": "text/plain"},
+        )
+        assert resp.status_code == 400
+
+    def test_unknown_share_id_returns_404(
+        self, client: TestClient, test_user: models.User, db_session: Session, web_enabled
+    ):
+        import uuid
+
+        resp = client.post(
+            f"{BASE}/{uuid.uuid4()}/sync-upload?path=file.md",
+            content=b"data",
+            headers={"X-Agent-Key": "tr_agent_fake", "Content-Type": "text/plain"},
+        )
+        assert resp.status_code in (401, 404)
+
+    def test_slug_rejected_as_share_id(
+        self, client: TestClient, test_user: models.User, db_session: Session, web_enabled
+    ):
+        share = make_folder_share(db_session, test_user, slug="su-slug-only")
+        raw_key, _ = make_agent_key(db_session, share)
+        resp = client.post(
+            f"{BASE}/su-slug-only/sync-upload?path=file.md",
+            content=b"data",
+            headers={"X-Agent-Key": raw_key, "Content-Type": "text/plain"},
+        )
+        assert resp.status_code == 404
+
+    def test_disabled_web_publish_returns_404(
+        self, client: TestClient, test_user: models.User, db_session: Session
+    ):
+        share = make_folder_share(db_session, test_user, slug="su-disabled")
+        raw_key, _ = make_agent_key(db_session, share)
+        resp = client.post(
+            f"{BASE}/{share.id}/sync-upload?path=file.md",
+            content=b"data",
+            headers={"X-Agent-Key": raw_key, "Content-Type": "text/plain"},
+        )
+        assert resp.status_code == 404


### PR DESCRIPTION
## Summary

- Adds `POST /v1/web/shares/{share_id}/sync-upload` endpoint for writing files into a folder-share sync store
- Implements ADR-0045 Approach C (CP as CAS-client): stores file content in MinIO under `sync-uploads/{share_id}/{sha256}`, upserts `web_folder_items` with `source=sync-artifact`, bumps `web_content_updated_at` for plugin discovery
- Returns `{ sync_url, web_url, path }` — `sync_url` is the relay WebSocket base URL for the share

## Key design decisions (from spike Q1/Q2/Q3)

- **Share resolution**: UUID-only (no slug fallback) — sync endpoint is for private authenticated writes, not web-published slug access
- **CAS key format**: `sync-uploads/{share_id}/{sha256}` in `MINIO_BUCKET` (prod: bucket `relay`, same bucket as relay-server) — avoids collision with `{uuid}/data.ysweet` and `web-assets/*`
- **sync_url**: `{relay_public_url}/{share_id}` — relay WebSocket URL for the folder share; s3 plugin task will use this to sync and discover new `web_folder_items` entries
- **Relay-server HTTP**: probed internal `http://172.18.0.2:8080` — all non-WebSocket paths return 404; CWT tokens not accepted for HTTP endpoints (comment confirmed in BackgroundSync.ts). Direct MinIO write is functionally equivalent since CP and relay-server share the same bucket

## Auth

Two-step agent-key lookup identical to `upload_mesh_artifact`: unknown key → 401, key-for-wrong-share → 403, revoked/expired/read-only → 403.

## Tests

21 tests in `tests/test_sync_upload.py`:
- Happy path: response shape, sync_url/web_url construction
- source=sync-artifact in web_folder_items, SHA256 correctness
- CAS key format, idempotent upsert, bump timestamps
- Auth: 401/403 for all failure modes
- Validation: path traversal, leading slash, 25MB cap, doc-share, slug-as-id rejected

## Test plan

- [x] `uv run pytest tests/test_sync_upload.py` → 21 passed
- [x] Full suite `uv run pytest` → 402 passed, 1 skipped