### PR TITLE
security(H4-H5): CORS allowlist + OAuth HMAC-state signing

### DIFF
--- a/apps/control-plane/app/core/config.py
+++ b/apps/control-plane/app/core/config.py
@@ -34,6 +34,15 @@ class Settings(BaseSettings):
     relay_public_url: AnyUrl = Field(default="wss://relay.localhost")
     relay_token_ttl_minutes: int = Field(default=30)
 
+    # CORS settings
+    cors_allowed_origins: str = Field(
+        default="https://cp.tr.entire.vc",
+        description=(
+            "Comma-separated list of allowed CORS origins. "
+            "Set to '*' only for local development (never in production)."
+        ),
+    )
+
     # Relay Ed25519 authentication
     relay_private_key: str | None = Field(
         default=None, description="Ed25519 private key in PEM format for signing relay tokens"
@@ -44,6 +53,14 @@ class Settings(BaseSettings):
     bootstrap_admin_password: str | None = Field(default=None)
 
     # OAuth/OIDC settings (simple single provider via env vars)
+    oauth_state_secret: str | None = Field(
+        default=None,
+        description=(
+            "HMAC-SHA256 secret for signing OAuth state parameters. "
+            "Required when oauth_enabled=True. "
+            "Generate with: python -c \"import secrets; print(secrets.token_hex(32))\""
+        ),
+    )
     oauth_enabled: bool = Field(default=False, description="Enable OAuth authentication")
     oauth_provider_name: str = Field(
         default="casdoor", description="OAuth provider name (e.g., 'casdoor', 'keycloak')"

--- a/apps/control-plane/app/core/config.py
+++ b/apps/control-plane/app/core/config.py
@@ -58,7 +58,7 @@ class Settings(BaseSettings):
         description=(
             "HMAC-SHA256 secret for signing OAuth state parameters. "
             "Required when oauth_enabled=True. "
-            "Generate with: python -c \"import secrets; print(secrets.token_hex(32))\""
+            'Generate with: python -c "import secrets; print(secrets.token_hex(32))"'
         ),
     )
     oauth_enabled: bool = Field(default=False, description="Enable OAuth authentication")

--- a/apps/control-plane/app/main.py
+++ b/apps/control-plane/app/main.py
@@ -233,7 +233,7 @@ Get a token by calling `POST /auth/login` with valid credentials.
         if settings.oauth_enabled and not settings.oauth_state_secret:
             raise ValueError(
                 "OAUTH_STATE_SECRET is required when OAuth is enabled. "
-                "Generate with: python -c \"import secrets; print(secrets.token_hex(32))\""
+                'Generate with: python -c "import secrets; print(secrets.token_hex(32))"'
             )
 
     @app.on_event("startup")

--- a/apps/control-plane/app/main.py
+++ b/apps/control-plane/app/main.py
@@ -120,9 +120,10 @@ Get a token by calling `POST /auth/login` with valid credentials.
     # Add middlewares (order matters - first added = outermost)
     app.add_middleware(PrometheusMiddleware)  # Metrics collection
     app.add_middleware(logging.RequestLoggingMiddleware)
+    cors_origins = [o.strip() for o in settings.cors_allowed_origins.split(",") if o.strip()]
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=["*"],
+        allow_origins=cors_origins,
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],
@@ -223,6 +224,16 @@ Get a token by calling `POST /auth/login` with valid credentials.
                 settings.oauth_scopes,
                 settings.oauth_auto_register,
                 settings.oauth_admin_groups,
+            )
+
+    @app.on_event("startup")
+    def _validate_oauth_state_secret() -> None:
+        """Require OAUTH_STATE_SECRET when OAuth is enabled."""
+        settings = get_settings()
+        if settings.oauth_enabled and not settings.oauth_state_secret:
+            raise ValueError(
+                "OAUTH_STATE_SECRET is required when OAuth is enabled. "
+                "Generate with: python -c \"import secrets; print(secrets.token_hex(32))\""
             )
 
     @app.on_event("startup")

--- a/apps/control-plane/app/services/oauth_service.py
+++ b/apps/control-plane/app/services/oauth_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import base64
 import hashlib
+import hmac
 import secrets
 import uuid
 from typing import Any
@@ -30,17 +31,49 @@ def generate_code_challenge(code_verifier: str) -> str:
     return base64.urlsafe_b64encode(digest).decode("utf-8").rstrip("=")
 
 
