### PR TITLE
fix(shares): inbound sync server endpoints + web_content_updated_at in ShareRead

### DIFF
--- a/apps/control-plane/app/api/routers/shares.py
+++ b/apps/control-plane/app/api/routers/shares.py
@@ -2,12 +2,16 @@ from __future__ import annotations
 
 import uuid
 
-from fastapi import APIRouter, Depends, Query, Request, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
+from minio import Minio
+from minio.error import S3Error
+from pydantic import BaseModel
 from slowapi import Limiter
 from slowapi.util import get_remote_address
 from sqlalchemy.orm import Session
 
 from app.api import deps
+from app.core.config import get_settings
 from app.db import models
 from app.db.session import get_db
 from app.schemas import share as share_schema
@@ -92,6 +96,116 @@ def read_share(
     response = share_schema.ShareRead.model_validate(share)
     response.web_url = share_service.get_web_url(share)
     return response
+
+
+class SyncArtifactItem(BaseModel):
+    path: str
+    sha256: str
+    size: int
+    updated_at: str
+    type: str = "sync-artifact"
+
+
+def _get_minio_client() -> Minio:
+    settings = get_settings()
+    return Minio(
+        settings.minio_endpoint,
+        access_key=settings.minio_access_key,
+        secret_key=settings.minio_secret_key,
+        secure=settings.minio_secure,
+    )
+
+
+@router.get("/{share_id}/files-index", response_model=list[SyncArtifactItem])
+def get_share_files_index(
+    share_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(deps.get_current_user),
+) -> list[SyncArtifactItem]:
+    """
+    List sync-artifact files for a share (plugin inbound sync, Bearer JWT).
+
+    Returns only items uploaded via sync-upload (source=sync-artifact) in
+    SyncArtifactItem format expected by the Obsidian plugin InboundFileDownloader.
+    """
+    share = share_service.get_share(db, share_id)
+    share_service.ensure_read_access(db, share, current_user)
+
+    folder_items = share.web_folder_items or []
+    result = []
+    for item in folder_items:
+        if item.get("source") != "sync-artifact":
+            continue
+        sha256 = item.get("sha256")
+        if not sha256:
+            continue
+        result.append(
+            SyncArtifactItem(
+                path=item["path"],
+                sha256=sha256,
+                size=item.get("size", 0),
+                updated_at=item.get("modified_at", ""),
+            )
+        )
+    return result
+
+
+@router.get("/{share_id}/download")
+def download_share_file(
+    share_id: uuid.UUID,
+    path: str = Query(..., description="Relative file path within share"),
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(deps.get_current_user),
+) -> Response:
+    """
+    Download a sync-artifact file by relative path (plugin inbound sync, Bearer JWT).
+
+    Resolution order: inline content in JSONB index → MinIO storage.
+    """
+    share = share_service.get_share(db, share_id)
+    share_service.ensure_read_access(db, share, current_user)
+
+    folder_items = share.web_folder_items or []
+    for item in folder_items:
+        if item.get("path") != path:
+            continue
+
+        content_str = item.get("content")
+        if content_str is not None:
+            mime = item.get("mime", "text/plain; charset=utf-8")
+            content_bytes = (
+                content_str.encode("utf-8") if isinstance(content_str, str) else content_str
+            )
+            return Response(content=content_bytes, media_type=mime)
+
+        storage_key = item.get("storage_key")
+        if storage_key:
+            settings = get_settings()
+            minio_client = _get_minio_client()
+            try:
+                resp = minio_client.get_object(settings.minio_bucket, storage_key)
+                try:
+                    data = resp.read()
+                finally:
+                    resp.close()
+                    resp.release_conn()
+            except S3Error as e:
+                if e.code == "NoSuchKey":
+                    raise HTTPException(
+                        status_code=status.HTTP_404_NOT_FOUND,
+                        detail="File not found in storage",
+                    )
+                raise HTTPException(
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    detail=f"Failed to retrieve file: {e}",
+                )
+            mime = item.get("mime", "application/octet-stream")
+            return Response(content=data, media_type=mime)
+
+    raise HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND,
+        detail=f"File not found: {path}",
+    )
 
 
 @router.patch("/{share_id}", response_model=share_schema.ShareRead)

--- a/apps/control-plane/app/schemas/share.py
+++ b/apps/control-plane/app/schemas/share.py
@@ -80,6 +80,7 @@ class ShareRead(BaseModel):
     web_sync_mode: str
     web_url: str | None = None  # Computed field, set by service
     web_doc_id: str | None = None  # Y-sweet document ID for real-time sync
