### PR TITLE
feat(web-publish): thread agent_key through SPA in-share navigation

### DIFF
--- a/apps/web-publish/src/lib/components/FileTree.svelte
+++ b/apps/web-publish/src/lib/components/FileTree.svelte
@@ -14,10 +14,11 @@
 		items: FolderItem[];
 		currentSlug: string;
 		currentPath?: string;
+		agentKey?: string;
 		onNavigate?: () => void;
 	}
 
-	let { items = [], currentSlug = '', currentPath = '', onNavigate }: Props = $props();
+	let { items = [], currentSlug = '', currentPath = '', agentKey, onNavigate }: Props = $props();
 
 	// Build tree from flat items
 	const tree = $derived(buildFileTree(items));
@@ -91,7 +92,8 @@
 	}
 
 	function getItemUrl(node: TreeNode): string {
-		return `/${currentSlug}/${slugifyPath(node.path)}`;
+		const base = `/${currentSlug}/${slugifyPath(node.path)}`;
+		return agentKey ? `${base}?agent_key=${encodeURIComponent(agentKey)}` : base;
 	}
 
 	function isActive(node: TreeNode): boolean {

--- a/apps/web-publish/src/lib/components/Sidebar.svelte
+++ b/apps/web-publish/src/lib/components/Sidebar.svelte
@@ -17,6 +17,7 @@
 		currentSlug?: string;
 		currentPath?: string;
 		branding?: Branding;
+		agentKey?: string;
 	}
 
 	let {
@@ -25,7 +26,8 @@
 		folderItems = [],
 		currentSlug = '',
 		currentPath = '',
-		branding
+		branding,
+		agentKey
 	}: Props = $props();
 
 	// Menu state for mobile
@@ -118,7 +120,7 @@
 				<div class="nav-section">
 					<div class="nav-section-header">Contents</div>
 				</div>
-				<FileTree items={folderItems} {currentSlug} {currentPath} onNavigate={closeMenu} />
+				<FileTree items={folderItems} {currentSlug} {currentPath} {agentKey} onNavigate={closeMenu} />
 			{:else}
 				<!-- Collapsed: show icon-only hint -->
 				<div class="collapsed-hint" title="Expand to see contents">

--- a/apps/web-publish/src/routes/+layout.svelte
+++ b/apps/web-publish/src/routes/+layout.svelte
@@ -19,6 +19,7 @@
 	const currentSlug = $derived($page.data?.share?.web_slug);
 	// Current path for highlighting active item in file tree
 	const currentPath = $derived($page.data?.filePath || '');
+	const agentKey = $derived($page.data?.agentKey);
 
 	// Get branding from server info (from layout load)
 	const branding = $derived(data?.serverInfo?.branding);
@@ -66,7 +67,7 @@
 
 <div class="app-container">
 	{#if !isHomePage}
-		<Sidebar {isAuthenticated} {folderItems} {currentSlug} {currentPath} {branding} />
+		<Sidebar {isAuthenticated} {folderItems} {currentSlug} {currentPath} {branding} {agentKey} />
 	{/if}
 	<main class="main-content" class:collapsed={sidebarCollapsed} class:home-page={isHomePage}>
 		<div class="content-wrapper" class:home-page={isHomePage}>

--- a/apps/web-publish/src/routes/[slug]/+page.server.ts
+++ b/apps/web-publish/src/routes/[slug]/+page.server.ts
@@ -100,7 +100,8 @@ export const load: PageServerLoad = async ({ params, cookies, url }) => {
 			needsPassword,
 			sessionToken,
 			authToken,
-			canEdit
+			canEdit,
+			agentKey
 		};
 	} catch (err) {
 		if (err && typeof err === 'object' && 'status' in err) throw err;

--- a/apps/web-publish/src/routes/[slug]/[...path]/+page.server.ts
+++ b/apps/web-publish/src/routes/[slug]/[...path]/+page.server.ts
@@ -75,7 +75,8 @@ export const load: PageServerLoad = async ({ params, cookies, url }) => {
 			filePath: slugifyPath(originalPath),
 			parentSlug: slug,
 			folderItems,
-			isFolder: false
+			isFolder: false,
+			agentKey
 		};
 	} catch (err) {
 		if (err && typeof err === 'object' && 'status' in err) throw err;

--- a/apps/web-publish/src/routes/[slug]/[...path]/+page.svelte
+++ b/apps/web-publish/src/routes/[slug]/[...path]/+page.svelte
@@ -17,7 +17,11 @@
 	let { data }: { data: PageData } = $props();
 
 	const shareUrl = $derived($page.url.href);
-	const backUrl = $derived(`/${data.parentSlug}`);
+	const backUrl = $derived(
+		data.agentKey
+			? `/${data.parentSlug}?agent_key=${encodeURIComponent(data.agentKey)}`
+			: `/${data.parentSlug}`
+	);
 	const description = $derived(
 		extractDescription(data.content || '', `View document: ${data.file.path}`)
 	);
@@ -51,7 +55,7 @@
 		<Breadcrumb class="mb-4 text-sm" style="padding-left: 0;">
 			<BreadcrumbList class="gap-1.5 pl-0">
 				<BreadcrumbItem>
-					<BreadcrumbLink href="/{data.parentSlug}" class="text-muted-foreground hover:text-foreground transition-colors">
+					<BreadcrumbLink href={backUrl} class="text-muted-foreground hover:text-foreground transition-colors">
 						{data.share.path}
 					</BreadcrumbLink>
 				</BreadcrumbItem>


### PR DESCRIPTION
## Summary

- Adds `agentKey` to the return value of both page server load functions (`[slug]/+page.server.ts` and `[slug]/[...path]/+page.server.ts`) so the key is available in page data
- Threads `agentKey` through `+layout.svelte` → `Sidebar.svelte` → `FileTree.svelte`
- `FileTree.getItemUrl` now appends `?agent_key=<key>` to every navigation link when a key is present
- Fixes the breadcrumb back-link in `[slug]/[...path]/+page.svelte` to use a derived `backUrl` that preserves the key instead of hardcoding `/{parentSlug}`

## Test plan

- [ ] `curl -s -o /dev/null -w '%{http_code}' "https://docs.entire.vc/<share>/<subdoc>?agent_key=<key>"` → 200
- [ ] Playwright: load entry-doc with agent_key → click sub-doc in tree → content renders, no 401/404
- [ ] Non-member without key → still 401/404

Fixes: ee36a686-2020-47a5-8363-9f4236bd21cf