### PR TITLE
fix(web): binary artifacts get /_assets/ prefix in public_url

### DIFF
--- a/apps/control-plane/app/api/routers/web.py
+++ b/apps/control-plane/app/api/routers/web.py
@@ -1291,7 +1291,10 @@ async def upload_mesh_artifact(
         domain = settings.web_publish_domain
         if not domain.startswith("http"):
             domain = f"https://{domain}"
-        public_url = f"{domain.rstrip('/')}/{share.web_slug}/{path}"
+        if is_text:
+            public_url = f"{domain.rstrip('/')}/{share.web_slug}/{path}"
+        else:
+            public_url = f"{domain.rstrip('/')}/{share.web_slug}/_assets/{path}"
 
     return {
         "ok": True,

--- a/apps/control-plane/tests/test_mesh_upload.py
+++ b/apps/control-plane/tests/test_mesh_upload.py
@@ -157,6 +157,40 @@ class TestMeshUpload:
         assert data["path"] == "Notes/hello.md"
         assert data["size_bytes"] == len(b"# Hello world")
 
+    def test_text_upload_public_url_no_assets_prefix(
+        self, client: TestClient, test_user: models.User, db_session: Session, web_enabled
+    ):
+        share = make_folder_share(db_session, test_user, slug="pub-text")
+        raw_key, _ = make_agent_key(db_session, share)
+        with minio_patch():
+            resp = client.post(
+                "/v1/web/shares/pub-text/upload?path=Notes/report.md",
+                content=b"# Report",
+                headers={"X-Agent-Key": raw_key, "Content-Type": "text/markdown"},
+            )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["public_url"] == "https://docs.test.com/pub-text/Notes/report.md"
+        assert "/_assets/" not in data["public_url"]
+
+    def test_binary_upload_public_url_has_assets_prefix(
+        self, client: TestClient, test_user: models.User, db_session: Session, web_enabled
+    ):
+        share = make_folder_share(db_session, test_user, slug="pub-bin")
+        raw_key, _ = make_agent_key(db_session, share)
+        with minio_patch():
+            resp = client.post(
+                "/v1/web/shares/pub-bin/upload?path=artifacts/task123/image.jpg",
+                content=b"\xff\xd8\xff",  # minimal JPEG header
+                headers={"X-Agent-Key": raw_key, "Content-Type": "image/jpeg"},
+            )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["public_url"] == (
+            "https://docs.test.com/pub-bin/_assets/artifacts/task123/image.jpg"
+        )
+        assert "/_assets/" in data["public_url"]
+
     def test_valid_upload_item_in_folder_items(
         self, client: TestClient, test_user: models.User, db_session: Session, web_enabled
     ):


### PR DESCRIPTION
## Summary

- `POST /upload` was generating identical `public_url` paths for all MIME types
- SvelteKit web-publish routes binary files through `/{slug}/_assets/[...path]` (MinIO direct), but text files through `/{slug}/[...path]` (text-index lookup)
- Without the `_assets` prefix, binary uploads (images, PDFs) hit the text-index route and returned 404
- Fix: branch on the existing `is_text` variable to emit the correct URL shape
- 41 existing binary artifacts need a SQL backfill — handled separately by Garfield (tracked in parent task #b85c4736)

## Changes

- `apps/control-plane/app/api/routers/web.py`: conditional `public_url` in `upload_mesh_artifact`
- `apps/control-plane/tests/test_mesh_upload.py`: 2 new tests asserting text URL (no `/_assets/`) and binary URL (has `/_assets/`)

## Test plan

- [x] `test_text_upload_public_url_no_assets_prefix` — text/markdown upload → URL without `/_assets/`
- [x] `test_binary_upload_public_url_has_assets_prefix` — image/jpeg upload → URL with `/_assets/`
- [x] All 35 existing `test_mesh_upload.py` tests pass

Related: parent RCA #16f86faf, epic #a5f35244