### PR TITLE
feat(argus): forward registered_at + casdoor_id in register_product_user (S2-3)

### DIFF
--- a/apps/control-plane/app/services/argus_service.py
+++ b/apps/control-plane/app/services/argus_service.py
@@ -1,8 +1,9 @@
-"""Argus CRM integration for Team Relay (S7).
+"""Argus CRM integration for Team Relay (S7/S2-3).
 
 Two public functions:
-  register_product_user(email, display_name) — fire-and-forget on TR registration.
-    Upserts the Argus contact and logs an ownership interaction (60d window).
+  register_product_user(email, display_name, registered_at, casdoor_id) —
+    fire-and-forget on TR registration. Upserts the Argus contact, logs an
+    ownership interaction with occurred_at=registered_at, and stores casdoor_id.
 
   is_suppressed(email) -> bool — blocking pre-send check in lifecycle worker.
     Returns True if the contact has a cross-product opt-out (SO-3 rule-5).
@@ -13,6 +14,7 @@ from __future__ import annotations
 
 import logging
 import threading
+from datetime import datetime
 
 import httpx
 
@@ -35,12 +37,22 @@ def _client() -> httpx.Client:
     )
 
 
-def _register_blocking(email: str, display_name: str) -> None:
+def _register_blocking(
+    email: str,
+    display_name: str,
+    registered_at: datetime | None = None,
+    casdoor_id: str | None = None,
+) -> None:
     try:
         with _client() as client:
