### PR TITLE
fix(inbound-sync): preserve sync-artifacts in web_folder_items during vault PATCH

### DIFF
--- a/apps/control-plane/app/services/share_service.py
+++ b/apps/control-plane/app/services/share_service.py
@@ -274,6 +274,12 @@ def update_share(
                     if key in existing:
                         new_item[key] = existing[key]
                 new_items.append(new_item)
+            # Preserve sync-artifacts not yet pulled to vault (absent from vault payload)
+            new_paths = {item["path"] for item in new_items}
+            for existing_item in (share.web_folder_items or []):
+                if (existing_item.get("source") == "sync-artifact"
+                        and existing_item.get("path") not in new_paths):
+                    new_items.append(existing_item)
             share.web_folder_items = new_items
         else:
             share.web_folder_items = None


### PR DESCRIPTION
## Проблема

Когда плагин Obsidian выполняет `_initialFullSync`, он PATCH-ит `web_folder_items` только с файлами из локального vault. Sync-артефакты, уже загруженные через Mesh→Relay транспорт (`sync-upload`), тихо удалялись — потому что логика мёрджа обрабатывала только пути, присутствующие в payload.

Результат: `files-index` возвращал пустой список → `InboundFileDownloader` не загружал артефакты в vault.

## Исправление

После мёрджа vault-элементов переносим обратно все существующие `web_folder_items` с `source="sync-artifact"`, чьи пути не попали в новый payload.

```python
# Preserve sync-artifacts not yet pulled to vault (absent from vault payload)
new_paths = {item["path"] for item in new_items}
for existing_item in (share.web_folder_items or []):
    if (existing_item.get("source") == "sync-artifact"
            and existing_item.get("path") not in new_paths):
        new_items.append(existing_item)
```

## Связь

Часть исправления задачи `#2ad7f006` (TR Incremental inbound не тянет новые артефакты в Spark-шару). Требует плагина `garfield/fix-inbound-sync-cache-bypass` (PR в obsidian-plugin репо) для полной цепочки.