### PR TITLE
feat(infra): add OFFSITE_S3_* vars to postgres-backup in docker-compose.yml

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -51,6 +51,13 @@ services:
       BACKUP_S3_ENABLED: ${BACKUP_S3_ENABLED:-false}
       BACKUP_S3_BUCKET: ${BACKUP_S3_BUCKET:-}
       RUN_ON_STARTUP: ${BACKUP_RUN_ON_STARTUP:-true}
+      OFFSITE_S3_ENABLED: ${OFFSITE_S3_ENABLED:-false}
+      OFFSITE_S3_ENDPOINT: ${OFFSITE_S3_ENDPOINT:-}
+      OFFSITE_S3_ACCESS: ${OFFSITE_S3_ACCESS:-}
+      OFFSITE_S3_SECRET: ${OFFSITE_S3_SECRET:-}
+      OFFSITE_S3_BUCKET: ${OFFSITE_S3_BUCKET:-}
+      MINIO_ENDPOINT: ${MINIO_ENDPOINT:-http://minio:9000}
+      MINIO_BUCKET: ${MINIO_BUCKET:-relay}
     volumes:
       - ./data/backups:/backups
     depends_on:

--- a/infra/env.example
+++ b/infra/env.example
@@ -35,6 +35,12 @@ BACKUP_HOUR=2                         # Hour to run daily backup (0-23, UTC)
 BACKUP_RUN_ON_STARTUP=true            # Run backup on container startup
 # BACKUP_S3_ENABLED=false             # Enable S3/MinIO upload
 # BACKUP_S3_BUCKET=relay-backups      # S3 bucket name
+# Offsite S3 backup (external S3-compatible storage, e.g. AWS, Backblaze B2)
+# OFFSITE_S3_ENABLED=false            # Enable offsite S3 upload
+# OFFSITE_S3_ENDPOINT=                # S3 endpoint URL (e.g. https://s3.amazonaws.com)
+# OFFSITE_S3_ACCESS=                  # S3 access key ID
+# OFFSITE_S3_SECRET=                  # S3 secret access key
+# OFFSITE_S3_BUCKET=relay-backups     # Offsite S3 bucket name
 
 # Grafana configuration
 GRAFANA_ADMIN_USER=admin


### PR DESCRIPTION
## Summary

- Adds `OFFSITE_S3_ENABLED`, `OFFSITE_S3_ENDPOINT`, `OFFSITE_S3_ACCESS`, `OFFSITE_S3_SECRET`, `OFFSITE_S3_BUCKET`, `MINIO_ENDPOINT`, `MINIO_BUCKET` to the `postgres-backup` service `environment:` block in `infra/docker-compose.yml`
- Adds matching commented-out entries in `infra/env.example` for self-hosters
- All vars use `${VAR:-default}` substitution — no breaking change for existing deploys

**Why `environment:` instead of `env_file:`:** Docker `--env-file` crashes on multi-line values (PEM private keys). Compose variable substitution via `environment:` handles them correctly.

## Test plan

- [ ] `docker compose config` on a fresh `.env` (no OFFSITE_S3_* set) shows defaults — no errors
- [ ] Existing deploys without OFFSITE_S3_* vars are unaffected

Closes Mesh task #d58299e8