+            payload: dict = {"email": email, "display_name": display_name, "product": _PRODUCT}
+            if registered_at is not None:
+                payload["registered_at"] = registered_at.isoformat()
+            if casdoor_id is not None:
+                payload["casdoor_id"] = casdoor_id
             resp = client.post(
                 "/api/outreach/register_product_user",
-                json={"email": email, "display_name": display_name, "product": _PRODUCT},
+                json=payload,
             )
             if resp.status_code not in (200, 201):
                 logger.warning(
@@ -52,18 +64,36 @@ def _register_blocking(email: str, display_name: str) -> None:
         logger.warning("argus register_product_user error", exc_info=True)
 
 
-def register_product_user(email: str, display_name: str) -> None:
+def register_product_user(
+    email: str,
+    display_name: str,
+    registered_at: datetime | None = None,
+    casdoor_id: str | None = None,
+) -> None:
     """Non-blocking: register TR user in Argus CRM.
 
     Spawns a daemon thread so registration latency never blocks the HTTP response.
     Errors are logged but never raised.
+
+    Args:
+        email: User email address.
+        display_name: Display name (used as Argus contact name).
+        registered_at: Timestamp of TR/Casdoor registration; Argus uses this as
+            occurred_at for the ownership interaction. Defaults to now() in Argus.
+        casdoor_id: Casdoor subject ID (provider_user_id from UserOAuthAccount).
+            Stored as an identity in Argus to support cross-product dedup.
     """
     settings = get_settings()
     if not settings.argus_enabled:
         return
     threading.Thread(
         target=_register_blocking,
-        args=(email, display_name),
+        kwargs={
+            "email": email,
+            "display_name": display_name,
+            "registered_at": registered_at,
+            "casdoor_id": casdoor_id,
+        },
         daemon=True,
         name="argus-register",
     ).start()

--- a/apps/control-plane/app/services/oauth_service.py
+++ b/apps/control-plane/app/services/oauth_service.py
@@ -16,6 +16,7 @@ from sqlalchemy.orm import Session
 from app.core.config import get_settings
 from app.db import models
 from app.schemas import oauth as oauth_schema
+from app.services import argus_service
 
 
 def generate_code_verifier() -> str:
@@ -442,6 +443,14 @@ def create_user_from_oauth(
     db.add(oauth_account)
     db.commit()
     db.refresh(user)
+
+    # Register in Argus CRM with casdoor_id for cross-product dedup (S2-3).
+    argus_service.register_product_user(
+        email=email,
+        display_name=name or email.split("@")[0],
+        registered_at=user.created_at,
+        casdoor_id=provider_user_id,
+    )
 
     return user
 

--- a/apps/control-plane/app/services/user_service.py
+++ b/apps/control-plane/app/services/user_service.py
@@ -49,8 +49,12 @@ def create_user(
         details={"email": user.email, "is_admin": user.is_admin},
     )
 
-    # Register in Argus CRM for cross-product ownership / suppression tracking (S7).
-    argus_service.register_product_user(email=user.email, display_name=user.email.split("@")[0])
+    # Register in Argus CRM for cross-product ownership / suppression tracking (S7/S2-3).
+    argus_service.register_product_user(
+        email=user.email,
+        display_name=user.email.split("@")[0],
+        registered_at=user.created_at,
+    )
 
     return user
 

--- a/apps/control-plane/tests/test_argus_integration.py
+++ b/apps/control-plane/tests/test_argus_integration.py
@@ -137,6 +137,70 @@ class TestArgusServiceEnabled:
             assert mock_thread_cls.call_args.kwargs.get("daemon") is True
             mock_thread.start.assert_called_once()
 
+    def test_register_sends_registered_at_and_casdoor_id(self):
+        """_register_blocking includes registered_at + casdoor_id in JSON payload."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+
+        ts = datetime(2024, 3, 15, 10, 0, 0, tzinfo=timezone.utc)
+
+        with patch("httpx.Client") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client_cls.return_value.__enter__.return_value = mock_client
+            mock_client.post.return_value = mock_resp
+
+            argus_service._register_blocking(
+                "user@example.com",
+                "User",
+                registered_at=ts,
+                casdoor_id="casdoor-sub-123",
+            )
+
+        mock_client.post.assert_called_once_with(
+            "/api/outreach/register_product_user",
+            json={
+                "email": "user@example.com",
+                "display_name": "User",
+                "product": "team-relay",
+                "registered_at": ts.isoformat(),
+                "casdoor_id": "casdoor-sub-123",
+            },
+        )
+
+    def test_register_omits_none_optional_fields(self):
+        """_register_blocking omits registered_at/casdoor_id when not provided."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+
+        with patch("httpx.Client") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client_cls.return_value.__enter__.return_value = mock_client
+            mock_client.post.return_value = mock_resp
+
+            argus_service._register_blocking("user@example.com", "User")
+
+        called_json = mock_client.post.call_args.kwargs["json"]
+        assert "registered_at" not in called_json
+        assert "casdoor_id" not in called_json
+
+    def test_register_sends_only_registered_at_without_casdoor_id(self):
+        """_register_blocking sends registered_at alone when casdoor_id is absent."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+
+        ts = datetime(2024, 3, 15, 10, 0, 0, tzinfo=timezone.utc)
+
+        with patch("httpx.Client") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client_cls.return_value.__enter__.return_value = mock_client
+            mock_client.post.return_value = mock_resp
+
+            argus_service._register_blocking("user@example.com", "User", registered_at=ts)
+
+        called_json = mock_client.post.call_args.kwargs["json"]
+        assert called_json["registered_at"] == ts.isoformat()
+        assert "casdoor_id" not in called_json
+
 
 # ---------------------------------------------------------------------------
 # lifecycle_service suppression integration tests

--- a/apps/control-plane/tests/test_oauth.py
+++ b/apps/control-plane/tests/test_oauth.py
@@ -185,6 +185,36 @@ class TestOAuthService:
         oauth_account = oauth_service.find_user_by_oauth(db_session, provider.id, "oauth_user_456")
         assert oauth_account is not None
 
+    def test_create_user_from_oauth_registers_argus_with_casdoor_id(self, db_session: Session):
+        """create_user_from_oauth fires register_product_user with casdoor_id + registered_at."""
+        provider = models.OAuthProvider(
+            id=uuid.uuid4(),
+            name="casdoor",
+            provider_type=models.OAuthProviderType.OIDC,
+            issuer_url="https://casdoor.example.com",
+            client_id="test_client",
+            client_secret_encrypted="secret",
+            enabled=True,
+            auto_register=True,
+        )
+        db_session.add(provider)
+        db_session.commit()
+
+        with patch("app.services.oauth_service.argus_service.register_product_user") as mock_reg:
+            user = oauth_service.create_user_from_oauth(
+                db_session,
+                email="oauth@example.com",
+                name="OAuth User",
+                provider_id=provider.id,
+                provider_user_id="casdoor-sub-xyz",
+            )
+
+        mock_reg.assert_called_once()
+        call_kwargs = mock_reg.call_args.kwargs
+        assert call_kwargs["email"] == "oauth@example.com"
+        assert call_kwargs["casdoor_id"] == "casdoor-sub-xyz"
+        assert call_kwargs["registered_at"] == user.created_at
+
     def test_link_oauth_account(self, db_session: Session):
         """Test linking OAuth account to existing user."""
         # Create user


### PR DESCRIPTION
## Summary

- **`argus_service`**: added optional `registered_at: datetime | None` and `casdoor_id: str | None` to `register_product_user` / `_register_blocking`. Serialised as ISO-8601, omitted from payload when None (backward-compatible).
- **`user_service.create_user`**: passes `registered_at=user.created_at` (password-based signup path).
- **`oauth_service.create_user_from_oauth`**: adds argus call with `casdoor_id=provider_user_id` + `registered_at=user.created_at`. Previously this OAuth/Casdoor signup path sent nothing to Argus.

## Test plan

- [x] `test_argus_integration.py` — 4 new tests: full payload, no optional fields, registered_at only; all 12 green
- [x] `test_oauth.py` — new `test_create_user_from_oauth_registers_argus_with_casdoor_id`
- [x] Full suite green

## Dependency

Deploy after S2-1 (Argus endpoint extension). Backward-compatible: extra fields ignored by old Argus.