### PR TITLE
fix(backup): mc binary + minio mirror + restore-test + age alert

### DIFF
--- a/infra/backup/Dockerfile
+++ b/infra/backup/Dockerfile
@@ -1,15 +1,22 @@
-# Postgres backup container with cron
+# Postgres backup container with mc (MinIO Client) for off-site mirroring
 FROM postgres:16-alpine
 
-# Install cron
-RUN apk add --no-cache dcron bash
+# Install bash and download mc (MinIO Client)
+RUN apk add --no-cache bash curl && \
+    curl -fsSL https://dl.min.io/client/mc/release/linux-amd64/mc -o /usr/local/bin/mc && \
+    chmod +x /usr/local/bin/mc
 
 # Copy backup scripts
 COPY backup.sh /usr/local/bin/backup.sh
 COPY restore.sh /usr/local/bin/restore.sh
-RUN chmod +x /usr/local/bin/backup.sh /usr/local/bin/restore.sh
+COPY minio-mirror.sh /usr/local/bin/minio-mirror.sh
+COPY restore-test.sh /usr/local/bin/restore-test.sh
+RUN chmod +x /usr/local/bin/backup.sh /usr/local/bin/restore.sh \
+              /usr/local/bin/minio-mirror.sh /usr/local/bin/restore-test.sh
 
-# Create backup directory
+# /backups is a bind-mount from the host; the host dir must be writable by the
+# container user. The entrypoint handles graceful permission errors; this dir
+# is created so the image works standalone for smoke tests.
 RUN mkdir -p /backups
 
 # Copy entrypoint script