+_STATE_HMAC_SEP = "."
+
+
+def _compute_state_hmac(payload_b64: str, secret: str) -> str:
+    """Return HMAC-SHA256 hex digest for a base64-encoded state payload.
+
+    Uses constant-time comparison in decode_state to prevent timing attacks.
+    The separator '.' is safe because urlsafe_b64 only uses A-Z a-z 0-9 - _.
+    """
+    return hmac.new(
+        secret.encode("utf-8"), payload_b64.encode("utf-8"), hashlib.sha256
+    ).hexdigest()
+
+
 def encode_state(state_data: oauth_schema.OAuthStateData) -> str:
-    """Encode state data as base64 JSON (not encrypted, just encoded)."""
-    json_str = state_data.model_dump_json()
-    return base64.urlsafe_b64encode(json_str.encode("utf-8")).decode("utf-8")
+    """Encode state data as base64 JSON, appending an HMAC-SHA256 signature when configured."""
+    settings = get_settings()
+    payload_b64 = base64.urlsafe_b64encode(
+        state_data.model_dump_json().encode("utf-8")
+    ).decode("utf-8")
+    if settings.oauth_state_secret:
+        sig = _compute_state_hmac(payload_b64, settings.oauth_state_secret)
+        return f"{payload_b64}{_STATE_HMAC_SEP}{sig}"
+    return payload_b64
 
 
 def decode_state(state: str) -> oauth_schema.OAuthStateData:
-    """Decode state data from base64 JSON."""
+    """Decode and verify state data. Rejects unsigned or tampered state when HMAC is configured."""
+    settings = get_settings()
     try:
