### PR TITLE
security(H1): make RELAY_PRIVATE_KEY required at startup

### DIFF
--- a/apps/control-plane/app/core/security.py
+++ b/apps/control-plane/app/core/security.py
@@ -100,11 +100,10 @@ def load_or_generate_relay_keypair(
     private_key_str = settings.relay_private_key
     if not private_key_str.startswith("-----BEGIN"):
         import base64 as b64
+
         private_key_str = b64.b64decode(private_key_str).decode("utf-8")
 
-    private_key = serialization.load_pem_private_key(
-        private_key_str.encode("utf-8"), password=None
-    )
+    private_key = serialization.load_pem_private_key(private_key_str.encode("utf-8"), password=None)
     public_bytes = private_key.public_key().public_bytes(
         encoding=serialization.Encoding.Raw, format=serialization.PublicFormat.Raw
     )

--- a/apps/control-plane/app/core/security.py
+++ b/apps/control-plane/app/core/security.py
@@ -89,41 +89,27 @@ def load_or_generate_relay_keypair(
     Returns:
         tuple: (private_key_object, public_key_base64, key_id)
     """
-    if settings.relay_private_key:
-        # Load existing private key from PEM
-        # Support both base64-encoded (from .env) and PEM format
-        private_key_str = settings.relay_private_key
-        if not private_key_str.startswith("-----BEGIN"):
-            # Base64-encoded - decode to PEM
-            import base64 as b64
-
-            private_key_str = b64.b64decode(private_key_str).decode("utf-8")
-
-        private_key = serialization.load_pem_private_key(
-            private_key_str.encode("utf-8"), password=None
+    if not settings.relay_private_key:
+        raise RuntimeError(
+            "RELAY_PRIVATE_KEY is required but not set. "
+            "Generate an Ed25519 key and set the RELAY_PRIVATE_KEY environment variable "
+            "(Base64-encoded PEM). See docs/setup.md for instructions."
         )
-        public_bytes = private_key.public_key().public_bytes(
-            encoding=serialization.Encoding.Raw, format=serialization.PublicFormat.Raw
-        )
-        public_base64 = base64.b64encode(public_bytes).decode("utf-8")
-        key_id = settings.relay_key_id
-    else:
-        # Generate new keypair on first run
-        private_pem, public_base64 = generate_ed25519_keypair()
-        private_key = serialization.load_pem_private_key(private_pem.encode("utf-8"), password=None)
-        key_id = f"relay_cp_{datetime.now(timezone.utc).strftime('%Y_%m_%d')}"
 
-        # Log for operator to save (not logging private key for security)
-        logger.warning(
-            f"Generated new Ed25519 keypair:\n"
-            f"Key ID: {key_id}\n"
-            f"Public Key: {public_base64}\n"
-            f"Add to relay.toml:\n"
-            f"[[auth]]\n"
-            f'key_id = "{key_id}"\n'
-            f'public_key = "{public_base64}"\n\n'
-            f"To persist, set RELAY_PRIVATE_KEY and RELAY_KEY_ID environment variables"
-        )
+    # Load private key — supports both Base64-encoded (from .env) and raw PEM formats
+    private_key_str = settings.relay_private_key
+    if not private_key_str.startswith("-----BEGIN"):
+        import base64 as b64
+        private_key_str = b64.b64decode(private_key_str).decode("utf-8")
+
+    private_key = serialization.load_pem_private_key(
+        private_key_str.encode("utf-8"), password=None
+    )
+    public_bytes = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.Raw, format=serialization.PublicFormat.Raw
+    )
+    public_base64 = base64.b64encode(public_bytes).decode("utf-8")
+    key_id = settings.relay_key_id
 
     return (private_key, public_base64, key_id)
 

--- a/apps/control-plane/tests/conftest.py
+++ b/apps/control-plane/tests/conftest.py
@@ -14,6 +14,7 @@ if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 from app.core.config import get_settings
+from app.core.security import generate_ed25519_keypair
 from app.db import session as session_module
 from app.db.models import Base
 from app.main import build_app
@@ -32,6 +33,10 @@ def test_env():
     os.environ["BOOTSTRAP_ADMIN_EMAIL"] = "bootstrap@example.com"
     os.environ["BOOTSTRAP_ADMIN_PASSWORD"] = "super-secret"
     os.environ["RELAY_PUBLIC_URL"] = "wss://relay.test"
+    # RELAY_PRIVATE_KEY is required at startup (fail-closed, no ephemeral fallback) —
+    # seed a throwaway keypair so the app lifespan can boot in tests.
+    private_pem, _public_b64 = generate_ed25519_keypair()
+    os.environ["RELAY_PRIVATE_KEY"] = private_pem
 
     get_settings.cache_clear()
     yield

--- a/apps/control-plane/tests/test_cwt_tokens.py
+++ b/apps/control-plane/tests/test_cwt_tokens.py
@@ -79,18 +79,15 @@ class TestEd25519Keypair:
         _, pub2 = generate_ed25519_keypair()
         assert pub1 != pub2
 
-    def test_load_or_generate_without_existing_key(self):
-        """When no private key is set, generates a new keypair."""
+    def test_load_or_generate_without_existing_key_fails_closed(self):
+        """When no private key is set, startup must fail closed — no ephemeral fallback."""
 
         class FakeSettings:
             relay_private_key = None
             relay_key_id = "test_key"
 
-        private_key, public_b64, key_id = load_or_generate_relay_keypair(FakeSettings())
-
-        assert isinstance(private_key, ed25519.Ed25519PrivateKey)
-        assert len(base64.b64decode(public_b64)) == 32
-        assert key_id.startswith("relay_cp_")
+        with pytest.raises(RuntimeError, match="RELAY_PRIVATE_KEY is required"):
+            load_or_generate_relay_keypair(FakeSettings())
 
     def test_load_or_generate_with_pem_key(self):
         """When PEM private key is provided, loads it correctly."""

--- a/infra/env.example
+++ b/infra/env.example
@@ -18,8 +18,8 @@ BOOTSTRAP_ADMIN_PASSWORD=super-secret-pass
 
 # Relay server
 RELAY_PUBLIC_URL=wss://${DOMAIN_BASE}/doc/ws
-# RELAY_KEY_ID=relay_cp_01              # Optional, auto-generated if not set
-# RELAY_PRIVATE_KEY=                     # Base64-encoded Ed25519 PEM, auto-generated if not set
+# RELAY_KEY_ID=relay_cp_01              # Optional, defaults to 'relay_cp_dev' if not set
+RELAY_PRIVATE_KEY=                       # REQUIRED — Base64-encoded Ed25519 PEM private key
 
 # Server identity (for multi-server plugin support)
 SERVER_NAME=My Relay Server


### PR DESCRIPTION
## Summary

- **H1 fail-closed**: Removes the ephemeral key auto-generation fallback from `load_or_generate_relay_keypair`. If `RELAY_PRIVATE_KEY` is not set, a `RuntimeError` is raised at startup and the service does not start.
- `env.example` updated: `RELAY_PRIVATE_KEY` marked as **REQUIRED** (was commented out as optional).

## Why

An ephemeral key regenerated on each restart means the relay-server's `[[auth]]` public key list becomes stale silently — existing relay tokens issued by the previous key stop working, and operators have no way to rotate keys predictably. The previous fallback also makes key injection from secrets management optional in practice, weakening the security posture.

## Test plan

- [ ] Deploy with `RELAY_PRIVATE_KEY` unset → service refuses to start with clear error message
- [ ] Deploy with `RELAY_PRIVATE_KEY` set (Base64 Ed25519 PEM) → service starts normally
- [ ] Existing relay token issuance endpoints continue to work