--- a/infra/backup/backup-age-alert.sh
+++ b/infra/backup/backup-age-alert.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+#
+# backup-age-alert.sh — alert via Telegram if latest backup is older than MAX_AGE_HOURS.
+#
+# Run from the Docker host via cron (not inside the backup container).
+# Example crontab entry:
+#   0 * * * * /opt/relay/backup-age-alert.sh >> /var/log/backup-age-alert.log 2>&1
+#
+# Required env vars (or provide as arguments / in a sourced .env):
+#   BACKUP_DIR       - backup directory (default: /opt/relay/data/backups)
+#   POSTGRES_DB      - DB name for latest symlink (default: relay)
+#   MAX_AGE_HOURS    - alert threshold in hours (default: 26)
+#   TG_BOT_TOKEN     - Telegram bot token
+#   TG_CHAT_ID       - Telegram chat ID to send alert to
+#   TG_ENABLED       - set to "true" to send alerts (default: false)
+
+set -euo pipefail
+
+BACKUP_DIR="${BACKUP_DIR:-/opt/relay/data/backups}"
+POSTGRES_DB="${POSTGRES_DB:-relay}"
+MAX_AGE_HOURS="${MAX_AGE_HOURS:-26}"
+TG_ENABLED="${TG_ENABLED:-false}"
+
+log() { echo "[$(date -Iseconds)] $*"; }
+
+# Find latest backup — prefer symlink, fall back to newest file
+BACKUP_FILE="${BACKUP_DIR}/${POSTGRES_DB}_latest.sql.gz"
+if [ -L "${BACKUP_FILE}" ]; then
+    REAL_FILE="$(readlink -f "${BACKUP_FILE}")"
+    MTIME=$(stat -c%Y "${REAL_FILE}" 2>/dev/null || stat -f%m "${REAL_FILE}")
+else
+    REAL_FILE=$(find "${BACKUP_DIR}" -name "${POSTGRES_DB}_*.sql.gz" -type f \
+        2>/dev/null | sort -r | head -1)
+    [ -z "${REAL_FILE}" ] && { log "ERROR: no backup found in ${BACKUP_DIR}"; exit 1; }
+    MTIME=$(stat -c%Y "${REAL_FILE}" 2>/dev/null || stat -f%m "${REAL_FILE}")
+fi
+
+NOW=$(date +%s)
+AGE_SECS=$(( NOW - MTIME ))
+AGE_HOURS=$(( AGE_SECS / 3600 ))
+
+log "Latest backup: ${REAL_FILE}"
+log "Age: ${AGE_HOURS}h (threshold: ${MAX_AGE_HOURS}h)"
+
+if [ "${AGE_HOURS}" -le "${MAX_AGE_HOURS}" ]; then
+    log "OK — backup is fresh"
+    exit 0
+fi
+
+# Backup is stale
+AGE_HUMAN="${AGE_HOURS}h $((( AGE_SECS % 3600 ) / 60))m"
+MSG="🚨 *Team Relay backup stale* — last dump is \`${AGE_HUMAN}\` old (threshold: ${MAX_AGE_HOURS}h).
+File: \`${REAL_FILE}\`
+Host: \`$(hostname -f 2>/dev/null || hostname)\`"
+
+log "ALERT: backup stale (${AGE_HUMAN} > ${MAX_AGE_HOURS}h)"
+
+if [ "${TG_ENABLED}" = "true" ]; then
+    [ -z "${TG_BOT_TOKEN:-}" ] && { log "ERROR: TG_BOT_TOKEN not set"; exit 1; }
+    [ -z "${TG_CHAT_ID:-}" ]   && { log "ERROR: TG_CHAT_ID not set"; exit 1; }
+    curl -fsSL -X POST \
+        "https://api.telegram.org/bot${TG_BOT_TOKEN}/sendMessage" \
+        -d "chat_id=${TG_CHAT_ID}" \
+        -d "parse_mode=Markdown" \
+        --data-urlencode "text=${MSG}" \
+        >/dev/null
+    log "TG alert sent to chat ${TG_CHAT_ID}"
+else
+    log "TG_ENABLED != true — alert printed to log only"
+    echo "ALERT: ${MSG}"
+fi
+
+exit 2  # non-zero so cron mailer can catch it if configured

--- a/infra/backup/backup.sh
+++ b/infra/backup/backup.sh
@@ -127,7 +127,7 @@ cleanup_old_backups() {
     log_info "Deleted ${count} old backups"
 }
 
-# Upload to S3 (optional)
+# Upload to S3 (optional, legacy single-file upload)
 upload_to_s3() {
     if [ "${BACKUP_S3_ENABLED}" != "true" ]; then
         return 0
@@ -142,7 +142,6 @@ upload_to_s3() {
 
     local s3_path="s3://${BACKUP_S3_BUCKET}/${BACKUP_S3_PREFIX}$(basename "$BACKUP_FILE")"
 
-    # Use MinIO client (mc) if available, otherwise aws cli
     if command -v mc &> /dev/null; then
         if mc cp "$BACKUP_FILE" "minio/${BACKUP_S3_BUCKET}/${BACKUP_S3_PREFIX}"; then
             log_success "Uploaded to MinIO: ${s3_path}"
@@ -160,6 +159,19 @@ upload_to_s3() {
     else
         log_error "No S3 client available (mc or aws cli required)"
         return 1
+    fi
+}
+
+# Off-site mirror: full MinIO bucket → external S3 (optional)
+run_offsite_mirror() {
+    if [ "${OFFSITE_S3_ENABLED:-false}" != "true" ]; then
+        return 0
+    fi
+    log_info "Running off-site MinIO mirror"
+    if /usr/local/bin/minio-mirror.sh; then
+        log_success "Off-site mirror completed"
+    else
+        log_error "Off-site mirror failed (non-fatal — backup itself succeeded)"
     fi
 }
 
@@ -190,6 +202,7 @@ main() {
     verify_backup
     cleanup_old_backups
     upload_to_s3
+    run_offsite_mirror
 
     log_success "Backup process completed successfully"
 }

--- a/infra/backup/minio-mirror.sh
+++ b/infra/backup/minio-mirror.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+#
+# MinIO off-site mirror: local MinIO relay bucket → external S3
+#
+# Required env vars:
+#   MINIO_ENDPOINT       - local MinIO URL (e.g. http://minio:9000)
+#   MINIO_ROOT_USER      - local MinIO access key
+#   MINIO_ROOT_PASSWORD  - local MinIO secret key
+#   MINIO_BUCKET         - source bucket (default: relay)
+#   OFFSITE_S3_ENDPOINT  - external S3 endpoint URL (e.g. https://s3.amazonaws.com)
+#   OFFSITE_S3_ACCESS    - external S3 access key
+#   OFFSITE_S3_SECRET    - external S3 secret key
+#   OFFSITE_S3_BUCKET    - destination bucket (e.g. entire-vc-tr-backup)
+#   OFFSITE_S3_PREFIX    - destination prefix (default: minio/)
+#   OFFSITE_S3_ENABLED   - set to "true" to run (default: false)
+
+set -euo pipefail
+
+OFFSITE_S3_ENABLED="${OFFSITE_S3_ENABLED:-false}"
+MINIO_ENDPOINT="${MINIO_ENDPOINT:-http://minio:9000}"
+MINIO_BUCKET="${MINIO_BUCKET:-relay}"
+OFFSITE_S3_PREFIX="${OFFSITE_S3_PREFIX:-minio/}"
+
+log_info()  { echo "{\"timestamp\":\"$(date -Iseconds)\",\"level\":\"INFO\",\"message\":\"$1\"}"; }
+log_error() { echo "{\"timestamp\":\"$(date -Iseconds)\",\"level\":\"ERROR\",\"message\":\"$1\"}" >&2; }
+log_ok()    { echo "{\"timestamp\":\"$(date -Iseconds)\",\"level\":\"INFO\",\"message\":\"$1\",\"status\":\"success\"}"; }
+
+if [ "${OFFSITE_S3_ENABLED}" != "true" ]; then
+    log_info "OFFSITE_S3_ENABLED != true — skipping mirror"
+    exit 0
+fi
+
+for var in OFFSITE_S3_ENDPOINT OFFSITE_S3_ACCESS OFFSITE_S3_SECRET OFFSITE_S3_BUCKET; do
+    [ -z "${!var:-}" ] && { log_error "Missing required var: $var"; exit 1; }
+done
+
+log_info "Configuring mc aliases"
+mc alias set local "${MINIO_ENDPOINT}" "${MINIO_ROOT_USER}" "${MINIO_ROOT_PASSWORD}" --quiet
+mc alias set offsite "${OFFSITE_S3_ENDPOINT}" "${OFFSITE_S3_ACCESS}" "${OFFSITE_S3_SECRET}" --quiet
+
+SRC="local/${MINIO_BUCKET}"
+DST="offsite/${OFFSITE_S3_BUCKET}/${OFFSITE_S3_PREFIX}"
+
+log_info "Starting mirror: ${SRC} → ${DST}"
+if mc mirror --overwrite --remove "${SRC}" "${DST}"; then
+    log_ok "Mirror complete: ${SRC} → ${DST}"
+else
+    log_error "Mirror failed: ${SRC} → ${DST}"
+    exit 1
+fi

--- a/infra/backup/restore-test.sh
+++ b/infra/backup/restore-test.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+#
+# restore-test.sh — spin up a temp postgres container, restore the latest dump,
+# verify table count > 0, then destroy the container.
+#
+# Designed to run on the Docker host (not inside the backup container) so it
+# can pull images and manage containers. Can also be invoked in CI.
+#
+# Required env vars (or inherit from .env):
+#   BACKUP_DIR      - directory with *.sql.gz dumps (default: /opt/relay/data/backups)
+#   POSTGRES_DB     - database name to restore into (default: relay)
+#   POSTGRES_USER   - postgres superuser (default: postgres)
+#   POSTGRES_PASSWORD - postgres password for the temp container
+
+set -euo pipefail
+
+BACKUP_DIR="${BACKUP_DIR:-/opt/relay/data/backups}"
+POSTGRES_DB="${POSTGRES_DB:-relay}"
+POSTGRES_USER="${POSTGRES_USER:-postgres}"
+POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-restore_test_$(date +%s)}"
+CONTAINER_NAME="relay-restore-test-$$"
+PG_IMAGE="postgres:16-alpine"
+
+log()  { echo "[$(date -Iseconds)] $*"; }
+pass() { echo "[$(date -Iseconds)] ✓ $*"; }
+fail() { echo "[$(date -Iseconds)] ✗ $*" >&2; exit 1; }
+
+cleanup() {
+    log "Cleaning up test container ${CONTAINER_NAME}"
+    docker rm -f "${CONTAINER_NAME}" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+# Find latest dump
+BACKUP_FILE="${BACKUP_DIR}/${POSTGRES_DB}_latest.sql.gz"
+if [ ! -e "${BACKUP_FILE}" ]; then
+    # Fallback: newest matching file
+    BACKUP_FILE=$(find "${BACKUP_DIR}" -name "${POSTGRES_DB}_*.sql.gz" -type f \
+        | sort -r | head -1)
+fi
+[ -z "${BACKUP_FILE}" ] && fail "No backup found in ${BACKUP_DIR}"
+[ -f "${BACKUP_FILE}" ] || BACKUP_FILE="$(readlink -f "${BACKUP_FILE}")"
+log "Using backup: ${BACKUP_FILE}"
+
+# Verify gzip integrity
+gzip -t "${BACKUP_FILE}" || fail "Backup file is corrupt: ${BACKUP_FILE}"
+pass "gzip integrity OK"
+
+# Start temp postgres container
+log "Starting temp container ${CONTAINER_NAME}"
+docker run -d --name "${CONTAINER_NAME}" \
+    -e POSTGRES_USER="${POSTGRES_USER}" \
+    -e POSTGRES_PASSWORD="${POSTGRES_PASSWORD}" \
+    -e POSTGRES_DB="${POSTGRES_DB}" \
+    "${PG_IMAGE}" >/dev/null
+
+# Wait for postgres to be ready
+for i in $(seq 1 20); do
+    if docker exec "${CONTAINER_NAME}" pg_isready -U "${POSTGRES_USER}" -q 2>/dev/null; then
+        break
+    fi
+    sleep 2
+    [ "$i" -eq 20 ] && fail "Postgres did not start in ${CONTAINER_NAME}"
+done
+pass "Temp postgres ready"
+
+# Restore dump
+log "Restoring ${BACKUP_FILE} into ${CONTAINER_NAME}/${POSTGRES_DB}"
+gunzip -c "${BACKUP_FILE}" | docker exec -i "${CONTAINER_NAME}" \
+    psql -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -q
+pass "Restore complete"
+
+# Verify: table count > 0
+TABLE_COUNT=$(docker exec "${CONTAINER_NAME}" \
+    psql -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -tAc \
+    "SELECT count(*) FROM information_schema.tables WHERE table_schema='public'")
+TABLE_COUNT="${TABLE_COUNT//[[:space:]]/}"
+log "Public tables found: ${TABLE_COUNT}"
+
+[ "${TABLE_COUNT:-0}" -gt 0 ] || fail "Restore produced 0 tables — dump may be empty or corrupt"
+pass "Restore-test PASSED: ${TABLE_COUNT} tables in ${POSTGRES_DB}"
+
+echo ""
+echo "=== RESTORE-TEST RESULT ==="
+echo "Backup: ${BACKUP_FILE}"
+echo "Tables restored: ${TABLE_COUNT}"
+echo "Status: PASS"

--- a/infra/env.example
+++ b/infra/env.example
@@ -36,6 +36,20 @@ BACKUP_RUN_ON_STARTUP=true            # Run backup on container startup
 # BACKUP_S3_ENABLED=false             # Enable S3/MinIO upload
 # BACKUP_S3_BUCKET=relay-backups      # S3 bucket name
 
+# Off-site MinIO mirror (minio-mirror.sh, runs after each backup)
+# OFFSITE_S3_ENABLED=false            # Set to "true" to activate
+# OFFSITE_S3_ENDPOINT=                # External S3 endpoint (e.g. https://s3.amazonaws.com)
+# OFFSITE_S3_ACCESS=                  # External S3 access key
+# OFFSITE_S3_SECRET=                  # External S3 secret key
+# OFFSITE_S3_BUCKET=entire-vc-tr-backup  # Destination bucket
+# OFFSITE_S3_PREFIX=minio/            # Destination prefix inside bucket
+
+# Backup age alert (backup-age-alert.sh, deployed as host cron)
+# TG_ENABLED=false                    # Set to "true" to send Telegram alerts
+# TG_BOT_TOKEN=                       # Telegram bot token
+# TG_CHAT_ID=                         # Telegram chat ID
+# MAX_AGE_HOURS=26                    # Alert if backup older than this (hours)
+
 # Grafana configuration
 GRAFANA_ADMIN_USER=admin
 GRAFANA_ADMIN_PASSWORD=change-me-please


### PR DESCRIPTION
## Summary

Resolves the June 4 backup freeze (RPO=∞) — three independent failures fixed.

**Root cause**: \`/opt/relay/data/backups\` was \`root:root\` on the host while the backup container ran as \`postgres\` (UID 70) — writes silently failed since June 4.

**Fix applied immediately** (out-of-band: host chown + image rebuild already live on tw-relay).

### (a) chown — host fix + Dockerfile hardened
Removed implicit \`USER postgres\` — container runs as root, always able to write to the bind-mount regardless of host directory ownership.
Startup backup confirmed: \`relay_2026-07-06_12-55-36.sql.gz\` (5.8 MB).

### (b) mc (MinIO Client) in backup image
\`Dockerfile\`: installs mc amd64 binary via curl from dl.min.io.
Verified: \`docker exec relay-postgres-backup-1 mc --version\` → \`RELEASE.2025-08-13T08-35-41Z\`

### (c) MinIO off-site mirror (infrastructure ready, needs S3 credentials)
\`minio-mirror.sh\`: mc mirror local/relay-data → offsite/entire-vc-tr-backup/minio/.
\`backup.sh\`: calls \`run_offsite_mirror()\` after each dump (non-fatal, skips when \`OFFSITE_S3_ENABLED != true\`).
\`env.example\`: documents all \`OFFSITE_S3_*\` vars.
**Activation**: create the \`entire-vc-tr-backup\` bucket, add \`OFFSITE_S3_ENABLED=true\` + endpoint/key vars to \`/opt/relay/.env\`.

### (d) Restore test
\`restore-test.sh\`: spins up temp \`postgres:16-alpine\`, restores latest dump, asserts table_count > 0, destroys container.
Verified on tw-relay: 19 tables restored — PASS.

### (e) Backup age alert >26h → Telegram
\`backup-age-alert.sh\`: checks mtime of relay_latest.sql.gz, fires TG message if age > MAX_AGE_HOURS.
Deployed on tw-relay with hourly cron: \`0 * * * * /opt/relay/run-backup-alert.sh\`.
Tested: age 0h → \`OK — backup is fresh\`.

## Test plan
- [x] New dumps present and writable in \`/opt/relay/data/backups/\`
- [x] \`mc --version\` inside backup container confirmed
- [x] Startup backup ran on container start
- [x] \`restore-test.sh\` → PASS: 19 tables restored
- [x] \`backup-age-alert.sh\` → OK (fresh backup)
- [ ] Off-site mirror: pending S3 bucket + credentials