### PR TITLE
fix(security): return 401 on invalid credentials for private web shares

### DIFF
--- a/apps/control-plane/app/api/routers/web.py
+++ b/apps/control-plane/app/api/routers/web.py
@@ -203,15 +203,24 @@ def get_share_by_slug(
             detail="Share not found or not published",
         )
 
-    # For PRIVATE shares: attempt auth; strip content if unauthenticated rather than 401-ing,
-    # so the SPA can render a proper "login required" prompt.
+    # For PRIVATE shares: attempt auth.
+    # - No credentials → 200 with content stripped so SPA can render a "login required" prompt.
+    # - Credentials present but invalid → re-raise 401 (don't silently expose metadata on failed auth).
     expose_content = True
     if share.visibility == models.ShareVisibility.PRIVATE:
+        has_credentials = bool(
+            request.headers.get("X-Agent-Key")
+            or request.query_params.get("agent_key")
+            or (request.headers.get("Authorization") or "").startswith("Bearer ")
+            or request.cookies.get("access_token")
+        )
         try:
             _require_private_web_auth(request, share, db)
             for header_name, header_value in _private_embed_headers(settings).items():
                 response.headers[header_name] = header_value
         except HTTPException:
+            if has_credentials:
+                raise  # invalid credentials → propagate 401
             expose_content = False
 
     # Parse folder items if present (only for authenticated PRIVATE or non-PRIVATE shares)

--- a/apps/control-plane/tests/test_web_publish.py
+++ b/apps/control-plane/tests/test_web_publish.py
@@ -758,6 +758,90 @@ class TestPrivateShareAuth:
         # The frontend then shows "login required" message
         assert response.status_code == 404
 
+    @pytest.fixture
+    def private_folder_share(self, db_session: Session, test_user: models.User) -> models.Share:
+        import json as _json
+        share = models.Share(
+            kind=models.ShareKind.FOLDER,
+            path="Private/Folder/",
+            visibility=models.ShareVisibility.PRIVATE,
+            owner_user_id=test_user.id,
+            web_published=True,
+            web_slug="private-folder-auth",
+            web_folder_items=[{"path": "note.md", "name": "note.md", "type": "doc"}],
+        )
+        db_session.add(share)
+        db_session.commit()
+        db_session.refresh(share)
+        return share
+
+    def _make_agent_key(self, db, share, scopes="read"):
+        import hashlib as _hl
+        import secrets as _sec
+        raw = "tr_agent_" + _sec.token_hex(24)
+        key_hash = _hl.sha256(raw.encode()).hexdigest()
+        ak = models.ShareAgentKey(
+            share_id=share.id, key_hash=key_hash, label="test-key", scopes=scopes
+        )
+        db.add(ak)
+        db.commit()
+        db.refresh(ak)
+        return raw, ak
+
+    def _web_settings(self):
+        return type("S", (), {"web_publish_enabled": True, "web_publish_domain": "docs.test.com",
+                               "web_frame_ancestors": None})()
+
+    def test_get_private_share_no_credentials_returns_200_stripped(
+        self, client: TestClient, private_folder_share: models.Share, monkeypatch
+    ):
+        """No credentials on PRIVATE share → 200 with web_folder_items=null (SPA shows login prompt)."""
+        monkeypatch.setattr("app.api.routers.web.get_settings", lambda: self._web_settings())
+        r = client.get(f"/v1/web/shares/{private_folder_share.web_slug}")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["visibility"] == "private"
+        assert data["web_folder_items"] is None
+
+    def test_get_private_share_invalid_agent_key_returns_401(
+        self, client: TestClient, private_folder_share: models.Share, monkeypatch
+    ):
+        """Invalid ?agent_key on PRIVATE share → 401 (not 200 with stripped content)."""
+        monkeypatch.setattr("app.api.routers.web.get_settings", lambda: self._web_settings())
+        r = client.get(
+            f"/v1/web/shares/{private_folder_share.web_slug}?agent_key=invalid_garbage_key"
+        )
+        assert r.status_code == 401
+
+    def test_get_private_share_invalid_bearer_returns_401(
+        self, client: TestClient, private_folder_share: models.Share, monkeypatch
+    ):
+        """Invalid Bearer token on PRIVATE share → 401."""
+        monkeypatch.setattr("app.api.routers.web.get_settings", lambda: self._web_settings())
+        r = client.get(
+            f"/v1/web/shares/{private_folder_share.web_slug}",
+            headers={"Authorization": "Bearer TOTALLY_FAKE_TOKEN"},
+        )
+        assert r.status_code == 401
+
+    def test_get_private_share_valid_agent_key_returns_200_with_content(
+        self,
+        client: TestClient,
+        db_session: Session,
+        private_folder_share: models.Share,
+        monkeypatch,
+    ):
+        """Valid agent_key on PRIVATE share → 200 with web_folder_items populated."""
+        monkeypatch.setattr("app.api.routers.web.get_settings", lambda: self._web_settings())
+        raw_key, _ = self._make_agent_key(db_session, private_folder_share, scopes="read")
+        r = client.get(
+            f"/v1/web/shares/{private_folder_share.web_slug}?agent_key={raw_key}"
+        )
+        assert r.status_code == 200
+        data = r.json()
+        assert data["web_folder_items"] is not None
+        assert len(data["web_folder_items"]) == 1
+
 
 class TestWebRelayToken:
     """Test web relay token endpoint for real-time sync."""


### PR DESCRIPTION
## Problem

`GET /v1/web/shares/<slug>?agent_key=<invalid>` returned **HTTP 200** with `web_folder_items=null` instead of 401. `get_share_by_slug` caught `HTTPException` from `_require_private_web_auth` unconditionally, always setting `expose_content=False` regardless of whether credentials were provided.

**Security impact:** `/api/embed-token` verifies auth by calling `getShareBySlug(slug, agentKey)`. If the CP returns 200 (rather than 401) for an invalid key, `getShareBySlug` doesn't throw — and embed-token issues a signed token for the invalid key.

## Fix

Distinguish two cases in `get_share_by_slug`:
- **No credentials** → 200 with stripped content (SPA shows login prompt) — behaviour preserved
- **Credentials present but invalid** → re-raise 401

```python
has_credentials = bool(
    request.headers.get("X-Agent-Key")
    or request.query_params.get("agent_key")
    or (request.headers.get("Authorization") or "").startswith("Bearer ")
    or request.cookies.get("access_token")
)
try:
    _require_private_web_auth(request, share, db)
    ...
except HTTPException:
    if has_credentials:
        raise  # invalid credentials → propagate 401
    expose_content = False
```

## Tests

4 new regression tests in `TestPrivateShareAuth`:
- no credentials → 200 stripped ✅
- invalid `agent_key` → 401 ✅
- invalid Bearer → 401 ✅
- valid `agent_key` → 200 with content ✅

85 tests pass, no regressions.

## Acceptance criteria

- `wget -qO- 'http://control-plane:8000/v1/web/shares/mesh?agent_key=invalid'` → 401
- `curl https://docs.entire.vc/api/embed-token?slug=mesh&path=REQUIREMENTS.md -H "Authorization: Bearer invalid_key"` → 401
- Valid key works without regressions