### PR TITLE
fix(sync-upload): binary assets → web-assets path + /_assets/ URL + agent_key forwarding

### DIFF
--- a/apps/control-plane/app/api/routers/web.py
+++ b/apps/control-plane/app/api/routers/web.py
@@ -1429,17 +1429,23 @@ async def sync_upload(
 
     mime = request.headers.get("Content-Type", "application/octet-stream").split(";")[0].strip()
     sha256 = hashlib.sha256(body).hexdigest()
+    is_text = mime.startswith("text/") or mime in ("application/json", "application/xml")
 
-    # CAS storage: key is content-addressed by SHA256, stored alongside relay-server's data.
+    # Storage: text files go to CAS (dedup for Obsidian plugin); binary assets go to
+    # web-assets/{share_id}/{path} so the _assets/ serve endpoint can find them by path.
     minio_client = _get_minio_client()
     bucket_name = settings.minio_bucket
     _ensure_minio_bucket(minio_client, bucket_name)
 
-    cas_key = f"sync-uploads/{share.id}/{sha256}"
+    if is_text:
+        storage_key = f"sync-uploads/{share.id}/{sha256}"
+    else:
+        storage_key = f"web-assets/{share.id}/{path}"
+
     try:
         minio_client.put_object(
             bucket_name,
-            cas_key,
+            storage_key,
             io.BytesIO(body),
             length=len(body),
             content_type=mime,
@@ -1466,7 +1472,6 @@ async def sync_upload(
     from sqlalchemy.orm.attributes import flag_modified
 
     now_iso = security.utcnow().isoformat()
-    is_text = mime.startswith("text/") or mime in ("application/json", "application/xml")
     inline_content = (
         body.decode("utf-8", errors="replace") if (is_text and len(body) < 256 * 1024) else None
     )
@@ -1484,7 +1489,7 @@ async def sync_upload(
                     "size": len(body),
                     "sha256": sha256,
                     "modified_at": now_iso,
-                    "storage_key": cas_key,
+                    "storage_key": storage_key,
                     "content": inline_content,
                 }
             )
@@ -1502,7 +1507,7 @@ async def sync_upload(
                 "size": len(body),
                 "sha256": sha256,
                 "modified_at": now_iso,
-                "storage_key": cas_key,
+                "storage_key": storage_key,
                 "content": inline_content,
             }
         )
@@ -1522,7 +1527,10 @@ async def sync_upload(
         domain = settings.web_publish_domain
         if not domain.startswith("http"):
             domain = f"https://{domain}"
-        web_url = f"{domain.rstrip('/')}/{share.web_slug}/{path}"
+        if is_text:
+            web_url = f"{domain.rstrip('/')}/{share.web_slug}/{path}"
+        else:
+            web_url = f"{domain.rstrip('/')}/{share.web_slug}/_assets/{path}"
 
     return {
         "sync_url": sync_url,

--- a/apps/web-publish/src/routes/[slug]/_assets/[...path]/+server.ts
+++ b/apps/web-publish/src/routes/[slug]/_assets/[...path]/+server.ts
@@ -2,7 +2,7 @@ import type { RequestHandler } from './$types';
 
 const CONTROL_PLANE_URL = process.env.CONTROL_PLANE_URL || 'http://control-plane:8000';
 
-export const GET: RequestHandler = async ({ params, request }) => {
+export const GET: RequestHandler = async ({ params, request, url }) => {
 	const { slug, path } = params;
 
 	// Forward cookies for auth (protected/private shares)
@@ -11,6 +11,9 @@ export const GET: RequestHandler = async ({ params, request }) => {
 	if (cookie) headers['Cookie'] = cookie;
 	const auth = request.headers.get('authorization');
 	if (auth) headers['Authorization'] = auth;
+	// Forward agent_key query param for private share auth
+	const agentKey = url.searchParams.get('agent_key');
+	if (agentKey) headers['X-Agent-Key'] = agentKey;
 
 	const response = await fetch(
 		`${CONTROL_PLANE_URL}/v1/web/shares/${slug}/assets?path=${encodeURIComponent(path)}`,


### PR DESCRIPTION
## Summary

- **Fix 1 & 2 (`web.py`)**: `sync_upload` was storing all files (text + binary) in CAS (`sync-uploads/{share_id}/{sha256}`). Binary files (images, PDFs, etc.) need to be stored at `web-assets/{share_id}/{path}` — the exact path the `GET /shares/{slug}/assets` serve endpoint reads from. Text files (markdown, JSON) keep CAS storage for Obsidian plugin dedup. `web_url` in the response now includes `/_assets/` prefix for binary files (matching `upload_web_asset` behavior).

- **Fix 3 (`+server.ts`)**: The SvelteKit `/_assets/[...path]/+server.ts` proxy wasn't forwarding `?agent_key=` from the incoming URL to the CP. Private share asset requests carry the key as a query param. Added forwarding as `X-Agent-Key` header — which `_require_private_web_auth` already accepts.

## Test plan

- [ ] Upload PNG via `POST /v1/web/shares/marketing/sync-upload?path=artifacts/test/test.png` — response `web_url` contains `/_assets/`
- [ ] `curl "https://docs.entire.vc/marketing/_assets/artifacts/test/test.png?agent_key=<key>"` → HTTP 200 with image bytes
- [ ] Upload markdown via sync-upload — `web_url` does NOT contain `/_assets/`, stored in `sync-uploads/` CAS path
- [ ] CI green