### PR TITLE
feat(web): Bearer JWT auth for /files-index and /download endpoints [s1]

### DIFF
--- a/apps/control-plane/app/api/routers/web.py
+++ b/apps/control-plane/app/api/routers/web.py
@@ -1324,7 +1324,7 @@ def _resolve_share_for_agent(share_identifier: str, db: Session) -> models.Share
     if share.kind != models.ShareKind.FOLDER:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Agent-key operations only supported for folder shares",
+            detail="This endpoint only supports folder shares",
         )
     return share
 
@@ -1376,6 +1376,95 @@ def _auth_agent_key(
             detail=f"Agent key does not have {required_scope} scope",
         )
     return agent_key
+
+
+def _auth_share_read_access(share: models.Share, request: Request, db: Session) -> str:
+    """Authenticate a read request for a folder share via X-Agent-Key or Bearer JWT.
+
+    Returns 'agent_key' or 'bearer' indicating which credential succeeded.
+    For agent-key auth, updates last_used_at on the key row (caller must db.commit()).
+    Raises HTTPException 401/403 if no valid credential is present.
+    """
+    import hashlib as _hl
+    from datetime import timezone as _tz
+
+    # --- Agent-key path (takes priority if header present) ---
+    raw_key = request.headers.get("X-Agent-Key")
+    if raw_key:
+        key_hash = _hl.sha256(raw_key.encode()).hexdigest()
+        agent_key = db.execute(
+            select(models.ShareAgentKey).where(models.ShareAgentKey.key_hash == key_hash)
+        ).scalar_one_or_none()
+        if agent_key is None:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid agent key")
+        if agent_key.share_id != share.id:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN, detail="Agent key not valid for this share"
+            )
+        if agent_key.revoked_at is not None:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN, detail="Agent key has been revoked"
+            )
+        if agent_key.expires_at is not None:
+            exp = agent_key.expires_at
+            if exp.tzinfo is None:
+                exp = exp.replace(tzinfo=_tz.utc)
+            if exp < security.utcnow():
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN, detail="Agent key has expired"
+                )
+        if "read" not in set(agent_key.scopes.split(",")):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Agent key does not have read scope",
+            )
+        agent_key.last_used_at = security.utcnow()
+        return "agent_key"
+
+    # --- Bearer JWT path ---
+    auth_header = request.headers.get("Authorization")
+    if auth_header and auth_header.startswith("Bearer "):
+        token = auth_header[7:]
+        try:
+            payload = security.decode_access_token(token)
+            user_id_str = payload.get("sub")
+            if not user_id_str:
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token"
+                )
+            user_id = UUID(user_id_str)
+            user = db.execute(
+                select(models.User).where(models.User.id == user_id)
+            ).scalar_one_or_none()
+            if not user or not user.is_active:
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found or inactive"
+                )
+            if share.owner_user_id == user_id:
+                return "bearer"
+            member = db.execute(
+                select(models.ShareMember).where(
+                    models.ShareMember.share_id == share.id,
+                    models.ShareMember.user_id == user_id,
+                )
+            ).scalar_one_or_none()
+            if member is not None:
+                return "bearer"
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN, detail="Access denied to this share"
+            )
+        except HTTPException:
+            raise
+        except Exception:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token"
+            )
+
+    raise HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Authentication required: provide X-Agent-Key header or Authorization: Bearer <token>",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
 
 
 @router.post("/shares/{share_id}/sync-upload", status_code=status.HTTP_200_OK)
@@ -1548,12 +1637,13 @@ def list_mesh_files(
     db: Session = Depends(get_db),
 ) -> dict:
     """
-    List files in a folder share using agent-key auth.
+    List files in a folder share.
 
     Returns the share's file index: mapping path → {type, mime, size, modified_at, source}.
     Content is never included; use /download to fetch individual file content.
 
-    Auth: X-Agent-Key header.
+    Auth: X-Agent-Key header (returns all items) or Authorization: Bearer JWT (returns
+    sync-artifact items only — for plugin inbound sync).
     share_identifier: folder UUID (private/sync shares) or web_slug (web-published only).
     """
     settings = get_settings()
@@ -1564,9 +1654,12 @@ def list_mesh_files(
         )
 
     share = _resolve_share_for_agent(share_identifier, db)
-    agent_key = _auth_agent_key(share, request, db, required_scope="read")
+    auth_method = _auth_share_read_access(share, request, db)
 
     folder_items = share.web_folder_items or []
