### PR TITLE
fix(infra): swap System3 relay image → ghcr.io/entire-vc/evc-relay-server:0.9.7

### DIFF
--- a/forks/relay-server-template/Dockerfile
+++ b/forks/relay-server-template/Dockerfile
@@ -1,1 +1,1 @@
-FROM docker.system3.md/relay-server
+FROM ghcr.io/entire-vc/evc-relay-server:0.9.7

--- a/forks/relay-server-template/relay.toml.example
+++ b/forks/relay-server-template/relay.toml.example
@@ -14,15 +14,6 @@ level = "info"                   # RUST_LOG
 format = "pretty"                # RELAY_SERVER_LOG_FORMAT: "json" or "pretty"
 
 
-# Relay.md public keys
-[[auth]]
-key_id = "relay_2025_10_22"
-public_key = "/6OgBTHaRdWLogewMdyE+7AxnI0/HP3WGqRs/bYBlFg="
-
-[[auth]]
-key_id = "relay_2025_10_23"
-public_key = "fbm9JLHrwPpST5HAYORTQR/i1VbZ1kdp2ZEy0XpMbf0="
-
 
 # Storage backend configuration
 # NOTE: S3-compatible storage is required for attachment storage, and highly

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -220,10 +220,8 @@ services:
       control-plane-migrate:
         condition: service_completed_successfully
 
-  # placeholder: relay server (будет подключён/собран агентом)
   relay-server:
-    build:
-      context: ../forks/relay-server-template
+    image: ghcr.io/entire-vc/evc-relay-server:0.9.7
     depends_on:
       minio:
         condition: service_healthy
@@ -237,8 +235,7 @@ services:
       - "8080"
       - "9090"
     healthcheck:
-      # Note: Container has minimal shell without curl/pgrep. Using /proc check.
-      test: ["CMD-SHELL", "grep -q relay /proc/1/cmdline || exit 1"]
+      test: ["CMD", "curl", "-f", "http://localhost:8080/ready"]
       interval: 15s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
## Summary

Replaces the upstream System3 relay image with our own fork (`evc-relay-server`), which includes H6 security fixes (token expiration enforcement, doc-scope validation) and a proper HEALTHCHECK.

- **`forks/relay-server-template/Dockerfile`**: `FROM docker.system3.md/relay-server` → `FROM ghcr.io/entire-vc/evc-relay-server:0.9.7`
- **`infra/docker-compose.yml`**: relay-server service switches from `build:` context to direct `image:` reference; healthcheck updated from `/proc` grep workaround to `curl -f http://localhost:8080/ready` (curl is now available in our image)
- **`forks/relay-server-template/relay.toml.example`**: System3 `[[auth]]` public keys (`relay_2025_10_22`, `relay_2025_10_23`) removed — no longer needed

## DoD verification

- No `docker.system3.md` in diff: `grep docker.system3.md` returns exit 1 on all three files ✅
- System3 auth keys removed from relay.toml.example ✅
- Image `ghcr.io/entire-vc/evc-relay-server:0.9.7` pull verified (sha256:625fceeded0f...) ✅

Part of `f5706a5a` (relay-server hardening), subtask s5.