+    web_content_updated_at: datetime | None = None
 
     model_config = {"from_attributes": True}
 

--- a/apps/control-plane/tests/test_inbound_sync.py
+++ b/apps/control-plane/tests/test_inbound_sync.py
@@ -1,0 +1,348 @@
+"""Tests for inbound sync endpoints: GET /shares/{id}/files-index and /download.
+
+These endpoints are the plugin-facing (Bearer JWT) counterparts to the agent-key
+files-index/download on the /v1/web/ router. They fix Bug 1/Bug 2/Bug 3 from
+the s5 E2E regression (task 64bc925e).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.db import models
+
+
+def login(client: TestClient, email: str, password: str) -> str:
+    response = client.post("/auth/login", json={"email": email, "password": password})
+    assert response.status_code == 200, response.text
+    return response.json()["access_token"]
+
+
+def auth_headers(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def make_folder_share(
+    db: Session,
+    user: models.User,
+    visibility: models.ShareVisibility = models.ShareVisibility.PRIVATE,
+    folder_items: list | None = None,
+) -> models.Share:
+    share = models.Share(
+        kind=models.ShareKind.FOLDER,
+        path="InboundFolder/",
+        visibility=visibility,
+        owner_user_id=user.id,
+        web_published=True,
+        web_slug=f"ib-{uuid.uuid4().hex[:8]}",
+        web_folder_items=folder_items or [],
+        web_content_updated_at=datetime(2026, 6, 7, 23, 0, 0, tzinfo=timezone.utc),
+    )
+    db.add(share)
+    db.commit()
+    db.refresh(share)
+    return share
+
+
+def sync_artifact_item(
+    path: str = "notes/hello.md",
+    sha256: str = "abc123",
+    size: int = 100,
+    content: str = "# Hello",
+) -> dict:
+    return {
+        "path": path,
+        "name": path.split("/")[-1],
+        "type": "doc",
+        "source": "sync-artifact",
+        "mime": "text/markdown",
+        "size": size,
+        "sha256": sha256,
+        "modified_at": "2026-06-07T23:00:00+00:00",
+        "storage_key": f"sync-uploads/fakeshare/{sha256}",
+        "content": content,
+    }
+
+
+def mesh_artifact_item(path: str = "agent/report.md") -> dict:
+    return {
+        "path": path,
+        "name": path.split("/")[-1],
+        "type": "doc",
+        "source": "mesh-artifact",
+        "mime": "text/markdown",
+        "size": 50,
+        "modified_at": "2026-06-07T22:00:00+00:00",
+        "storage_key": "web-assets/fakeshare/report.md",
+        "content": "# Agent report",
+    }
+
+
+# ── GET /shares/{id}/files-index ─────────────────────────────────────────────
+
+
+class TestFilesIndexEndpoint:
+    def test_owner_gets_sync_artifact_items(
+        self, client: TestClient, test_user: models.User, db_session: Session
+    ):
+        item = sync_artifact_item()
+        share = make_folder_share(db_session, test_user, folder_items=[item])
+        token = login(client, "testuser@example.com", "test123456")
+
+        resp = client.get(f"/v1/shares/{share.id}/files-index", headers=auth_headers(token))
+
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert isinstance(data, list)
+        assert len(data) == 1
+        assert data[0]["path"] == "notes/hello.md"
+        assert data[0]["sha256"] == "abc123"
+        assert data[0]["size"] == 100
+        assert data[0]["updated_at"] == "2026-06-07T23:00:00+00:00"
+        assert data[0]["type"] == "sync-artifact"
+
+    def test_only_sync_artifacts_returned_not_mesh_artifacts(
+        self, client: TestClient, test_user: models.User, db_session: Session
+    ):
+        items = [sync_artifact_item(), mesh_artifact_item()]
+        share = make_folder_share(db_session, test_user, folder_items=items)
+        token = login(client, "testuser@example.com", "test123456")
+
+        resp = client.get(f"/v1/shares/{share.id}/files-index", headers=auth_headers(token))
+
+        assert resp.status_code == 200, resp.text
+        paths = [i["path"] for i in resp.json()]
+        assert "notes/hello.md" in paths
+        assert "agent/report.md" not in paths
+
+    def test_items_without_sha256_excluded(
+        self, client: TestClient, test_user: models.User, db_session: Session
+    ):
+        no_hash = {
+            "path": "old.md",
+            "name": "old.md",
+            "type": "doc",
+            "source": "sync-artifact",
+            "size": 10,
+            "modified_at": "2026-06-07T00:00:00+00:00",
+        }
+        share = make_folder_share(db_session, test_user, folder_items=[no_hash])
+        token = login(client, "testuser@example.com", "test123456")
+
+        resp = client.get(f"/v1/shares/{share.id}/files-index", headers=auth_headers(token))
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json() == []
+
+    def test_empty_share_returns_empty_list(
+        self, client: TestClient, test_user: models.User, db_session: Session
+    ):
+        share = make_folder_share(db_session, test_user, folder_items=[])
+        token = login(client, "testuser@example.com", "test123456")
+
+        resp = client.get(f"/v1/shares/{share.id}/files-index", headers=auth_headers(token))
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json() == []
+
+    def test_unauthenticated_returns_401(
+        self, client: TestClient, test_user: models.User, db_session: Session
+    ):
+        share = make_folder_share(db_session, test_user)
+
+        resp = client.get(f"/v1/shares/{share.id}/files-index")
+
+        assert resp.status_code == 401
+
+    def test_non_member_on_private_share_returns_403(
+        self, client: TestClient, test_user: models.User, db_session: Session
+    ):
+        from app.core import security as sec
+
+        share = make_folder_share(db_session, test_user, folder_items=[sync_artifact_item()])
+
+        other = models.User(
+            email="other@example.com",
+            password_hash=sec.get_password_hash("pass123456"),
+            is_active=True,
+        )
+        db_session.add(other)
+        db_session.commit()
+
+        token = login(client, "other@example.com", "pass123456")
+        resp = client.get(f"/v1/shares/{share.id}/files-index", headers=auth_headers(token))
+
+        assert resp.status_code == 403
+
+    def test_member_can_read_files_index(
+        self, client: TestClient, test_user: models.User, db_session: Session
+    ):
+        from app.core import security as sec
+
+        share = make_folder_share(db_session, test_user, folder_items=[sync_artifact_item()])
+
+        member_user = models.User(
+            email="member@example.com",
+            password_hash=sec.get_password_hash("pass123456"),
+            is_active=True,
+        )
+        db_session.add(member_user)
+        db_session.commit()
+        db_session.refresh(member_user)
+
+        db_session.add(
+            models.ShareMember(
+                share_id=share.id,
+                user_id=member_user.id,
+                role=models.ShareMemberRole.VIEWER,
+            )
+        )
+        db_session.commit()
+
+        token = login(client, "member@example.com", "pass123456")
+        resp = client.get(f"/v1/shares/{share.id}/files-index", headers=auth_headers(token))
+
+        assert resp.status_code == 200, resp.text
+        assert len(resp.json()) == 1
+
+    def test_legacy_path_without_v1_works(
+        self, client: TestClient, test_user: models.User, db_session: Session
+    ):
+        share = make_folder_share(db_session, test_user, folder_items=[sync_artifact_item()])
+        token = login(client, "testuser@example.com", "test123456")
+
+        resp = client.get(f"/shares/{share.id}/files-index", headers=auth_headers(token))
+
+        assert resp.status_code == 200, resp.text
+
+    def test_unknown_share_returns_404(
+        self, client: TestClient, test_user: models.User, db_session: Session
+    ):
+        token = login(client, "testuser@example.com", "test123456")
+
+        resp = client.get(f"/v1/shares/{uuid.uuid4()}/files-index", headers=auth_headers(token))
+
+        assert resp.status_code == 404
+
+
+# ── GET /shares/{id}/download ─────────────────────────────────────────────────
+
+
+class TestDownloadEndpoint:
+    def test_owner_can_download_inline_content(
+        self, client: TestClient, test_user: models.User, db_session: Session
+    ):
+        item = sync_artifact_item(path="notes/hello.md", content="# Hello world")
+        share = make_folder_share(db_session, test_user, folder_items=[item])
+        token = login(client, "testuser@example.com", "test123456")
+
+        resp = client.get(
+            f"/v1/shares/{share.id}/download?path=notes/hello.md",
+            headers=auth_headers(token),
+        )
+
+        assert resp.status_code == 200, resp.text
+        assert b"# Hello world" in resp.content
+
+    def test_file_not_found_returns_404(
+        self, client: TestClient, test_user: models.User, db_session: Session
+    ):
+        share = make_folder_share(db_session, test_user, folder_items=[sync_artifact_item()])
+        token = login(client, "testuser@example.com", "test123456")
+
+        resp = client.get(
+            f"/v1/shares/{share.id}/download?path=nonexistent.md",
+            headers=auth_headers(token),
+        )
+
+        assert resp.status_code == 404
+
+    def test_unauthenticated_returns_401(
+        self, client: TestClient, test_user: models.User, db_session: Session
+    ):
+        share = make_folder_share(db_session, test_user, folder_items=[sync_artifact_item()])
+
+        resp = client.get(f"/v1/shares/{share.id}/download?path=notes/hello.md")
+
+        assert resp.status_code == 401
+
+    def test_non_member_on_private_share_returns_403(
+        self, client: TestClient, test_user: models.User, db_session: Session
+    ):
+        from app.core import security as sec
+
+        share = make_folder_share(db_session, test_user, folder_items=[sync_artifact_item()])
+
+        other = models.User(
+            email="other2@example.com",
+            password_hash=sec.get_password_hash("pass123456"),
+            is_active=True,
+        )
+        db_session.add(other)
+        db_session.commit()
+
+        token = login(client, "other2@example.com", "pass123456")
+        resp = client.get(
+            f"/v1/shares/{share.id}/download?path=notes/hello.md",
+            headers=auth_headers(token),
+        )
+
+        assert resp.status_code == 403
+
+    def test_legacy_path_without_v1_works(
+        self, client: TestClient, test_user: models.User, db_session: Session
+    ):
+        item = sync_artifact_item(path="doc.md", content="data")
+        share = make_folder_share(db_session, test_user, folder_items=[item])
+        token = login(client, "testuser@example.com", "test123456")
+
+        resp = client.get(
+            f"/shares/{share.id}/download?path=doc.md",
+            headers=auth_headers(token),
+        )
+
+        assert resp.status_code == 200, resp.text
+
+
+# ── Bug 2: web_content_updated_at in ShareRead ────────────────────────────────
+
+
+class TestShareReadIncludesWebContentUpdatedAt:
+    def test_share_detail_includes_web_content_updated_at(
+        self, client: TestClient, test_user: models.User, db_session: Session
+    ):
+        share = make_folder_share(db_session, test_user)
+        token = login(client, "testuser@example.com", "test123456")
+
+        resp = client.get(f"/v1/shares/{share.id}", headers=auth_headers(token))
+
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert "web_content_updated_at" in data
+        assert data["web_content_updated_at"] is not None
+
+    def test_share_detail_web_content_updated_at_none_when_not_bumped(
+        self, client: TestClient, test_user: models.User, db_session: Session
+    ):
+        share = models.Share(
+            kind=models.ShareKind.FOLDER,
+            path="Fresh/",
+            visibility=models.ShareVisibility.PRIVATE,
+            owner_user_id=test_user.id,
+            web_published=False,
+            web_folder_items=[],
+        )
+        db_session.add(share)
+        db_session.commit()
+        db_session.refresh(share)
+
+        token = login(client, "testuser@example.com", "test123456")
+        resp = client.get(f"/v1/shares/{share.id}", headers=auth_headers(token))
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["web_content_updated_at"] is None


### PR DESCRIPTION
## Summary

Fixes 3 server-side bugs blocking AC#4 (inbound vault sync) found during s5 E2E (task 64bc925e). See bug task d1f8a435.

- **Bug 1** — `GET /shares/{id}/files-index` and `GET /shares/{id}/download` added to `shares.py` router (Bearer JWT auth). Plugin calls these paths without `/web/` prefix; the web router endpoint at `/v1/web/shares/{id}/files-index` was unreachable from plugin auth flow.
- **Bug 2** — `web_content_updated_at` added to `ShareRead` schema so `InboundSyncPoller` can read the bump timestamp from `GET /shares/{id}`.
- **Bug 3** — New `files-index` endpoint returns `SyncArtifactItem[]` flat array with `{path, sha256, size, updated_at, type}` filtered to `source=sync-artifact` items only — matches the TypeScript interface in `InboundFileDownloader`.

## Changes

- `app/api/routers/shares.py` — `SyncArtifactItem` schema, `_get_minio_client()` helper, `GET /{share_id}/files-index`, `GET /{share_id}/download`
- `app/schemas/share.py` — `web_content_updated_at: datetime | None = None` added to `ShareRead`
- `tests/test_inbound_sync.py` — 16 new tests (auth, format, filtering, legacy paths)

## Test plan

- [x] `uv run pytest tests/test_inbound_sync.py -v` → 16 passed
- [x] `uv run pytest tests/ --ignore=tests/e2e` → 427 passed, 1 skipped (no regressions)
- [x] `uv run ruff check` → no lint errors