### PR TITLE
fix(security): validate JWT on POST /web/shares/{slug}/files — close auth bypass

### DIFF
--- a/apps/control-plane/app/api/routers/web.py
+++ b/apps/control-plane/app/api/routers/web.py
@@ -503,20 +503,7 @@ def sync_folder_file_content(
             detail="This endpoint is only for folder shares",
         )
 
-    # For now, require authentication via session cookie
-    # TODO: Support plugin authentication via JWT token
-    session_token = request.cookies.get("web_session")
-    if not session_token:
-        # Try to validate JWT token from Authorization header
-        auth_header = request.headers.get("Authorization")
-        if not auth_header or not auth_header.startswith("Bearer "):
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="Authentication required",
-            )
-        # For now, just check if token exists - proper validation would require
-        # checking user ownership of the share
-        # This will be handled by plugin sending proper JWT tokens
+    _require_private_web_auth(request, share, db)
 
     # Update folder items with content
     folder_items = share.web_folder_items or []

--- a/apps/control-plane/tests/test_web_publish.py
+++ b/apps/control-plane/tests/test_web_publish.py
@@ -913,6 +913,23 @@ class TestWebRelayToken:
 class TestFolderFileContentSync:
     """Test folder file content sync endpoints (v1.8)."""
 
+    def _make_agent_key(self, db, share, scopes="write"):
+        import hashlib as _hl
+        import secrets as _sec
+
+        raw = "tr_agent_" + _sec.token_hex(24)
+        key_hash = _hl.sha256(raw.encode()).hexdigest()
+        ak = models.ShareAgentKey(
+            share_id=share.id,
+            key_hash=key_hash,
+            label="test-key",
+            scopes=scopes,
+        )
+        db.add(ak)
+        db.commit()
+        db.refresh(ak)
+        return raw, ak
+
     @pytest.fixture
     def folder_share(self, db_session: Session, test_user: models.User) -> models.Share:
         """Create a folder share with some items."""
@@ -944,25 +961,42 @@ class TestFolderFileContentSync:
         assert response.status_code == 404
 
     def test_sync_folder_file_content_enabled(
-        self, client: TestClient, folder_share: models.Share, monkeypatch
+        self, client: TestClient, db_session: Session, folder_share: models.Share, monkeypatch
     ):
-        """Test syncing file content to folder share."""
-        # Enable web publishing
+        """Test syncing file content to folder share via valid X-Agent-Key."""
         monkeypatch.setenv("WEB_PUBLISH_DOMAIN", "docs.test.com")
         from app.core.config import get_settings
 
         get_settings.cache_clear()
 
-        # Sync content (with mock auth for now)
+        raw_key, _ = self._make_agent_key(db_session, folder_share, scopes="write")
         response = client.post(
             f"/v1/web/shares/{folder_share.web_slug}/files?path=doc1.md",
             json={"content": "# Document 1\n\nThis is the content."},
-            headers={"Authorization": "Bearer mock-token"},
+            headers={"X-Agent-Key": raw_key},
         )
         assert response.status_code == 200
         data = response.json()
         assert data["path"] == "doc1.md"
         assert "message" in data
+
+        get_settings.cache_clear()
+
+    def test_sync_folder_file_content_fake_bearer_returns_401(
+        self, client: TestClient, folder_share: models.Share, monkeypatch
+    ):
+        """Regression: POST /files with fake Bearer token must return 401 (not 200)."""
+        monkeypatch.setenv("WEB_PUBLISH_DOMAIN", "docs.test.com")
+        from app.core.config import get_settings
+
+        get_settings.cache_clear()
+
+        response = client.post(
+            f"/v1/web/shares/{folder_share.web_slug}/files?path=doc1.md",
+            json={"content": "injected"},
+            headers={"Authorization": "Bearer FAKE_TOKEN_INVALID"},
+        )
+        assert response.status_code == 401
 
         get_settings.cache_clear()
 


### PR DESCRIPTION
## Проблема

`POST /v1/web/shares/{slug}/files` проверял только наличие `Authorization: Bearer` заголовка, но не валидировал JWT. Любой `Bearer <anything>` → 200, контент перезаписан.

Уязвимость регрессировала трижды — fix применялся in-place в контейнере/rsync-дереве и перезатирался при следующем rebuild.

## Исправление

Заменил сломанный блок (14 строк «check header presence only») на вызов `_require_private_web_auth(request, share, db)` — того же хелпера, что используется в `/token`, `/content`, `/items`.

`_require_private_web_auth` принимает:
1. `X-Agent-Key` header (plugin flow)
2. `Authorization: Bearer <valid-JWT>` (owner/member)
3. `access_token` cookie (browser iframe)

## Тесты

- Обновлён `test_sync_folder_file_content_enabled` → теперь использует `X-Agent-Key` вместо mock-токена
- Добавлен регресс-тест `test_sync_folder_file_content_fake_bearer_returns_401`
- Все 444 тестов зелёные

## Задача

Mesh #d6a16a30, epic #a5f35244