### PR TITLE
feat(web-publish): D5-b signed embed tokens for iframe previews

### DIFF
--- a/apps/control-plane/app/services/share_service.py
+++ b/apps/control-plane/app/services/share_service.py
@@ -276,9 +276,11 @@ def update_share(
                 new_items.append(new_item)
             # Preserve sync-artifacts not yet pulled to vault (absent from vault payload)
             new_paths = {item["path"] for item in new_items}
-            for existing_item in (share.web_folder_items or []):
-                if (existing_item.get("source") == "sync-artifact"
-                        and existing_item.get("path") not in new_paths):
+            for existing_item in share.web_folder_items or []:
+                if (
+                    existing_item.get("source") == "sync-artifact"
+                    and existing_item.get("path") not in new_paths
+                ):
                     new_items.append(existing_item)
             share.web_folder_items = new_items
         else:

--- a/apps/web-publish/.env.example
+++ b/apps/web-publish/.env.example
@@ -9,3 +9,16 @@ PUBLIC_WEB_DOMAIN=docs.example.com
 
 # Origin for CSRF protection
 ORIGIN=https://docs.example.com
+
+# iframe embed token config (D5-b signed embed-URLs)
+# EMBED_TOKEN_SECRET: random secret ≥32 bytes for HMAC-SHA256 signing
+# Generate: openssl rand -hex 32
+EMBED_TOKEN_SECRET=
+
+# WEB_PUBLISH_AGENT_KEY: a read-only agent key provisioned on the control plane.
+# Used server-side when serving embed-token requests (never sent to browser).
+WEB_PUBLISH_AGENT_KEY=
+
+# Comma-separated list of origins allowed to embed pages via iframe
+# (appended to frame-ancestors CSP, e.g. https://mesh.entire.host)
+WEB_FRAME_ANCESTORS=

--- a/apps/web-publish/src/lib/embed-token.ts
+++ b/apps/web-publish/src/lib/embed-token.ts
@@ -1,0 +1,96 @@
+/**
+ * Short-lived HMAC-signed embed tokens for iframe previews.
+ *
+ * Token format: base64url(payload) + "." + base64url(HMAC-SHA256)
+ * Payload: JSON { slug, path, exp }
+ *
+ * Uses Web Crypto API (available globally in Node 18+/browsers) — no imports needed.
+ */
+
+interface EmbedTokenPayload {
+	slug: string;
+	path: string;
+	exp: number;
+}
+
+export interface VerifyResult {
+	ok: boolean;
+	slug?: string;
+	path?: string;
+}
+
+function b64urlEncode(input: Uint8Array | string): string {
+	const bytes =
+		typeof input === 'string' ? new TextEncoder().encode(input) : input;
+	let binary = '';
+	bytes.forEach((b) => (binary += String.fromCharCode(b)));
+	return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+}
+
+function b64urlDecode(s: string): Uint8Array {
+	const padded = s.replace(/-/g, '+').replace(/_/g, '/');
+	const pad = (4 - (padded.length % 4)) % 4;
+	return Uint8Array.from(atob(padded + '='.repeat(pad)), (c) => c.charCodeAt(0));
+}
+
+async function hmacSign(data: string, secret: string): Promise<Uint8Array> {
+	const enc = new TextEncoder();
+	const key = await crypto.subtle.importKey(
+		'raw',
+		enc.encode(secret),
+		{ name: 'HMAC', hash: 'SHA-256' },
+		false,
+		['sign']
+	);
+	return new Uint8Array(await crypto.subtle.sign('HMAC', key, enc.encode(data)));
+}
+
+export async function signEmbedToken(
+	slug: string,
+	path: string,
+	secret: string,
+	ttlSeconds = 3600
+): Promise<string> {
+	const payload: EmbedTokenPayload = {
+		slug,
+		path,
+		exp: Math.floor(Date.now() / 1000) + ttlSeconds
+	};
+	const encoded = b64urlEncode(JSON.stringify(payload));
+	const sig = b64urlEncode(await hmacSign(encoded, secret));
+	return `${encoded}.${sig}`;
+}
+
+export async function verifyEmbedToken(token: string, secret: string): Promise<VerifyResult> {
+	const dot = token.lastIndexOf('.');
+	if (dot < 1) return { ok: false };
+
+	const encoded = token.slice(0, dot);
+	const providedSig = token.slice(dot + 1);
+
+	const expectedSig = b64urlEncode(await hmacSign(encoded, secret));
+
+	// Constant-time comparison — XOR all chars, accumulate diff
+	if (providedSig.length !== expectedSig.length) return { ok: false };
+	let diff = 0;
+	for (let i = 0; i < providedSig.length; i++) {
+		diff |= providedSig.charCodeAt(i) ^ expectedSig.charCodeAt(i);
+	}
+	if (diff !== 0) return { ok: false };
+
+	let payload: EmbedTokenPayload;
+	try {
+		payload = JSON.parse(new TextDecoder().decode(b64urlDecode(encoded)));
+	} catch {
+		return { ok: false };
+	}
+
+	if (!payload.slug || payload.path === undefined || !payload.exp) {
+		return { ok: false };
+	}
+	if (Math.floor(Date.now() / 1000) > payload.exp) {
+		return { ok: false };
+	}
+
+	return { ok: true, slug: payload.slug, path: payload.path };
+}

--- a/apps/web-publish/src/routes/[slug]/[...path]/+page.server.ts
+++ b/apps/web-publish/src/routes/[slug]/[...path]/+page.server.ts
@@ -1,15 +1,38 @@
 import { error } from '@sveltejs/kit';
+import { env } from '$env/dynamic/private';
 import { getShareBySlug, validateSession, validateUserToken, getFolderFileContent } from '$lib/api';
 import { slugifyPath } from '$lib/file-tree';
+import { verifyEmbedToken } from '$lib/embed-token';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ params, cookies, url }) => {
 	const { slug, path } = params;
 	const agentKey = url.searchParams.get('agent_key') ?? undefined;
+	const embedToken = url.searchParams.get('embed_token') ?? undefined;
+
+	// Determine the key to use for CP calls:
+	// - embed_token path uses WEB_PUBLISH_AGENT_KEY (server-side only, never in browser)
+	// - direct agent_key path uses the caller-provided key
+	let resolvedAgentKey = agentKey;
+	let isEmbedTokenAuth = false;
+
+	if (embedToken && !agentKey) {
+		const secret = env.EMBED_TOKEN_SECRET;
+		if (secret) {
+			const result = await verifyEmbedToken(embedToken, secret);
+			if (result.ok && result.slug === slug) {
+				const serviceKey = env.WEB_PUBLISH_AGENT_KEY;
+				if (serviceKey) {
+					resolvedAgentKey = serviceKey;
+					isEmbedTokenAuth = true;
+				}
+			}
+		}
+	}
 
 	try {
-		// Fetch folder share metadata from Control Plane (agent_key forwarded so CP can expose content)
-		const share = await getShareBySlug(slug, agentKey);
+		// Fetch folder share metadata from Control Plane
+		const share = await getShareBySlug(slug, resolvedAgentKey);
 
 		if (share.kind !== 'folder') {
 			throw error(404, 'Not a folder share');
@@ -26,13 +49,14 @@ export const load: PageServerLoad = async ({ params, cookies, url }) => {
 			}
 		}
 
+		// For private shares: embed_token auth (short-lived token issued by /api/embed-token)
 		// For private shares: agent_key auth — CP already validated; content non-null = accepted.
 		let isAgentAuthenticated = false;
-		if (share.visibility === 'private' && agentKey) {
+		if (share.visibility === 'private' && resolvedAgentKey) {
 			isAgentAuthenticated = share.web_folder_items !== null;
 		}
 
-		// For private shares: OAuth/JWT auth (only when no agent_key)
+		// For private shares: OAuth/JWT auth (only when no key-based auth)
 		let isOAuthAuthenticated = false;
 		let authToken: string | undefined;
 		if (share.visibility === 'private' && !isAgentAuthenticated) {
@@ -62,7 +86,7 @@ export const load: PageServerLoad = async ({ params, cookies, url }) => {
 
 		let content: string;
 		try {
-			const fileContent = await getFolderFileContent(slug, originalPath, sessionToken, authToken, agentKey);
+			const fileContent = await getFolderFileContent(slug, originalPath, sessionToken, authToken, resolvedAgentKey);
 			content = fileContent.content || '# Content not available\n\nThis file has not been synced yet.';
 		} catch (fetchError) {
 			content = `# ${file.name}\n\n> **Content not yet synced**`;
@@ -76,7 +100,8 @@ export const load: PageServerLoad = async ({ params, cookies, url }) => {
 			parentSlug: slug,
 			folderItems,
 			isFolder: false,
-			agentKey
+			// Never expose the resolved key or service key to the client
+			agentKey: isEmbedTokenAuth ? undefined : agentKey,
 		};
 	} catch (err) {
 		if (err && typeof err === 'object' && 'status' in err) throw err;

--- a/apps/web-publish/src/routes/api/embed-token/+server.ts
+++ b/apps/web-publish/src/routes/api/embed-token/+server.ts
@@ -1,0 +1,67 @@
+/**
+ * GET /api/embed-token?slug=<share_slug>&path=<doc_path>
+ *
+ * Issues a short-lived (1h) signed embed URL for a private share doc.
+ * Caller must provide a valid agent key in the Authorization header.
+ *
+ * The returned embed_url uses ?embed_token=<token> instead of ?agent_key=<key>,
+ * so the long-lived key is never exposed to the browser.
+ *
+ * Required env vars:
+ *   EMBED_TOKEN_SECRET  — HMAC-SHA256 signing secret (≥32 bytes random)
+ *   PUBLIC_WEB_DOMAIN   — used to build the embed URL (e.g. docs.entire.vc)
+ */
+
+import { json, error } from '@sveltejs/kit';
+import { env } from '$env/dynamic/private';
+import { getShareBySlug } from '$lib/api';
+import { signEmbedToken } from '$lib/embed-token';
+import type { RequestHandler } from '@sveltejs/kit';
+
+const EMBED_TTL_SECONDS = 3600; // 1 hour
+
+export const GET: RequestHandler = async ({ url, request }) => {
+	const secret = env.EMBED_TOKEN_SECRET;
+	if (!secret || secret.length < 16) {
+		throw error(503, 'Embed token feature not configured');
+	}
+
+	const slug = url.searchParams.get('slug');
+	const path = url.searchParams.get('path') ?? '';
+
+	if (!slug) {
+		throw error(400, 'Missing required query param: slug');
+	}
+
+	// Validate caller's agent key
+	const authHeader = request.headers.get('authorization') ?? '';
+	const agentKey = authHeader.startsWith('Bearer ') ? authHeader.slice(7).trim() : '';
+	if (!agentKey) {
+		throw error(401, 'Authorization: Bearer <agent_key> required');
+	}
+
+	// Verify agent key is valid for this share by calling the control plane
+	let share;
+	try {
+		share = await getShareBySlug(slug, agentKey);
+	} catch {
+		throw error(401, 'Invalid agent key or share not found');
+	}
+
+	if (share.visibility !== 'private') {
+		// Non-private shares don't need token-based auth
+		throw error(400, 'Embed tokens are only for private shares');
+	}
+
+	// Issue token
+	const token = await signEmbedToken(slug, path, secret, EMBED_TTL_SECONDS);
+
+	const webDomain = env.PUBLIC_WEB_DOMAIN ?? url.host;
+	const protocol = webDomain.startsWith('localhost') ? 'http' : 'https';
+	const pathSegment = path ? `/${path}` : '';
+	const embedUrl = `${protocol}://${webDomain}/${slug}${pathSegment}?embed_token=${token}`;
+
+	const expiresAt = new Date(Date.now() + EMBED_TTL_SECONDS * 1000).toISOString();
+
+	return json({ embed_url: embedUrl, expires_at: expiresAt });
+};


### PR DESCRIPTION
## Что делает этот PR

Реализует D5-b из задачи [Mesh×TR Phase 4] — короткоживущие HMAC-подписанные токены для iframe-превью `relay://` документов.

Без этого Mesh передавал долгоживущий `agent_key` прямо в `src` iframe'а, где его видит браузер и DevTools. С токенами:
- Mesh вызывает `/api/embed-token` с `agent_key` в заголовке (сервер→сервер)
- web-publish возвращает `embed_url` с коротким токеном (1h, HMAC-SHA256)
- iframe открывается с `?embed_token=...` — ключ в браузер не попадает

## Изменения

### Новые файлы

- **`src/lib/embed-token.ts`** — HMAC-SHA256 sign/verify через Web Crypto API (без `node:crypto`, без импортов)
- **`src/routes/api/embed-token/+server.ts`** — GET-эндпоинт: проверяет agent_key через CP, выдаёт подписанный embed_url (TTL 1h)

### Изменённые файлы

- **`src/routes/[slug]/[...path]/+page.server.ts`** — принимает `?embed_token=`, верифицирует HMAC + slug, подставляет `WEB_PUBLISH_AGENT_KEY` для CP-вызовов на сервере; в клиент ключ не передаётся
- **`.env.example`** — документированы новые переменные окружения

## Новые env-переменные (нужно добавить в prod)

```
EMBED_TOKEN_SECRET=<openssl rand -hex 32>
WEB_PUBLISH_AGENT_KEY=<read-only agent key с CP>
WEB_FRAME_ANCESTORS=https://mesh.entire.host
```

## Связанные PRs

Парный PR в `evc-mesh`: изменение `tr_preview_url_handler.go` — вызывает `/api/embed-token` с fallback на legacy `?agent_key=` URL если эндпоинт недоступен.