+    if auth_method == "bearer":
+        folder_items = [item for item in folder_items if item.get("type") == "sync-artifact"]
+
     files = {
         item["path"]: {
             "type": item.get("type", "doc"),
@@ -1579,7 +1672,6 @@ def list_mesh_files(
         if item.get("path")
     }
 
-    agent_key.last_used_at = security.utcnow()
     db.commit()
 
     return {"share_id": str(share.id), "files": files}
@@ -1593,11 +1685,11 @@ def download_mesh_artifact(
     db: Session = Depends(get_db),
 ) -> Response:
     """
-    Download a file artifact from a folder share using agent-key auth.
+    Download a file artifact from a folder share.
 
     Resolution order: inline content in JSONB index → MinIO storage.
 
-    Auth: X-Agent-Key header.
+    Auth: X-Agent-Key header or Authorization: Bearer JWT.
     share_identifier: folder UUID (private/sync shares) or web_slug (web-published only).
     """
     settings = get_settings()
@@ -1610,7 +1702,7 @@ def download_mesh_artifact(
     _validate_upload_path(path)
 
     share = _resolve_share_for_agent(share_identifier, db)
-    agent_key = _auth_agent_key(share, request, db, required_scope="read")
+    _auth_share_read_access(share, request, db)
 
     folder_items = share.web_folder_items or []
     for item in folder_items:
@@ -1623,7 +1715,6 @@ def download_mesh_artifact(
             content_bytes = (
                 content_str.encode("utf-8") if isinstance(content_str, str) else content_str
             )
-            agent_key.last_used_at = security.utcnow()
             db.commit()
             return Response(content=content_bytes, media_type=mime)
 
@@ -1647,7 +1738,6 @@ def download_mesh_artifact(
                     detail=f"Failed to retrieve file: {e}",
                 )
             mime = item.get("mime", "application/octet-stream")
-            agent_key.last_used_at = security.utcnow()
             db.commit()
             return Response(content=data, media_type=mime)
 

--- a/apps/control-plane/tests/test_bearer_download_auth.py
+++ b/apps/control-plane/tests/test_bearer_download_auth.py
@@ -1,0 +1,306 @@
+"""Tests for Bearer JWT auth on /files-index and /download endpoints (s1).
+
+These endpoints previously required X-Agent-Key. After s1 they accept either
+X-Agent-Key or Authorization: Bearer JWT (owner or share member).
+
+Bearer /files-index returns only sync-artifact items (plugin inbound sync).
+Bearer /download returns any file the share contains.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import secrets
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.db import models
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+def login(client: TestClient, email: str, password: str) -> str:
+    r = client.post("/auth/login", json={"email": email, "password": password})
+    assert r.status_code == 200, r.text
+    return r.json()["access_token"]
+
+
+def bearer(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def make_folder_share(
+    db: Session,
+    user: models.User,
+    slug: str = "bearer-test-share",
+    items: list[dict] | None = None,
+) -> models.Share:
+    share = models.Share(
+        kind=models.ShareKind.FOLDER,
+        path="BearerTest/",
+        visibility=models.ShareVisibility.PRIVATE,
+        owner_user_id=user.id,
+        web_published=True,
+        web_slug=slug,
+        web_folder_items=items or [],
+    )
+    db.add(share)
+    db.commit()
+    db.refresh(share)
+    return share
+
+
+def make_agent_key(db: Session, share: models.Share, scopes: str = "read") -> str:
+    raw = "tr_agent_" + secrets.token_hex(24)
+    key_hash = hashlib.sha256(raw.encode()).hexdigest()
+    ak = models.ShareAgentKey(
+        share_id=share.id, key_hash=key_hash, label="test-key", scopes=scopes
+    )
+    db.add(ak)
+    db.commit()
+    return raw
+
+
+def add_member(db: Session, share: models.Share, user: models.User) -> None:
+    member = models.ShareMember(
+        share_id=share.id,
+        user_id=user.id,
+        role=models.ShareMemberRole.VIEWER,
+    )
+    db.add(member)
+    db.commit()
+
+
+MIXED_ITEMS = [
+    {"path": "artifact.md", "type": "sync-artifact", "content": "artifact content", "mime": "text/markdown"},
+    {"path": "vault-doc.md", "type": "doc", "content": "vault doc", "mime": "text/markdown"},
+    {"path": "another-artifact.txt", "type": "sync-artifact", "content": "other artifact", "mime": "text/plain"},
+]
+
+
+# ── fixture ───────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def web_enabled(monkeypatch):
+    monkeypatch.setenv("WEB_PUBLISH_DOMAIN", "docs.test.com")
+    from app.core.config import get_settings
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture
+def second_user(db_session: Session) -> models.User:
+    from app.core import security as sec
+    user = models.User(
+        email="member@example.com",
+        password_hash=sec.get_password_hash("test123456"),
+        is_admin=False,
+        is_active=True,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+@pytest.fixture
+def stranger_user(db_session: Session) -> models.User:
+    from app.core import security as sec
+    user = models.User(
+        email="stranger@example.com",
+        password_hash=sec.get_password_hash("test123456"),
+        is_admin=False,
+        is_active=True,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+# ── /files-index Bearer auth ──────────────────────────────────────────────────
+
+
+class TestFilesIndexBearerAuth:
+    """Bearer JWT auth on GET /v1/web/shares/{id}/files-index."""
+
+    def test_no_auth_returns_401(
+        self, client: TestClient, db_session: Session, test_user: models.User, web_enabled
+    ):
+        share = make_folder_share(db_session, test_user, slug="fi-no-auth", items=MIXED_ITEMS)
+        r = client.get(f"/v1/web/shares/{share.web_slug}/files-index")
+        assert r.status_code == 401
+
+    def test_bearer_owner_returns_200_and_filters_sync_artifacts(
+        self, client: TestClient, db_session: Session, test_user: models.User, web_enabled
+    ):
+        share = make_folder_share(db_session, test_user, slug="fi-owner", items=MIXED_ITEMS)
+        token = login(client, test_user.email, "test123456")
+        r = client.get(f"/v1/web/shares/{share.web_slug}/files-index", headers=bearer(token))
+        assert r.status_code == 200, r.text
+        files = r.json()["files"]
+        assert "artifact.md" in files
+        assert "another-artifact.txt" in files
+        assert "vault-doc.md" not in files, "Bearer path must filter to sync-artifact only"
+
+    def test_bearer_member_returns_200(
+        self,
+        client: TestClient,
+        db_session: Session,
+        test_user: models.User,
+        second_user: models.User,
+        web_enabled,
+    ):
+        share = make_folder_share(db_session, test_user, slug="fi-member", items=MIXED_ITEMS)
+        add_member(db_session, share, second_user)
+        token = login(client, second_user.email, "test123456")
+        r = client.get(f"/v1/web/shares/{share.web_slug}/files-index", headers=bearer(token))
+        assert r.status_code == 200, r.text
+        files = r.json()["files"]
+        assert "artifact.md" in files
+
+    def test_bearer_stranger_returns_403(
+        self,
+        client: TestClient,
+        db_session: Session,
+        test_user: models.User,
+        stranger_user: models.User,
+        web_enabled,
+    ):
+        share = make_folder_share(db_session, test_user, slug="fi-stranger", items=MIXED_ITEMS)
+        token = login(client, stranger_user.email, "test123456")
+        r = client.get(f"/v1/web/shares/{share.web_slug}/files-index", headers=bearer(token))
+        assert r.status_code == 403
+
+    def test_agent_key_still_returns_all_items(
+        self, client: TestClient, db_session: Session, test_user: models.User, web_enabled
+    ):
+        """Regression: existing X-Agent-Key auth still works and returns all items."""
+        share = make_folder_share(db_session, test_user, slug="fi-agentkey", items=MIXED_ITEMS)
+        raw_key = make_agent_key(db_session, share, scopes="read")
+        r = client.get(
+            f"/v1/web/shares/{share.web_slug}/files-index",
+            headers={"X-Agent-Key": raw_key},
+        )
+        assert r.status_code == 200, r.text
+        files = r.json()["files"]
+        assert "artifact.md" in files
+        assert "vault-doc.md" in files, "Agent-key path must return all items (no filtering)"
+
+    def test_invalid_bearer_returns_401(
+        self, client: TestClient, db_session: Session, test_user: models.User, web_enabled
+    ):
+        share = make_folder_share(db_session, test_user, slug="fi-bad-token")
+        r = client.get(
+            f"/v1/web/shares/{share.web_slug}/files-index",
+            headers={"Authorization": "Bearer totallywrong"},
+        )
+        assert r.status_code == 401
+
+    def test_share_id_uuid_works_for_bearer(
+        self, client: TestClient, db_session: Session, test_user: models.User, web_enabled
+    ):
+        """Bearer auth also works when addressing share by UUID (not slug)."""
+        share = make_folder_share(db_session, test_user, slug="fi-uuid", items=MIXED_ITEMS)
+        token = login(client, test_user.email, "test123456")
+        r = client.get(f"/v1/web/shares/{share.id}/files-index", headers=bearer(token))
+        assert r.status_code == 200, r.text
+
+
+# ── /download Bearer auth ─────────────────────────────────────────────────────
+
+
+class TestDownloadBearerAuth:
+    """Bearer JWT auth on GET /v1/web/shares/{id}/download."""
+
+    ITEMS = [
+        {"path": "file.md", "type": "sync-artifact", "content": "hello world", "mime": "text/markdown"},
+    ]
+
+    def test_no_auth_returns_401(
+        self, client: TestClient, db_session: Session, test_user: models.User, web_enabled
+    ):
+        share = make_folder_share(db_session, test_user, slug="dl-no-auth", items=self.ITEMS)
+        r = client.get(f"/v1/web/shares/{share.web_slug}/download?path=file.md")
+        assert r.status_code == 401
+
+    def test_bearer_owner_returns_file(
+        self, client: TestClient, db_session: Session, test_user: models.User, web_enabled
+    ):
+        share = make_folder_share(db_session, test_user, slug="dl-owner", items=self.ITEMS)
+        token = login(client, test_user.email, "test123456")
+        r = client.get(
+            f"/v1/web/shares/{share.web_slug}/download?path=file.md", headers=bearer(token)
+        )
+        assert r.status_code == 200, r.text
+        assert b"hello world" in r.content
+
+    def test_bearer_member_returns_file(
+        self,
+        client: TestClient,
+        db_session: Session,
+        test_user: models.User,
+        second_user: models.User,
+        web_enabled,
+    ):
+        share = make_folder_share(db_session, test_user, slug="dl-member", items=self.ITEMS)
+        add_member(db_session, share, second_user)
+        token = login(client, second_user.email, "test123456")
+        r = client.get(
+            f"/v1/web/shares/{share.web_slug}/download?path=file.md", headers=bearer(token)
+        )
+        assert r.status_code == 200, r.text
+
+    def test_bearer_stranger_returns_403(
+        self,
+        client: TestClient,
+        db_session: Session,
+        test_user: models.User,
+        stranger_user: models.User,
+        web_enabled,
+    ):
+        share = make_folder_share(db_session, test_user, slug="dl-stranger", items=self.ITEMS)
+        token = login(client, stranger_user.email, "test123456")
+        r = client.get(
+            f"/v1/web/shares/{share.web_slug}/download?path=file.md", headers=bearer(token)
+        )
+        assert r.status_code == 403
+
+    def test_bearer_file_not_found_returns_404(
+        self, client: TestClient, db_session: Session, test_user: models.User, web_enabled
+    ):
+        share = make_folder_share(db_session, test_user, slug="dl-missing", items=self.ITEMS)
+        token = login(client, test_user.email, "test123456")
+        r = client.get(
+            f"/v1/web/shares/{share.web_slug}/download?path=nonexistent.md",
+            headers=bearer(token),
+        )
+        assert r.status_code == 404
+
+    def test_agent_key_still_works_for_download(
+        self, client: TestClient, db_session: Session, test_user: models.User, web_enabled
+    ):
+        """Regression: existing X-Agent-Key download still works."""
+        share = make_folder_share(db_session, test_user, slug="dl-agentkey", items=self.ITEMS)
+        raw_key = make_agent_key(db_session, share, scopes="read")
+        r = client.get(
+            f"/v1/web/shares/{share.web_slug}/download?path=file.md",
+            headers={"X-Agent-Key": raw_key},
+        )
+        assert r.status_code == 200, r.text
+        assert b"hello world" in r.content
+
+    def test_invalid_bearer_returns_401(
+        self, client: TestClient, db_session: Session, test_user: models.User, web_enabled
+    ):
+        share = make_folder_share(db_session, test_user, slug="dl-bad-token", items=self.ITEMS)
+        r = client.get(
+            f"/v1/web/shares/{share.web_slug}/download?path=file.md",
+            headers={"Authorization": "Bearer bad.token.here"},
+        )
+        assert r.status_code == 401


### PR DESCRIPTION
## Summary

- Adds `_auth_share_read_access()` helper that accepts **either X-Agent-Key or Authorization: Bearer JWT** (owner or share member) for read access
- `GET /v1/web/shares/{id}/files-index` — Bearer path filters to `sync-artifact` items only (plugin inbound sync); agent-key path returns all items (backward compat)
- `GET /v1/web/shares/{id}/download` — both auth methods serve the same content
- Existing X-Agent-Key callers are fully unaffected
- Updated `_resolve_share_for_agent` error message to remove agent-key-specific wording

## Motivation

The Obsidian plugin uses Bearer JWT for all `/v1/shares/*` API calls and has no agent-key management. Adding per-share agent-key handling to the plugin would require new credential storage, UI, and key rotation logic. Bearer auth already proves share ownership semantically. Decision recorded in task b9f7ece1.

## Test plan

- [x] 14 new tests in `test_bearer_download_auth.py` covering owner, member, stranger, invalid-token, and agent-key regression cases
- [x] Existing `TestAgentKeyReadScope` (6 tests) pass unchanged — agent-key path unaffected
- [x] `pytest tests/test_bearer_download_auth.py` → 14 passed
- [x] `pytest tests/test_mesh_upload.py -k "files_index or download"` → 6 passed