-        json_str = base64.urlsafe_b64decode(state.encode("utf-8")).decode("utf-8")
+        if settings.oauth_state_secret:
+            if _STATE_HMAC_SEP not in state:
+                raise ValueError("Missing HMAC signature in state parameter")
+            payload_b64, received_sig = state.rsplit(_STATE_HMAC_SEP, 1)
+            expected_sig = _compute_state_hmac(payload_b64, settings.oauth_state_secret)
+            if not hmac.compare_digest(received_sig, expected_sig):
+                raise ValueError("State HMAC signature mismatch — possible CSRF attempt")
+        else:
+            payload_b64 = state
+        json_str = base64.urlsafe_b64decode(payload_b64.encode("utf-8")).decode("utf-8")
         return oauth_schema.OAuthStateData.model_validate_json(json_str)
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/apps/control-plane/app/services/oauth_service.py
+++ b/apps/control-plane/app/services/oauth_service.py
@@ -40,17 +40,15 @@ def _compute_state_hmac(payload_b64: str, secret: str) -> str:
     Uses constant-time comparison in decode_state to prevent timing attacks.
     The separator '.' is safe because urlsafe_b64 only uses A-Z a-z 0-9 - _.
     """
-    return hmac.new(
-        secret.encode("utf-8"), payload_b64.encode("utf-8"), hashlib.sha256
-    ).hexdigest()
+    return hmac.new(secret.encode("utf-8"), payload_b64.encode("utf-8"), hashlib.sha256).hexdigest()
 
 
 def encode_state(state_data: oauth_schema.OAuthStateData) -> str:
     """Encode state data as base64 JSON, appending an HMAC-SHA256 signature when configured."""
     settings = get_settings()
-    payload_b64 = base64.urlsafe_b64encode(
-        state_data.model_dump_json().encode("utf-8")
-    ).decode("utf-8")
+    payload_b64 = base64.urlsafe_b64encode(state_data.model_dump_json().encode("utf-8")).decode(
+        "utf-8"
+    )
     if settings.oauth_state_secret:
         sig = _compute_state_hmac(payload_b64, settings.oauth_state_secret)
         return f"{payload_b64}{_STATE_HMAC_SEP}{sig}"

--- a/apps/control-plane/tests/test_oauth.py
+++ b/apps/control-plane/tests/test_oauth.py
@@ -450,6 +450,7 @@ class TestOAuthEndpoints:
                 oauth_client_secret="test_secret",
                 oauth_auto_register=True,
                 oauth_scopes="openid profile email",
+                oauth_state_secret=None,
             )
 
             # Test with 127.0.0.1
@@ -806,3 +807,129 @@ class TestOAuthGroupMapping:
             # Only exact match or org/exact_match should work
             assert oauth_service.should_be_admin(["admin"]) is True
             assert oauth_service.should_be_admin(["org/admin"]) is True
+
+
+class TestOAuthHmacState:
+    """Tests for H5 — OAuth state HMAC signing (login-CSRF prevention)."""
+
+    def test_encode_decode_state_with_hmac(self):
+        """encode_state + decode_state round-trip when OAUTH_STATE_SECRET is set."""
+        from app.schemas.oauth import OAuthStateData
+
+        state_data = OAuthStateData(
+            code_verifier="test_verifier",
+            redirect_uri="https://example.com/callback",
+        )
+
+        with patch("app.services.oauth_service.get_settings") as mock_settings:
+            mock_settings.return_value = MagicMock(oauth_state_secret="testsecret32bytes00000000000000x")
+            encoded = oauth_service.encode_state(state_data)
+            # Signed state must contain separator
+            assert "." in encoded, "HMAC-signed state must contain a separator"
+            decoded = oauth_service.decode_state(encoded)
+
+        assert decoded.code_verifier == state_data.code_verifier
+        assert decoded.redirect_uri == state_data.redirect_uri
+
+    def test_decode_state_rejects_tampered_payload(self):
+        """State with a valid signature but altered payload must be rejected (400)."""
+        from app.schemas.oauth import OAuthStateData
+        from fastapi import HTTPException
+
+        state_data = OAuthStateData(
+            code_verifier="test_verifier",
+            redirect_uri="https://example.com/callback",
+        )
+
+        with patch("app.services.oauth_service.get_settings") as mock_settings:
+            mock_settings.return_value = MagicMock(oauth_state_secret="testsecret32bytes00000000000000x")
+            encoded = oauth_service.encode_state(state_data)
+            payload_b64, sig = encoded.rsplit(".", 1)
+            # Replace payload with a different one (attacker's state) but keep original sig
+            import base64, json
+            evil_payload = base64.urlsafe_b64encode(
+                json.dumps({"code_verifier": "evil", "redirect_uri": "https://attacker.com"}).encode()
+            ).decode()
+            tampered = f"{evil_payload}.{sig}"
+
+        with patch("app.services.oauth_service.get_settings") as mock_settings:
+            mock_settings.return_value = MagicMock(oauth_state_secret="testsecret32bytes00000000000000x")
+            with pytest.raises(HTTPException) as exc_info:
+                oauth_service.decode_state(tampered)
+
+        assert exc_info.value.status_code == 400
+        assert "Invalid state parameter" in exc_info.value.detail
+
+    def test_decode_state_rejects_missing_signature(self):
+        """State without HMAC signature is rejected (400) when secret is configured."""
+        from fastapi import HTTPException
+        import base64, json
+
+        # Craft an unsigned state (plain base64 JSON, no sig)
+        unsigned = base64.urlsafe_b64encode(
+            json.dumps({"code_verifier": "v", "redirect_uri": "https://evil.com"}).encode()
+        ).decode()
+
+        with patch("app.services.oauth_service.get_settings") as mock_settings:
+            mock_settings.return_value = MagicMock(oauth_state_secret="testsecret32bytes00000000000000x")
+            with pytest.raises(HTTPException) as exc_info:
+                oauth_service.decode_state(unsigned)
+
+        assert exc_info.value.status_code == 400
+
+    def test_decode_state_unsigned_allowed_without_secret(self):
+        """When oauth_state_secret is None, unsigned states are still accepted (backwards compat)."""
+        from app.schemas.oauth import OAuthStateData
+
+        state_data = OAuthStateData(
+            code_verifier="test_verifier",
+            redirect_uri="https://example.com/callback",
+        )
+
+        with patch("app.services.oauth_service.get_settings") as mock_settings:
+            mock_settings.return_value = MagicMock(oauth_state_secret=None)
+            encoded = oauth_service.encode_state(state_data)
+            assert "." not in encoded, "Unsigned state must not contain a separator"
+            decoded = oauth_service.decode_state(encoded)
+
+        assert decoded.code_verifier == state_data.code_verifier
+
+    def test_compute_state_hmac_deterministic(self):
+        """_compute_state_hmac returns same value for same inputs (deterministic)."""
+        sig1 = oauth_service._compute_state_hmac("payload", "secret")
+        sig2 = oauth_service._compute_state_hmac("payload", "secret")
+        assert sig1 == sig2
+
+    def test_compute_state_hmac_differs_on_different_payload(self):
+        """_compute_state_hmac returns different values for different payloads."""
+        sig1 = oauth_service._compute_state_hmac("payload_a", "secret")
+        sig2 = oauth_service._compute_state_hmac("payload_b", "secret")
+        assert sig1 != sig2
+
+
+class TestCorsAllowlistConfig:
+    """Tests for H4 — CORS_ALLOWED_ORIGINS parsing."""
+
+    def test_single_origin_parsed(self):
+        """Single origin string is correctly parsed into a list."""
+        from app.core.config import Settings
+
+        s = Settings(cors_allowed_origins="https://cp.tr.entire.vc")
+        origins = [o.strip() for o in s.cors_allowed_origins.split(",") if o.strip()]
+        assert origins == ["https://cp.tr.entire.vc"]
+
+    def test_multiple_origins_parsed(self):
+        """Comma-separated origins are correctly split."""
+        from app.core.config import Settings
+
+        s = Settings(cors_allowed_origins="https://app.example.com, https://admin.example.com")
+        origins = [o.strip() for o in s.cors_allowed_origins.split(",") if o.strip()]
+        assert origins == ["https://app.example.com", "https://admin.example.com"]
+
+    def test_default_is_production_origin(self):
+        """Default CORS origin is the production control-plane URL, not wildcard."""
+        from app.core.config import Settings
+
+        s = Settings()
+        assert "*" not in s.cors_allowed_origins
+        assert "cp.tr.entire.vc" in s.cors_allowed_origins

--- a/apps/control-plane/tests/test_oauth.py
+++ b/apps/control-plane/tests/test_oauth.py
@@ -809,6 +809,9 @@ class TestOAuthGroupMapping:
             assert oauth_service.should_be_admin(["org/admin"]) is True
 
 
+_TEST_STATE_SECRET = "testsecret32bytes00000000000000x"
+
+
 class TestOAuthHmacState:
     """Tests for H5 — OAuth state HMAC signing (login-CSRF prevention)."""
 
@@ -822,7 +825,7 @@ class TestOAuthHmacState:
         )
 
         with patch("app.services.oauth_service.get_settings") as mock_settings:
-            mock_settings.return_value = MagicMock(oauth_state_secret="testsecret32bytes00000000000000x")
+            mock_settings.return_value = MagicMock(oauth_state_secret=_TEST_STATE_SECRET)
             encoded = oauth_service.encode_state(state_data)
             # Signed state must contain separator
             assert "." in encoded, "HMAC-signed state must contain a separator"
@@ -833,8 +836,9 @@ class TestOAuthHmacState:
 
     def test_decode_state_rejects_tampered_payload(self):
         """State with a valid signature but altered payload must be rejected (400)."""
-        from app.schemas.oauth import OAuthStateData
         from fastapi import HTTPException
+
+        from app.schemas.oauth import OAuthStateData
 
         state_data = OAuthStateData(
             code_verifier="test_verifier",
@@ -842,18 +846,22 @@ class TestOAuthHmacState:
         )
 
         with patch("app.services.oauth_service.get_settings") as mock_settings:
-            mock_settings.return_value = MagicMock(oauth_state_secret="testsecret32bytes00000000000000x")
+            mock_settings.return_value = MagicMock(oauth_state_secret=_TEST_STATE_SECRET)
             encoded = oauth_service.encode_state(state_data)
             payload_b64, sig = encoded.rsplit(".", 1)
             # Replace payload with a different one (attacker's state) but keep original sig
-            import base64, json
+            import base64
+            import json
+
             evil_payload = base64.urlsafe_b64encode(
-                json.dumps({"code_verifier": "evil", "redirect_uri": "https://attacker.com"}).encode()
+                json.dumps(
+                    {"code_verifier": "evil", "redirect_uri": "https://attacker.com"}
+                ).encode()
             ).decode()
             tampered = f"{evil_payload}.{sig}"
 
         with patch("app.services.oauth_service.get_settings") as mock_settings:
-            mock_settings.return_value = MagicMock(oauth_state_secret="testsecret32bytes00000000000000x")
+            mock_settings.return_value = MagicMock(oauth_state_secret=_TEST_STATE_SECRET)
             with pytest.raises(HTTPException) as exc_info:
                 oauth_service.decode_state(tampered)
 
@@ -862,8 +870,10 @@ class TestOAuthHmacState:
 
     def test_decode_state_rejects_missing_signature(self):
         """State without HMAC signature is rejected (400) when secret is configured."""
+        import base64
+        import json
+
         from fastapi import HTTPException
-        import base64, json
 
         # Craft an unsigned state (plain base64 JSON, no sig)
         unsigned = base64.urlsafe_b64encode(
@@ -871,14 +881,14 @@ class TestOAuthHmacState:
         ).decode()
 
         with patch("app.services.oauth_service.get_settings") as mock_settings:
-            mock_settings.return_value = MagicMock(oauth_state_secret="testsecret32bytes00000000000000x")
+            mock_settings.return_value = MagicMock(oauth_state_secret=_TEST_STATE_SECRET)
             with pytest.raises(HTTPException) as exc_info:
                 oauth_service.decode_state(unsigned)
 
         assert exc_info.value.status_code == 400
 
     def test_decode_state_unsigned_allowed_without_secret(self):
-        """When oauth_state_secret is None, unsigned states are still accepted (backwards compat)."""
+        """When oauth_state_secret is None, unsigned states are still accepted (backcompat)."""
         from app.schemas.oauth import OAuthStateData
 
         state_data = OAuthStateData(

--- a/infra/env.example
+++ b/infra/env.example
@@ -16,6 +16,9 @@ JWT_SECRET=replace-me
 BOOTSTRAP_ADMIN_EMAIL=admin@example.com
 BOOTSTRAP_ADMIN_PASSWORD=super-secret-pass
 
+# CORS configuration
+CORS_ALLOWED_ORIGINS=https://cp.tr.entire.vc     # Comma-separated; use '*' only for local dev
+
 # Relay server
 RELAY_PUBLIC_URL=wss://${DOMAIN_BASE}/doc/ws
 # RELAY_KEY_ID=relay_cp_01              # Optional, defaults to 'relay_cp_dev' if not set
@@ -74,6 +77,10 @@ LIFECYCLE_LAUNCH_DATE=                # ISO datetime cutoff; nudge only users re
 LIFECYCLE_FROM_NAME=                  # Lead persona display name (e.g. "Alex from Entire")
 LIFECYCLE_FROM_EMAIL=                 # Lead persona send-as address (must be an SMTP alias)
 LIFECYCLE_UNSUBSCRIBE_SECRET=change-me-in-prod  # HMAC-SHA256 key for unsubscribe tokens
+
+# OAuth state signing (required when OAUTH_ENABLED=true)
+# Generate with: python -c "import secrets; print(secrets.token_hex(32))"
+# OAUTH_STATE_SECRET=                   # REQUIRED when OAuth is enabled
 
 # Argus CRM integration (S7 — contact dedup + cross-product suppression-read)
 # Set ARGUS_ENABLED=true once Hermes outreach endpoints are live (S7b) and


### PR DESCRIPTION
## Summary

- **H4**: Replace `allow_origins=["*"]` with configurable `CORS_ALLOWED_ORIGINS` env var — defaults to `https://cp.tr.entire.vc` (restrictive), parsed as comma-separated list in `build_app()`.
- **H5**: Add HMAC-SHA256 signing of OAuth state parameter via `OAUTH_STATE_SECRET` env var. Signing is backwards-compatible (unsigned states accepted when secret is unset). Startup guard raises on `oauth_enabled=True` without secret configured.

## Changes

- `app/core/config.py` — added `cors_allowed_origins` and `oauth_state_secret` fields
- `app/main.py` — CORS uses allowlist from config; added `_validate_oauth_state_secret` startup handler  
- `app/services/oauth_service.py` — `_compute_state_hmac()`, updated `encode_state()`/`decode_state()` with HMAC sign/verify
- `infra/env.example` — added `CORS_ALLOWED_ORIGINS` and `OAUTH_STATE_SECRET` entries
- `tests/test_oauth.py` — 9 new tests (`TestOAuthHmacState` + `TestCorsAllowlistConfig`); fixed existing mock missing `oauth_state_secret=None`

## Test results

```
42 passed, 0 failed
```

Part of parent security hardening task (d5eb1d99). Companion to #94 (H1-H3).

@daedalus — requesting review.