### PR TITLE
fix(deploy): stdin consumption kills compose-up; bump cryptography 48.0.1

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -9,7 +9,7 @@
 #
 # All baseline findings (CI 1.8, 2026-05-23) have been remediated — task 1bf42b38:
 # - pillow 12.2.0 (constraint relaxed from >=10.0,<11.0 to >=12.2.0,<13.0)
-# - cryptography 46.0.7 (constraint updated to >=46.0.5,<47.0)
+# - cryptography 48.0.1 (constraint bumped to >=48.0.1,<49.0 — fixes HIGH CVE not present in 46.x baseline)
 # - authlib 1.6.12 (constraint updated to >=1.6.12)
 # - cbor2 5.9.0, pyjwt 2.13.0, mako 1.3.12, python-multipart 0.0.29
 # - lodash-es 4.18.1 (package.json override >=4.18.1, PRs #14 #16 #17)

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -42,8 +42,14 @@ docker build -t "$IMAGE" control-plane-src/
 # 3. Migration gate — FAIL-CLOSED.
 #    docker compose run returns the migrate container's exit code; alembic failure
 #    => non-zero => we abort here and the app is NEVER restarted.
+#
+#    -T:        disable pseudo-TTY (non-interactive CI run).
+#    </dev/null: prevent docker compose run from inheriting bash's stdin.
+#               Without this, when the script is fed via 'bash -s < deploy.sh'
+#               over SSH, docker compose run consumes the rest of the file from
+#               stdin — bash hits EOF and exits before 'compose up' ever runs.
 log "running migration gate (alembic upgrade head)"
-if ! docker compose run --rm control-plane-migrate; then
+if ! docker compose run --rm -T control-plane-migrate </dev/null; then
   die "MIGRATION GATE FAILED — app NOT restarted, prod left on previous image. Investigate before retrying."
 fi
 log "migration gate passed (schema at head)"


### PR DESCRIPTION
## Summary

- **Critical deploy bug fixed:** `docker compose run` inherited `bash -s`'s stdin (the script fed over SSH), consuming the remainder of the file. bash hit EOF and exited 0 before `compose up` ever ran — containers silently stayed on the old image while the job reported success. Fix: add `-T` + `</dev/null` to the migrate step.
- **Trivy gate unblocked:** bump `cryptography 46.0.7 → 48.0.1` (HIGH CVE fix); update `uv.lock`. Constraint: `>=48.0.1,<49.0`.

## Root cause (deploy stdin bug)

```
ssh ... "bash -s" < scripts/deploy.sh
            ↑
   bash reads the SCRIPT from stdin (SSH pipe)
            ↓
docker compose run --rm control-plane-migrate
   ↑ inherits bash's stdin by default
   ↑ reads/consumes the rest of deploy.sh from the pipe
            ↓
bash has nothing left → EOF → exits 0
"compose up" on line 58 never executes
```

Fixed by adding `</dev/null` (severs stdin from bash's pipe) and `-T` (no TTY for CI).

## Test plan

- [ ] Trigger workflow_dispatch on this branch with `dry_run=false` → job log must show `==> restarting app services` and `==> deploy complete` lines
- [ ] After run: `ssh tw-relay 'docker inspect relay-control-plane-1 --format "{{.State.StartedAt}}"'` — timestamp within 1 min of deploy
- [ ] Trivy CI passes (no HIGH cryptography finding)