### PR TITLE
fix(deploy): add --force-recreate so rebuilt image is always picked up

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -55,7 +55,7 @@ if [ "$DRY_RUN" = "true" ]; then
 fi
 
 log "restarting app services"
-docker compose up -d control-plane webhook-worker email-worker
+docker compose up -d --force-recreate control-plane webhook-worker email-worker
 
 # 5. Post-deploy health check (best-effort, non-fatal — restart already issued).
 log "waiting for control-plane health"


### PR DESCRIPTION
## Summary
- Adds `--force-recreate` to `docker compose up -d` in `scripts/deploy.sh`
- Fixes the S2-3 deploy incident where the control-plane container stayed on the old image SHA (`687ebe9e`) instead of the freshly-built one (`b9a9ebcc`) after a rebuild
- All three rebuilt-image services (`control-plane`, `webhook-worker`, `email-worker`) get the flag — they are already enumerated explicitly so postgres/caddy/minio are unaffected

## Test plan
- [ ] Run `workflow_dispatch` with `dry_run=true` — "Build, migrate, restart" step exits 0
- [ ] Subsequent normal deploy: `docker inspect relay-control-plane-1 | grep Id` returns the new SHA after deploy

Relates: Mesh task `372b322d` (S2-3 deploy incident `9f9d1aab`)
