### PR TITLE
infra(env): document LIFECYCLE + ARGUS env vars in env.example

### DIFF
--- a/infra/env.example
+++ b/infra/env.example
@@ -59,3 +59,20 @@ EMAIL_WORKER_BATCH_SIZE=100           # Max emails to process per cycle
 # Web Publishing configuration (v1.7)
 WEB_PUBLISH_DOMAIN=                   # Web publishing domain (e.g., docs.example.com)
                                        # Leave empty to disable web publishing
+
+# Lifecycle email nudge engine (S3)
+# Set LIFECYCLE_ENABLED=true after E2E smoke test passes.
+LIFECYCLE_ENABLED=false
+LIFECYCLE_LAUNCH_DATE=                # ISO datetime cutoff; nudge only users registered on/after this date
+# LIFECYCLE_WORKER_INTERVAL=3600     # Poll interval seconds (default 3600)
+LIFECYCLE_FROM_NAME=                  # Lead persona display name (e.g. "Alex from Entire")
+LIFECYCLE_FROM_EMAIL=                 # Lead persona send-as address (must be an SMTP alias)
+LIFECYCLE_UNSUBSCRIBE_SECRET=change-me-in-prod  # HMAC-SHA256 key for unsubscribe tokens
+
+# Argus CRM integration (S7 — contact dedup + cross-product suppression-read)
+# Set ARGUS_ENABLED=true once Hermes outreach endpoints are live (S7b) and
+# ARGUS_SERVICE_KEY is provisioned by the Hermes operator.
+ARGUS_ENABLED=false
+ARGUS_API_URL=https://argus.entire.host
+# ARGUS_SERVICE_KEY=                  # X-Argus-Service-Key for M2M auth (from Hermes operator)
+# ARGUS_TIMEOUT_SECONDS=3             # Request timeout in seconds (default 3)


### PR DESCRIPTION
## Summary

- Documents `LIFECYCLE_*` env vars (S3 lifecycle nudge engine) in `infra/env.example`
- Documents `ARGUS_*` env vars (S7 Argus CRM integration) in `infra/env.example`
- Both groups ship disabled by default (`*_ENABLED=false`)
- Comments explain what each operator needs to enable them (S7b for ARGUS key)

**Operational context (S7c):** `ARGUS_ENABLED=false` and `ARGUS_API_URL=https://argus.entire.host` are already set in staging `.env`. `ARGUS_SERVICE_KEY` is pending S7b delivery from Hermes operator.

## Test plan

- [ ] Verify env.example renders correctly (no syntax errors)
- [ ] Confirm documented defaults match `app/core/config.py` field defaults