### PR TITLE
[TR] S7: Argus contact dedup + suppression-read integration

### DIFF
--- a/apps/control-plane/app/core/config.py
+++ b/apps/control-plane/app/core/config.py
@@ -161,6 +161,14 @@ class Settings(BaseSettings):
         default=10, description="Max agent key creations per user per hour"
     )
 
+    # Argus CRM integration (S7: contact dedup + cross-product suppression-read)
+    argus_enabled: bool = Field(default=False, description="Enable Argus CRM integration")
+    argus_api_url: str = Field(default="http://argus-api:8000", description="Argus API base URL")
+    argus_timeout_seconds: float = Field(default=5.0, description="Argus API request timeout")
+    argus_service_key: str | None = Field(
+        default=None, description="X-Argus-Service-Key for M2M auth"
+    )
+
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore")
 
 

--- a/apps/control-plane/app/services/argus_service.py
+++ b/apps/control-plane/app/services/argus_service.py
@@ -1,0 +1,99 @@
+"""Argus CRM integration for Team Relay (S7).
+
+Two public functions:
+  register_product_user(email, display_name) — fire-and-forget on TR registration.
+    Upserts the Argus contact and logs an ownership interaction (60d window).
+
+  is_suppressed(email) -> bool — blocking pre-send check in lifecycle worker.
+    Returns True if the contact has a cross-product opt-out (SO-3 rule-5).
+    Fails open on timeout / Argus unavailability (returns False, logs warning).
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+
+import httpx
+
+from app.core.config import get_settings
+
+logger = logging.getLogger(__name__)
+
+_PRODUCT = "team-relay"
+_CHANNEL = "email"
+
+
+def _client() -> httpx.Client:
+    settings = get_settings()
+    headers: dict[str, str] = {}
+    if settings.argus_service_key:
+        headers["X-Argus-Service-Key"] = settings.argus_service_key
+    return httpx.Client(
+        base_url=settings.argus_api_url,
+        headers=headers,
+        timeout=settings.argus_timeout_seconds,
+    )
+
+
+def _register_blocking(email: str, display_name: str) -> None:
+    try:
+        with _client() as client:
+            resp = client.post(
+                "/api/outreach/register_product_user",
+                json={"email": email, "display_name": display_name, "product": _PRODUCT},
+            )
+            if resp.status_code not in (200, 201):
+                logger.warning(
+                    "argus register_product_user failed: %s — %s",
+                    resp.status_code,
+                    resp.text[:200],
+                )
+    except Exception:
+        logger.warning("argus register_product_user error", exc_info=True)
+
+
+def register_product_user(email: str, display_name: str) -> None:
+    """Non-blocking: register TR user in Argus CRM.
+
+    Spawns a daemon thread so registration latency never blocks the HTTP response.
+    Errors are logged but never raised.
+    """
+    settings = get_settings()
+    if not settings.argus_enabled:
+        return
+    threading.Thread(
+        target=_register_blocking,
+        args=(email, display_name),
+        daemon=True,
+        name="argus-register",
+    ).start()
+
+
+def is_suppressed(email: str) -> bool:
+    """Check cross-product hard suppression in Argus (SO-3 rule-5).
+
+    Returns True only when Argus explicitly says suppressed=true.
+    Returns False on timeout, network error, or unknown contact (fail-open).
+    """
+    settings = get_settings()
+    if not settings.argus_enabled:
+        return False
+    try:
+        with _client() as client:
+            resp = client.post(
+                "/api/outreach/suppression_check",
+                json={"email": email},
+            )
+            if resp.status_code == 200:
+                return bool(resp.json().get("suppressed"))
+            logger.warning(
+                "argus suppression_check unexpected status: %s — %s",
+                resp.status_code,
+                resp.text[:200],
+            )
+    except httpx.TimeoutException:
+        logger.warning("argus suppression_check timed out for %s, failing open", email)
+    except Exception:
+        logger.warning("argus suppression_check error", exc_info=True)
+    return False

--- a/apps/control-plane/app/services/lifecycle_service.py
+++ b/apps/control-plane/app/services/lifecycle_service.py
@@ -9,7 +9,8 @@ Idempotency: lifecycle_state table (unique on user_id, trigger_key) prevents dou
 Cap: max LIFECYCLE_CAP total nudges sent per user across all triggers.
 Pre-send: lifecycle_emails preference checked (missing row = ON).
 
-TODO(S7): add Argus suppression check pre-send (fast-follow, hook marked below).
+Argus suppression check (S7): is_suppressed() is called pre-send to enforce
+SO-3 rule-5 cross-product opt-out (opt-out anywhere → stop everywhere).
 """
 
 from __future__ import annotations
