### PR TITLE
docs(relay): clarify relay-server = our y-sweet fork, not System3

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ You want your team in Obsidian, editing together, publishing docs — without gi
 
 ### Real-time Collaboration
 - **Live editing** — CRDT-based sync via y-sweet (Yjs), no merge conflicts
+  <!-- relay-server runs our own y-sweet fork: ghcr.io/entire-vc/evc-relay-server (see docs/adr-relay-server-own-fork.md), not the System3 binary. -->
 - **Offline-first** — edit without connection, sync seamlessly when back online
 - **Folder sharing** — share entire folders with viewer/editor permissions
 

--- a/docs/adr-relay-server-own-fork.md
+++ b/docs/adr-relay-server-own-fork.md
@@ -1,0 +1,35 @@
+# ADR: relay-server is our own y-sweet fork, NOT the System3 binary
+
+**Status:** approved 2026-07-07.
+
+## Decision (read this before touching relay-server)
+
+`relay-server` runs our **own image `ghcr.io/entire-vc/evc-relay-server`** (pinned, currently
+`:0.9.7`), built from a fork of **`no-instructions/y-sweet`** (MIT). See `infra/docker-compose.yml`.
+
+We used to pull the closed `docker.system3.md/relay-server` binary (System3 = a commercial
+y-sweet distributor). PR #99 swapped it for our ghcr image. **The System3 binary and its access
+token are no longer used.**
+
+## Why we forked
+Vendor lock on the most critical component (CRDT sync + document persistence); the image was
+pulled `:latest` (unreproducible); we couldn't audit/fix token-scope enforcement (it was their
+code); and it required a secret access token from System3. y-sweet is MIT and self-buildable
+(`crates/relay` + `crates/Dockerfile`), so we build it ourselves.
+
+## Common confusion — "didn't we write the token logic ourselves?"
+Two layers, don't conflate:
+- **Issuer (mints/signs tokens) = our control-plane** — `apps/control-plane/app/core/security.py`
+  (Ed25519 keygen, `create_relay_token`, `create_relay_token_cwt`) + `token_service.py`. Always ours.
+- **Verifier (checks tokens) = relay-server** — `crates/y-sweet-core/src/cwt.rs`. Was upstream's;
+  **now ours too** after the fork. The whole token path is under our control.
+
+## Where documents live (matters for backups)
+`relay.toml [store] type = "minio", endpoint = "http://minio:9000"` → CRDT docs, web content and
+uploads sit in the **local MinIO** volume (`relay_minio-data`), NOT external S3. That MinIO **must
+be backed up off-site** (see `docs/backup-restore.md`).
+
+## Still-stale (ignore for our deployment)
+`forks/relay-server-template/` are vendored upstream deploy templates (Fly/Docker/k8s) that still
+reference `docker.system3.md/relay-server`. **That is not our deployment** — ours is the ghcr image
+in `infra/docker-compose.yml`. Kept only as reference.

--- a/forks/relay-server-template/README.md
+++ b/forks/relay-server-template/README.md
@@ -1,3 +1,7 @@
+> ⚠️ **Entire VC note:** we do NOT deploy the `docker.system3.md/relay-server` image referenced
+> throughout this template. We build our own from a y-sweet fork and run `ghcr.io/entire-vc/evc-relay-server`
+> (see `infra/docker-compose.yml` and `docs/adr-relay-server-own-fork.md`). Treat this folder as upstream reference only.
+
 # Hosting an on-premise Relay Server
 
 [Relay](https://relay.md) supports self-hosting your Relay Server for added privacy.


### PR DESCRIPTION
Prevents recurring agent confusion (System3 binary vs our ghcr image, swapped in #99). Adds ADR + notes. Docs-only.