### PR TITLE
fix(web): SELECT FOR UPDATE on concurrent JSONB uploads (race fix)

### DIFF
--- a/apps/control-plane/app/api/routers/web.py
+++ b/apps/control-plane/app/api/routers/web.py
@@ -1141,7 +1141,7 @@ async def upload_mesh_artifact(
             models.Share.web_slug == share_identifier,
             models.Share.web_published == True,  # noqa: E712
         )
-    share = db.execute(stmt).scalar_one_or_none()
+    share = db.execute(stmt.with_for_update()).scalar_one_or_none()
     if not share:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Share not found")
     if share.kind != models.ShareKind.FOLDER:
@@ -1420,7 +1420,7 @@ async def sync_upload(
             models.Share.web_published == True,  # noqa: E712
         )
 
-    share = db.execute(_stmt).scalar_one_or_none()
+    share = db.execute(_stmt.with_for_update()).scalar_one_or_none()
     if not share:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Share not found")
     if share.kind != models.ShareKind.FOLDER:

--- a/apps/control-plane/tests/test_sync_upload.py
+++ b/apps/control-plane/tests/test_sync_upload.py
@@ -304,6 +304,53 @@ class TestSyncUploadAuth:
         assert resp.status_code == 403
 
 
+class TestSyncUploadRaceFix:
+    """Regression tests for the JSONB read-modify-write race condition fix (with_for_update).
+
+    True concurrent testing requires PostgreSQL — SQLite serializes all connections via
+    StaticPool. These tests verify that sequential uploads to the same share all appear
+    in web_folder_items (the invariant the FOR UPDATE lock preserves in production).
+    """
+
+    def test_five_sequential_uploads_all_indexed(
+        self, client: TestClient, test_user: models.User, db_session: Session, web_enabled
+    ):
+        share = make_folder_share(db_session, test_user, slug="su-race")
+        raw_key, _ = make_agent_key(db_session, share)
+        paths = [f"artifacts/task1/file{i}.md" for i in range(5)]
+        with minio_patch():
+            for p in paths:
+                resp = client.post(
+                    f"{BASE}/{share.id}/sync-upload?path={p}",
+                    content=f"content of {p}".encode(),
+                    headers={"X-Agent-Key": raw_key, "Content-Type": "text/markdown"},
+                )
+                assert resp.status_code == 200, f"upload failed for {p}: {resp.text}"
+        db_session.refresh(share)
+        indexed = {i["path"] for i in (share.web_folder_items or [])}
+        for p in paths:
+            assert p in indexed, f"Missing from index after sequential uploads: {p}"
+
+    def test_upload_endpoint_five_sequential_uploads_all_indexed(
+        self, client: TestClient, test_user: models.User, db_session: Session, web_enabled
+    ):
+        share = make_folder_share(db_session, test_user, slug="su-race-upload")
+        raw_key, _ = make_agent_key(db_session, share)
+        paths = [f"artifacts/task2/file{i}.txt" for i in range(5)]
+        with minio_patch():
+            for p in paths:
+                resp = client.post(
+                    f"/v1/web/shares/{share.id}/upload?path={p}",
+                    content=f"content {p}".encode(),
+                    headers={"X-Agent-Key": raw_key, "Content-Type": "text/plain"},
+                )
+                assert resp.status_code == 200, f"upload failed for {p}: {resp.text}"
+        db_session.refresh(share)
+        indexed = {i["path"] for i in (share.web_folder_items or [])}
+        for p in paths:
+            assert p in indexed, f"Missing from index after sequential uploads: {p}"
+
+
 class TestSyncUploadValidation:
     def test_path_traversal_returns_400(
         self, client: TestClient, test_user: models.User, db_session: Session, web_enabled


### PR DESCRIPTION
## Summary

- `POST /upload` and `POST /sync-upload` both read-modify-write `share.web_folder_items` (JSONB) without locking the row
- Concurrent artifact uploads for the same task race on the same share snapshot: only the last committer's write survives, silently dropping earlier items
- Fix: add `.with_for_update()` to the Share SELECT in both handlers — serialises concurrent writers at the DB level (PostgreSQL)

## Evidence

- Task `047053b3` (spark): 4 artifacts uploaded at 13:23:00–01 UTC, only 1 survived in `web_folder_items`
- RCA: parent task #16f86faf

## Changes

- `apps/control-plane/app/api/routers/web.py`: `stmt.with_for_update()` and `_stmt.with_for_update()` in `/upload` and `/sync-upload` handlers respectively
- `apps/control-plane/tests/test_sync_upload.py`: 2 regression tests — 5 sequential uploads to same share, all must appear in index

## Test plan

- [x] 5 sequential uploads to `/upload` — all 5 in `web_folder_items`
- [x] 5 sequential uploads to `/sync-upload` — all 5 in `web_folder_items`
- [x] All 56 existing `test_sync_upload.py` + `test_mesh_upload.py` tests pass
- Note: true concurrent test requires PostgreSQL; SQLite+StaticPool serialises connections

Related: epic #a5f35244, RCA #16f86faf