@@ -34,6 +35,7 @@ from app.db.models import (
     User,
     UserEmailPreferences,
 )
+from app.services import argus_service
 from app.services.email_service import (
     EMAIL_TYPE_LIFECYCLE_INACTIVE_AFTER_SHARE,
     EMAIL_TYPE_LIFECYCLE_NO_SHARE_24H,
@@ -199,7 +201,8 @@ def process_t1_no_share_24h(db: Session, launch_cutoff: datetime) -> int:
             continue
         if _total_sent_count(db, user.id) >= LIFECYCLE_CAP:
             continue
-        # TODO(S7): check Argus suppression here (fast-follow)
+        if argus_service.is_suppressed(user.email):
+            continue
 
         ctx = _template_context(user)
         html, text = _render_template("lifecycle-no-share-24h", ctx)
@@ -268,7 +271,8 @@ def process_t2_inactive_after_share(db: Session, launch_cutoff: datetime) -> int
             continue
         if _total_sent_count(db, user.id) >= LIFECYCLE_CAP:
             continue
-        # TODO(S7): check Argus suppression here (fast-follow)
+        if argus_service.is_suppressed(user.email):
+            continue
 
         ctx = _template_context(user)
         html, text = _render_template("lifecycle-inactive-after-share", ctx)

--- a/apps/control-plane/app/services/user_service.py
+++ b/apps/control-plane/app/services/user_service.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import Session
 from app.core import security
 from app.db import models
 from app.schemas import user as user_schema
-from app.services import audit_service
+from app.services import argus_service, audit_service
 
 
 def _normalize_email(email: str) -> str:
@@ -48,6 +48,9 @@ def create_user(
         target_user_id=user.id,
         details={"email": user.email, "is_admin": user.is_admin},
     )
+
+    # Register in Argus CRM for cross-product ownership / suppression tracking (S7).
+    argus_service.register_product_user(email=user.email, display_name=user.email.split("@")[0])
 
     return user
 

--- a/apps/control-plane/tests/test_argus_integration.py
+++ b/apps/control-plane/tests/test_argus_integration.py
@@ -1,0 +1,234 @@
+"""Tests for Argus CRM integration — argus_service + lifecycle_service suppression hook.
+
+Unit tests use monkeypatching to avoid real Argus HTTP calls. The argus_service module
+is tested for correct fire-and-forget behavior and fail-open semantics. The lifecycle
+tests verify that suppressed contacts are skipped and unsuppressed ones proceed.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+from app.services import argus_service
+
+# ---------------------------------------------------------------------------
+# argus_service unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestArgusServiceDisabled:
+    """When ARGUS_ENABLED=false (default), all functions are no-ops."""
+
+    def setup_method(self):
+        os.environ["ARGUS_ENABLED"] = "false"
+        from app.core.config import get_settings
+        get_settings.cache_clear()
+
+    def teardown_method(self):
+        os.environ.pop("ARGUS_ENABLED", None)
+        from app.core.config import get_settings
+        get_settings.cache_clear()
+
+    def test_register_product_user_noop(self):
+        """register_product_user returns immediately without spawning a thread."""
+        with patch("threading.Thread") as mock_thread:
+            argus_service.register_product_user("user@example.com", "User")
+            mock_thread.assert_not_called()
+
+    def test_is_suppressed_returns_false(self):
+        """is_suppressed returns False without touching Argus when disabled."""
+        with patch("httpx.Client") as mock_client:
+            result = argus_service.is_suppressed("user@example.com")
+            assert result is False
+            mock_client.assert_not_called()
+
+
+class TestArgusServiceEnabled:
+    """When ARGUS_ENABLED=true, functions hit the configured API."""
+
+    def setup_method(self):
+        os.environ["ARGUS_ENABLED"] = "true"
+        os.environ["ARGUS_API_URL"] = "http://argus-test:8000"
+        os.environ["ARGUS_SERVICE_KEY"] = "test-key"
+        from app.core.config import get_settings
+        get_settings.cache_clear()
+
+    def teardown_method(self):
+        for key in ("ARGUS_ENABLED", "ARGUS_API_URL", "ARGUS_SERVICE_KEY"):
+            os.environ.pop(key, None)
+        from app.core.config import get_settings
+        get_settings.cache_clear()
+
+    def test_is_suppressed_true(self):
+        """is_suppressed returns True when Argus reports suppressed=true."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"suppressed": True, "reason": "opt_out", "person_id": "abc"}
+
+        with patch("httpx.Client") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client_cls.return_value.__enter__.return_value = mock_client
+            mock_client.post.return_value = mock_resp
+
+            result = argus_service.is_suppressed("user@example.com")
+
+        assert result is True
+        mock_client.post.assert_called_once_with(
+            "/api/outreach/suppression_check",
+            json={"email": "user@example.com"},
+        )
+
+    def test_is_suppressed_false(self):
+        """is_suppressed returns False when Argus reports suppressed=false."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"suppressed": False, "reason": None, "person_id": "abc"}
+
+        with patch("httpx.Client") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client_cls.return_value.__enter__.return_value = mock_client
+            mock_client.post.return_value = mock_resp
+
+            result = argus_service.is_suppressed("user@example.com")
+
+        assert result is False
+
+    def test_is_suppressed_fail_open_on_timeout(self):
+        """is_suppressed returns False on Argus timeout (fail-open per SO-3)."""
+        import httpx
+
+        with patch("httpx.Client") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client_cls.return_value.__enter__.return_value = mock_client
+            mock_client.post.side_effect = httpx.TimeoutException("timeout")
+
+            result = argus_service.is_suppressed("user@example.com")
+
+        assert result is False
+
+    def test_is_suppressed_fail_open_on_http_error(self):
+        """is_suppressed returns False when Argus returns non-200 (fail-open)."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 503
+        mock_resp.text = "Service Unavailable"
+
+        with patch("httpx.Client") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client_cls.return_value.__enter__.return_value = mock_client
+            mock_client.post.return_value = mock_resp
+
+            result = argus_service.is_suppressed("user@example.com")
+
+        assert result is False
+
+    def test_register_product_user_spawns_daemon_thread(self):
+        """register_product_user spawns a daemon thread and does not block."""
+        with patch("threading.Thread") as mock_thread_cls:
+            mock_thread = MagicMock()
+            mock_thread_cls.return_value = mock_thread
+            argus_service.register_product_user("new@example.com", "New User")
+            mock_thread_cls.assert_called_once()
+            assert mock_thread_cls.call_args.kwargs.get("daemon") is True
+            mock_thread.start.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# lifecycle_service suppression integration tests
+# ---------------------------------------------------------------------------
+
+
+def _make_user(email: str = "u@example.com"):
+    """Create a minimal User-like object for lifecycle tests."""
+    user = MagicMock()
+    user.id = "11111111-1111-1111-1111-111111111111"
+    user.email = email
+    user.created_at = datetime(2020, 1, 1, tzinfo=timezone.utc)
+    return user
+
+
+class TestLifecycleArgusSuppressionT1:
+    """T1 trigger (no_share_24h) skips suppressed users."""
+
+    def setup_method(self):
+        os.environ["ARGUS_ENABLED"] = "true"
+        os.environ["ARGUS_API_URL"] = "http://argus-test:8000"
+        from app.core.config import get_settings
+        get_settings.cache_clear()
+
+    def teardown_method(self):
+        for key in ("ARGUS_ENABLED", "ARGUS_API_URL"):
+            os.environ.pop(key, None)
+        from app.core.config import get_settings
+        get_settings.cache_clear()
+
+    def test_suppressed_user_skipped(self):
+        """T1: suppressed user → no email queued."""
+        from app.services.lifecycle_service import process_t1_no_share_24h
+
+        db = MagicMock()
+        launch_cutoff = datetime(2019, 1, 1, tzinfo=timezone.utc)
+        user = _make_user("suppressed@example.com")
+
+        with (
+            patch(
+                "app.services.lifecycle_service._already_handled", return_value=False
+            ),
+            patch(
+                "app.services.lifecycle_service._lifecycle_opt_in", return_value=True
+            ),
+            patch(
+                "app.services.lifecycle_service._total_sent_count", return_value=0
+            ),
+            patch(
+                "app.services.argus_service.is_suppressed", return_value=True
+            ),
+            patch("app.services.lifecycle_service.get_email_service") as mock_email,
+        ):
+            # Patch the DB query to return our user
+            db.execute.return_value.scalars.return_value.all.return_value = [user]
+            sent = process_t1_no_share_24h(db, launch_cutoff)
+
+        assert sent == 0
+        # email service's queue_email should NOT have been called
+        mock_email.return_value.queue_email.assert_not_called()
+
+    def test_unsuppressed_user_gets_email(self):
+        """T1: unsuppressed user → email queued (argus returns False)."""
+        from app.services.lifecycle_service import process_t1_no_share_24h
+
+        db = MagicMock()
+        launch_cutoff = datetime(2019, 1, 1, tzinfo=timezone.utc)
+        user = _make_user("active@example.com")
+
+        with (
+            patch(
+                "app.services.lifecycle_service._already_handled", return_value=False
+            ),
+            patch(
+                "app.services.lifecycle_service._lifecycle_opt_in", return_value=True
+            ),
+            patch(
+                "app.services.lifecycle_service._total_sent_count", return_value=0
+            ),
+            patch(
+                "app.services.argus_service.is_suppressed", return_value=False
+            ),
+            patch(
+                "app.services.lifecycle_service._render_template",
+                return_value=("<html>", "text"),
+            ),
+            patch(
+                "app.services.lifecycle_service._template_context", return_value={}
+            ),
+            patch(
+                "app.services.lifecycle_service._mark_sent"
+            ),
+            patch("app.services.lifecycle_service.get_email_service") as mock_email,
+        ):
+            db.execute.return_value.scalars.return_value.all.return_value = [user]
+            sent = process_t1_no_share_24h(db, launch_cutoff)
+
+        assert sent == 1
+        mock_email.return_value.queue_email.assert_called_once()


### PR DESCRIPTION
## Summary

- **On TR registration**: fires a background `register_product_user()` call to Argus CRM, tagging the contact with `product=team-relay`. This establishes 60d ownership so Spark-scouting `can_outreach` gate returns deny during the window (SO-3 #491dffa1).
- **Pre-send in lifecycle worker (T1 + T2)**: calls `is_suppressed(email)` before queuing any nudge — SO-3 rule-5 cross-product opt-out (opt-out anywhere → stop everywhere).
- **Fail-open everywhere**: Argus unavailability never blocks registration or healthy nudge delivery. `ARGUS_ENABLED=false` default — integration is a no-op until Hermes REST endpoints are live and the env var is set.

## Files changed

| File | Change |
|------|--------|
| `app/services/argus_service.py` | **New** — `register_product_user()` (background thread) + `is_suppressed()` (blocking, fail-open) |
| `app/core/config.py` | Added `argus_enabled`, `argus_api_url`, `argus_timeout_seconds`, `argus_service_key` |
| `app/services/user_service.py` | Call `argus_service.register_product_user()` after user creation |
| `app/services/lifecycle_service.py` | Replace both `TODO(S7)` hooks with `argus_service.is_suppressed()` checks |
| `tests/test_argus_integration.py` | **New** — 9 unit tests (disabled/enabled/fail-open for both functions + lifecycle suppression integration) |

## Test plan

- [x] `pytest tests/test_argus_integration.py` — 9/9 passed
- [x] Full suite `pytest tests/` — 420 passed, 1 skipped (no regressions)
- [x] `ruff check` — clean
- [ ] Staging acceptance: register TR user → verify Argus contact ownership=team-relay (paste needed post-Hermes endpoints live)
- [ ] Staging smoke: Argus-suppressed contact → lifecycle worker sends 0 nudges

## Depends on

Stacked on S3 (`feature/s3-lifecycle-worker` / PR #51). Base branch will be updated to `main` after S3 merges.

**Note**: Requires Hermes to expose `/api/outreach/register_product_user` + `/api/outreach/suppression_check` REST endpoints before `ARGUS_ENABLED=true` in prod. Acceptance paste (criteria 1–2) added once those endpoints are live.