### PR TITLE
fix(web-publish): raise files sync rate limit 30→300/min + web_content_updated_at in PATCH

### DIFF
--- a/apps/control-plane/app/api/routers/web.py
+++ b/apps/control-plane/app/api/routers/web.py
@@ -458,7 +458,7 @@ def get_web_relay_token(
 
 
 @router.post("/shares/{slug}/files", status_code=status.HTTP_200_OK)
-@limiter.limit("30/minute")  # Rate limit for content sync
+@limiter.limit("300/minute")  # Rate limit for content sync — raised for bulk initial full-sync (was 30/min)
 def sync_folder_file_content(
     request: Request,
     slug: str,

--- a/apps/control-plane/app/schemas/share.py
+++ b/apps/control-plane/app/schemas/share.py
@@ -57,6 +57,7 @@ class ShareUpdate(BaseModel):
     web_content: str | None = None  # Document content for web publishing
     web_folder_items: list[FolderItem] | None = None  # Folder contents for web publishing
     web_doc_id: str | None = None  # Y-sweet document ID for real-time sync
+    web_content_updated_at: datetime | None = None  # Plugin sets this after initial full-sync completes
 
     @field_validator("web_sync_mode")
     @classmethod

--- a/apps/control-plane/app/services/share_service.py
+++ b/apps/control-plane/app/services/share_service.py
@@ -278,6 +278,10 @@ def update_share(
         else:
             share.web_folder_items = None
 
+    # Handle explicit web_content_updated_at bump — plugin sets this after initial full-sync completes
+    if payload.web_content_updated_at is not None:
+        share.web_content_updated_at = payload.web_content_updated_at
+
     # Handle web doc_id update (y-sweet document ID for real-time sync)
     if payload.web_doc_id is not None:
         old_doc_id = share.web_doc_id


### PR DESCRIPTION
## Проблема

`_initialFullSync` в Obsidian-плагине отправляет ~5 req/sec (задержка 200ms между файлами), но rate limit на `POST /v1/web/shares/{slug}/files` был 30/min (~0.5 req/sec). После первых ~30 файлов все запросы возвращают 429, которые silently проглатываются в плагине (`catch {}`). В итоге content для `rnd/`, `specs/`, `adrs/` файлов остаётся NULL в `web_folder_items`. На docs.entire.vc показывается «Content not available».

Root cause подтверждён по логам CP (`2026-06-16T11:12:49`): серия `ratelimit 30 per 1 minute exceeded at endpoint: /v1/web/shares/spark/files`.

## Изменения

- **web.py**: rate limit `sync_folder_file_content` повышен с `30/minute` до `300/minute` (5 req/sec — соответствует задержке плагина 200ms)
- **share.py**: добавлено `web_content_updated_at: datetime | None` в `ShareUpdate` — плагин явно сбрасывает timestamp после завершения initial full-sync, предотвращая повторный запуск stale-проверки
- **share_service.py**: обработка нового поля в `update_share`

## Тест

После деплоя и перезапуска Obsidian на MacBook Pavel:
```
curl -s "https://cp.tr.entire.vc/v1/web/shares/spark/files?path=rnd%2FSpark%20GTM%20-%20Execution%20Plan.md&agent_key=..." | jq '.content | length'
# Expected: > 0
```