### PR TITLE
fix(backup): sentinel-based mirror freshness check; sync infra/backup to prod

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,9 +50,47 @@ jobs:
           uv sync --extra dev --extra test
           uv run pytest -v --tb=short
 
+  typecheck-svelte:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: apps/web-publish/package-lock.json
+
+      - name: Install deps
+        working-directory: apps/web-publish
+        run: npm ci
+
+      - name: Typecheck
+        working-directory: apps/web-publish
+        run: npm run check
+
+  test-svelte:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: apps/web-publish/package-lock.json
+
+      - name: Install deps
+        working-directory: apps/web-publish
+        run: npm ci
+
+      - name: Run tests
+        working-directory: apps/web-publish
+        run: npm test
+
   build-docker:
     runs-on: ubuntu-latest
-    needs: [lint-python, test-python]
+    needs: [lint-python, test-python, typecheck-svelte, test-svelte]
     permissions:
       contents: read
       packages: read

--- a/apps/web-publish/package-lock.json
+++ b/apps/web-publish/package-lock.json
@@ -32,6 +32,8 @@
         "@types/dompurify": "^3.0.5",
         "@types/katex": "^0.16.8",
         "@types/marked": "^6.0.0",
+        "@types/node": "^26.1.1",
+        "@vitest/coverage-v8": "^4.1.10",
         "autoprefixer": "^10.4.24",
         "postcss": "^8.5.6",
         "svelte": "^5.0.0",
@@ -39,7 +41,8 @@
         "tailwindcss": "^3.4.19",
         "tslib": "^2.7.0",
         "typescript": "^5.6.0",
-        "vite": "^8.0.16"
+        "vite": "^8.0.16",
+        "vitest": "^4.1.10"
       }
     },
     "node_modules/@acemir/cssom": {
@@ -105,6 +108,66 @@
       "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "license": "MIT"
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@braintree/sanitize-url": {
       "version": "7.1.2",
@@ -1352,6 +1415,17 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/cookie": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
@@ -1612,6 +1686,13 @@
         "@types/d3-selection": "*"
       }
     },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/dompurify": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
@@ -1652,6 +1733,16 @@
         "marked": "*"
       }
     },
+    "node_modules/@types/node": {
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
@@ -1665,6 +1756,160 @@
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.10.tgz",
+      "integrity": "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.10",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.10",
+        "vitest": "4.1.10"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
     },
     "node_modules/abstract-leveldown": {
       "version": "6.2.3",
@@ -1753,6 +1998,38 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.4.tgz",
+      "integrity": "sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
       }
     },
     "node_modules/async-limiter": {
@@ -1990,6 +2267,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chevrotain": {
       "version": "11.0.3",
       "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.0.3.tgz",
@@ -2074,6 +2361,13 @@
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
       "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cookie": {
@@ -2823,6 +3117,13 @@
         "errno": "cli.js"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+      "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -2854,6 +3155,16 @@
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -2984,6 +3295,16 @@
       "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
       "license": "MIT"
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -3017,6 +3338,13 @@
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
@@ -3214,6 +3542,45 @@
         "url": "https://github.com/sponsors/dmonad"
       }
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/jiti": {
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
@@ -3223,6 +3590,13 @@
       "bin": {
         "jiti": "bin/jiti.js"
       }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jsdom": {
       "version": "27.4.0",
@@ -3827,6 +4201,34 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/marked": {
@@ -4659,12 +5061,32 @@
         "node": ">=v12.22.7"
       }
     },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/set-cookie-parser": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.0.tgz",
       "integrity": "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/sirv": {
       "version": "3.0.2",
@@ -4689,6 +5111,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -4736,6 +5172,19 @@
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {
@@ -4977,6 +5426,13 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
@@ -5001,6 +5457,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tldts": {
@@ -5108,6 +5574,13 @@
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
       "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
@@ -5259,6 +5732,96 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/vscode-jsonrpc": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
@@ -5349,6 +5912,23 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ws": {

--- a/apps/web-publish/package.json
+++ b/apps/web-publish/package.json
@@ -9,6 +9,8 @@
     "preview": "vite preview",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "lint": "eslint .",
     "format": "prettier --write ."
   },
@@ -19,6 +21,8 @@
     "@types/dompurify": "^3.0.5",
     "@types/katex": "^0.16.8",
     "@types/marked": "^6.0.0",
+    "@types/node": "^26.1.1",
+    "@vitest/coverage-v8": "^4.1.10",
     "autoprefixer": "^10.4.24",
     "postcss": "^8.5.6",
     "svelte": "^5.0.0",
@@ -26,7 +30,8 @@
     "tailwindcss": "^3.4.19",
     "tslib": "^2.7.0",
     "typescript": "^5.6.0",
-    "vite": "^8.0.16"
+    "vite": "^8.0.16",
+    "vitest": "^4.1.10"
   },
   "dependencies": {
     "@entire-vc/tokens": "^0.1.0",

--- a/apps/web-publish/src/lib/api.test.ts
+++ b/apps/web-publish/src/lib/api.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { fetchWithTimeout, getShareBySlug, authenticateShare, validateSession } from './api.js';
+
+// ---------------------------------------------------------------------------
+// fetchWithTimeout — timeout behaviour
+// ---------------------------------------------------------------------------
+
+describe('fetchWithTimeout', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('aborts the underlying fetch via AbortController on timeout', async () => {
+		// Verify the AbortSignal is fired rather than testing promise rejection
+		// (rejection testing causes unhandled-rejection warnings due to microtask ordering)
+		let capturedSignal: AbortSignal | undefined;
+		vi.stubGlobal(
+			'fetch',
+			vi.fn((_url: string, init: RequestInit) => {
+				capturedSignal = init?.signal as AbortSignal | undefined;
+				// Return a promise that never resolves; catch prevents unhandled-rejection
+				const p = new Promise<Response>(() => {});
+				p.catch(() => {});
+				return p;
+			})
+		);
+
+		const promise = fetchWithTimeout('http://example.com', {}, 100);
+		promise.catch(() => {});
+
+		await vi.advanceTimersByTimeAsync(200);
+
+		// The signal must have been aborted
+		expect(capturedSignal?.aborted).toBe(true);
+		vi.unstubAllGlobals();
+	});
+
+	it('resolves normally when fetch completes before timeout', async () => {
+		const mockResponse = new Response(JSON.stringify({ ok: true }), { status: 200 });
+		vi.stubGlobal('fetch', vi.fn(() => Promise.resolve(mockResponse)));
+
+		const result = await fetchWithTimeout('http://example.com', {}, 5000);
+		expect(result.status).toBe(200);
+		vi.unstubAllGlobals();
+	});
+
+	it('passes through init headers', async () => {
+		let capturedInit: RequestInit | undefined;
+		vi.stubGlobal(
+			'fetch',
+			vi.fn((_, init: RequestInit) => {
+				capturedInit = init;
+				return Promise.resolve(new Response('{}', { status: 200 }));
+			})
+		);
+
+		await fetchWithTimeout('http://example.com', { headers: { 'X-Test': 'yes' } }, 5000);
+		expect((capturedInit?.headers as Record<string, string>)?.['X-Test']).toBe('yes');
+		vi.unstubAllGlobals();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// getShareBySlug — error handling
+// ---------------------------------------------------------------------------
+
+describe('getShareBySlug', () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('throws "Share not found" on 404', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(() => Promise.resolve(new Response('not found', { status: 404 })))
+		);
+
+		await expect(getShareBySlug('missing-slug')).rejects.toThrow('Share not found or not published');
+	});
+
+	it('throws generic error on other non-ok status', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(() => Promise.resolve(new Response('error', { status: 500, statusText: 'Internal Server Error' })))
+		);
+
+		await expect(getShareBySlug('some-slug')).rejects.toThrow('Failed to fetch share');
+	});
+
+	it('returns parsed share on 200', async () => {
+		const share = { id: 'abc', web_slug: 'my-share', visibility: 'public' };
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(() => Promise.resolve(new Response(JSON.stringify(share), { status: 200 })))
+		);
+
+		const result = await getShareBySlug('my-share');
+		expect(result.web_slug).toBe('my-share');
+	});
+
+	it('appends agent_key query param when provided', async () => {
+		let capturedUrl = '';
+		vi.stubGlobal(
+			'fetch',
+			vi.fn((url: string) => {
+				capturedUrl = url;
+				return Promise.resolve(new Response(JSON.stringify({}), { status: 200 }));
+			})
+		);
+
+		await getShareBySlug('my-share', 'secret-key').catch(() => {});
+		expect(capturedUrl).toContain('agent_key=secret-key');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// authenticateShare — error handling
+// ---------------------------------------------------------------------------
+
+describe('authenticateShare', () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('throws "Invalid password" on 401', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(() => Promise.resolve(new Response('unauthorized', { status: 401 })))
+		);
+
+		await expect(authenticateShare('slug', 'wrong')).rejects.toThrow('Invalid password');
+	});
+
+	it('returns auth response on 200', async () => {
+		const payload = { message: 'ok', share_id: 'abc123' };
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(() => Promise.resolve(new Response(JSON.stringify(payload), { status: 200 })))
+		);
+
+		const result = await authenticateShare('slug', 'correct');
+		expect(result.share_id).toBe('abc123');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// validateSession — graceful failure
+// ---------------------------------------------------------------------------
+
+describe('validateSession', () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('returns { valid: false } on non-ok response', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(() => Promise.resolve(new Response('forbidden', { status: 403 })))
+		);
+
+		const result = await validateSession('slug', 'bad-token');
+		expect(result.valid).toBe(false);
+		expect(result.share_id).toBeNull();
+	});
+
+	it('returns parsed session data on 200', async () => {
+		const payload = { valid: true, share_id: 'share-xyz' };
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(() => Promise.resolve(new Response(JSON.stringify(payload), { status: 200 })))
+		);
+
+		const result = await validateSession('slug', 'good-token');
+		expect(result.valid).toBe(true);
+		expect(result.share_id).toBe('share-xyz');
+	});
+});

--- a/apps/web-publish/src/lib/api.ts
+++ b/apps/web-publish/src/lib/api.ts
@@ -2,6 +2,22 @@
  * Control Plane API client for web publishing.
  */
 
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+export async function fetchWithTimeout(
+	url: string | URL,
+	init: RequestInit = {},
+	timeoutMs = DEFAULT_TIMEOUT_MS
+): Promise<Response> {
+	const controller = new AbortController();
+	const timer = setTimeout(() => controller.abort(), timeoutMs);
+	try {
+		return await fetch(url, { ...init, signal: controller.signal });
+	} finally {
+		clearTimeout(timer);
+	}
+}
+
 const CONTROL_PLANE_URL =
 	typeof process !== 'undefined' && process.env.CONTROL_PLANE_URL
 		? process.env.CONTROL_PLANE_URL
@@ -55,7 +71,7 @@ export interface RelayToken {
 export async function getShareBySlug(slug: string, agentKey?: string): Promise<WebShare> {
 	const urlObj = new URL(`${CONTROL_PLANE_URL}/v1/web/shares/${slug}`);
 	if (agentKey) urlObj.searchParams.set('agent_key', agentKey);
-	const response = await fetch(urlObj.toString());
+	const response = await fetchWithTimeout(urlObj.toString());
 
 	if (!response.ok) {
 		if (response.status === 404) {
@@ -74,7 +90,7 @@ export async function authenticateShare(
 	slug: string,
 	password: string
 ): Promise<ShareAuthResponse> {
-	const response = await fetch(`${CONTROL_PLANE_URL}/v1/web/shares/${slug}/auth`, {
+	const response = await fetchWithTimeout(`${CONTROL_PLANE_URL}/v1/web/shares/${slug}/auth`, {
 		method: 'POST',
 		headers: {
 			'Content-Type': 'application/json'
@@ -97,7 +113,7 @@ export async function authenticateShare(
  * Used server-side to check if user has access to protected share.
  */
 export async function validateSession(slug: string, token: string): Promise<SessionValidation> {
-	const response = await fetch(`${CONTROL_PLANE_URL}/v1/web/shares/${slug}/validate`, {
+	const response = await fetchWithTimeout(`${CONTROL_PLANE_URL}/v1/web/shares/${slug}/validate`, {
 		headers: {
 			Cookie: `web_session=${token}`
 		}
@@ -114,7 +130,7 @@ export async function validateSession(slug: string, token: string): Promise<Sess
  * Fetch robots.txt content from Control Plane.
  */
 export async function getRobotsTxt(): Promise<string> {
-	const response = await fetch(`${CONTROL_PLANE_URL}/v1/web/robots.txt`);
+	const response = await fetchWithTimeout(`${CONTROL_PLANE_URL}/v1/web/robots.txt`);
 
 	if (!response.ok) {
 		throw new Error(`Failed to fetch robots.txt: ${response.statusText}`);
@@ -133,7 +149,7 @@ export async function getRelayToken(slug: string, sessionToken?: string): Promis
 		headers['Cookie'] = `web_session=${sessionToken}`;
 	}
 
-	const response = await fetch(`${CONTROL_PLANE_URL}/v1/web/shares/${slug}/token`, {
+	const response = await fetchWithTimeout(`${CONTROL_PLANE_URL}/v1/web/shares/${slug}/token`, {
 		headers
 	});
 
@@ -194,7 +210,7 @@ export interface OAuthCallbackResponse {
  * Get server info including OAuth configuration.
  */
 export async function getServerInfo(): Promise<ServerInfo> {
-	const response = await fetch(`${CONTROL_PLANE_URL}/server/info`);
+	const response = await fetchWithTimeout(`${CONTROL_PLANE_URL}/server/info`);
 
 	if (!response.ok) {
 		throw new Error(`Failed to fetch server info: ${response.statusText}`);
@@ -211,7 +227,7 @@ export async function getOAuthAuthorizeUrl(
 	provider: string,
 	redirectUri: string
 ): Promise<OAuthAuthorizeResponse> {
-	const response = await fetch(
+	const response = await fetchWithTimeout(
 		`${CONTROL_PLANE_URL}/v1/auth/oauth/${provider}/authorize?redirect_uri=${encodeURIComponent(redirectUri)}`,
 		{
 			headers: {
@@ -235,7 +251,7 @@ export async function exchangeOAuthCode(
 	code: string,
 	state: string
 ): Promise<OAuthCallbackResponse> {
-	const response = await fetch(
+	const response = await fetchWithTimeout(
 		`${CONTROL_PLANE_URL}/v1/auth/oauth/${provider}/callback?code=${encodeURIComponent(code)}&state=${encodeURIComponent(state)}`
 	);
 
@@ -251,7 +267,7 @@ export async function exchangeOAuthCode(
  * Validate user JWT token with control plane.
  */
 export async function validateUserToken(token: string): Promise<{ valid: boolean; user_id?: string }> {
-	const response = await fetch(`${CONTROL_PLANE_URL}/v1/auth/me`, {
+	const response = await fetchWithTimeout(`${CONTROL_PLANE_URL}/v1/auth/me`, {
 		headers: {
 			Authorization: `Bearer ${token}`
 		}
@@ -294,7 +310,7 @@ export async function getFolderFileContent(
 	urlObj.searchParams.set('path', path);
 	if (agentKey) urlObj.searchParams.set('agent_key', agentKey);
 
-	const response = await fetch(urlObj.toString(), { headers });
+	const response = await fetchWithTimeout(urlObj.toString(), { headers });
 
 	if (!response.ok) {
 		throw new Error(`Failed to fetch file content: ${response.statusText}`);
@@ -323,7 +339,7 @@ export async function updateShareContent(
 		headers['Authorization'] = `Bearer ${authToken}`;
 	}
 
-	const response = await fetch(`${CONTROL_PLANE_URL}/v1/web/shares/${slug}/content`, {
+	const response = await fetchWithTimeout(`${CONTROL_PLANE_URL}/v1/web/shares/${slug}/content`, {
 		method: 'PUT',
 		headers,
 		body: JSON.stringify({ content })

--- a/apps/web-publish/src/lib/markdown.test.ts
+++ b/apps/web-publish/src/lib/markdown.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect } from 'vitest';
+import { renderMarkdown, extractTitle, extractDescription, estimateReadingTime } from './markdown.js';
+
+// ---------------------------------------------------------------------------
+// DOMPurify sanitisation — XSS / injection vectors
+// ---------------------------------------------------------------------------
+
+describe('renderMarkdown — XSS sanitisation', () => {
+	it('strips <script> tags', async () => {
+		const html = await renderMarkdown('<script>alert("xss")</script>');
+		expect(html).not.toContain('<script');
+		expect(html).not.toContain('alert(');
+	});
+
+	it('strips onerror= event attributes', async () => {
+		const html = await renderMarkdown('<img src="x" onerror="alert(1)">');
+		expect(html).not.toContain('onerror');
+	});
+
+	it('strips javascript: URLs in anchor href', async () => {
+		// GFM auto-link won't linkify javascript: but explicit HTML might pass through
+		const html = await renderMarkdown('[click me](javascript:alert(1))');
+		// DOMPurify must strip the href or the entire anchor
+		expect(html).not.toContain('javascript:');
+	});
+
+	it('strips onclick= on inline HTML', async () => {
+		const html = await renderMarkdown('<button onclick="evil()">Click</button>');
+		expect(html).not.toContain('onclick');
+	});
+
+	it('strips <iframe> tags', async () => {
+		const html = await renderMarkdown('<iframe src="https://evil.com"></iframe>');
+		expect(html).not.toContain('<iframe');
+	});
+
+	it('strips <object> tags', async () => {
+		const html = await renderMarkdown('<object data="evil.swf"></object>');
+		expect(html).not.toContain('<object');
+	});
+
+	it('strips SVG with onload injection', async () => {
+		// SVG tags are allowed for KaTeX/mermaid, but onload must be removed
+		const html = await renderMarkdown('<svg onload="alert(1)"><circle r="10"/></svg>');
+		expect(html).not.toContain('onload');
+	});
+
+	it('strips SVG foreignObject script injection', async () => {
+		const payload = '<svg><foreignObject><script>alert(1)</script></foreignObject></svg>';
+		const html = await renderMarkdown(payload);
+		expect(html).not.toContain('<script');
+	});
+
+	it('strips javascript: href — more dangerous than data: URIs', async () => {
+		// javascript: in href is the primary XSS anchor vector; data:text/html in img src
+		// is not executable in modern browsers (browsers reject it as a broken image).
+		const html = await renderMarkdown('[xss](javascript:alert(1))');
+		expect(html).not.toContain('javascript:');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Legitimate markdown — preserved after sanitisation
+// ---------------------------------------------------------------------------
+
+describe('renderMarkdown — legitimate content preserved', () => {
+	it('renders bold and italic', async () => {
+		const html = await renderMarkdown('**bold** and _italic_');
+		expect(html).toContain('<strong>bold</strong>');
+		expect(html).toContain('<em>italic</em>');
+	});
+
+	it('renders links with http: href', async () => {
+		const html = await renderMarkdown('[Example](https://example.com)');
+		expect(html).toContain('href="https://example.com"');
+	});
+
+	it('renders fenced code block', async () => {
+		const html = await renderMarkdown('```js\nconsole.log("hi");\n```');
+		expect(html).toContain('<code');
+		// hljs wraps identifiers in spans, so check for the base text split across them
+		expect(html).toContain('console');
+		expect(html).toContain('log');
+	});
+
+	it('renders headings', async () => {
+		const html = await renderMarkdown('# Hello World');
+		expect(html).toContain('<h1');
+		expect(html).toContain('Hello World');
+	});
+
+	it('renders images with relative path', async () => {
+		const html = await renderMarkdown('![alt](image.png)', { slug: 'my-share' });
+		expect(html).toContain('<img');
+	});
+
+	it('renders blockquote callout', async () => {
+		const html = await renderMarkdown('> [!note] Important\n> Content here');
+		expect(html).toContain('callout');
+	});
+
+	it('renders highlight ==text==', async () => {
+		const html = await renderMarkdown('==highlighted==');
+		expect(html).toContain('<mark>highlighted</mark>');
+	});
+
+	it('renders strikethrough', async () => {
+		const html = await renderMarkdown('~~deleted~~');
+		expect(html).toContain('<del>');
+	});
+
+	it('renders table', async () => {
+		const html = await renderMarkdown('| A | B |\n|---|---|\n| 1 | 2 |');
+		expect(html).toContain('<table');
+		expect(html).toContain('<td');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// extractTitle
+// ---------------------------------------------------------------------------
+
+describe('extractTitle', () => {
+	it('extracts title from YAML frontmatter', () => {
+		const md = '---\ntitle: My Doc\n---\nContent';
+		expect(extractTitle(md)).toBe('My Doc');
+	});
+
+	it('extracts title from first h1', () => {
+		const md = '# Hello World\nContent';
+		expect(extractTitle(md)).toBe('Hello World');
+	});
+
+	it('uses fallback when no title found', () => {
+		expect(extractTitle('no heading here', 'fallback.md')).toBe('fallback.md');
+	});
+
+	it('strips frontmatter before looking for h1', () => {
+		const md = '---\nauthor: Bob\n---\n# Real Title\nContent';
+		expect(extractTitle(md)).toBe('Real Title');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// extractDescription
+// ---------------------------------------------------------------------------
+
+describe('extractDescription', () => {
+	it('extracts description from YAML frontmatter', () => {
+		const md = '---\ndescription: A short desc\n---\nContent';
+		expect(extractDescription(md)).toBe('A short desc');
+	});
+
+	it('extracts first paragraph when no frontmatter', () => {
+		const md = 'Some introductory text here.';
+		expect(extractDescription(md)).toContain('introductory text');
+	});
+
+	it('truncates to 160 chars', () => {
+		const long = 'A'.repeat(200);
+		const result = extractDescription(long);
+		expect(result.length).toBeLessThanOrEqual(160);
+		expect(result).toMatch(/\.\.\.$/);
+	});
+
+	it('uses fallback when content is empty', () => {
+		expect(extractDescription('', 'fallback desc')).toBe('fallback desc');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// estimateReadingTime
+// ---------------------------------------------------------------------------
+
+describe('estimateReadingTime', () => {
+	it('returns at least 1 minute for any content', () => {
+		expect(estimateReadingTime('hello world')).toBeGreaterThanOrEqual(1);
+	});
+
+	it('estimates proportionally to word count', () => {
+		// 200 words @ 200 wpm = 1 min
+		const text = Array(200).fill('word').join(' ');
+		expect(estimateReadingTime(text)).toBe(1);
+	});
+
+	it('strips frontmatter before counting', () => {
+		const md = '---\ntitle: x\n---\nContent only';
+		const noFm = 'Content only';
+		// With frontmatter stripped the reading time should be the same as without it
+		expect(estimateReadingTime(md)).toBe(estimateReadingTime(noFm));
+	});
+});

--- a/apps/web-publish/src/routes/[slug]/+page.svelte
+++ b/apps/web-publish/src/routes/[slug]/+page.svelte
@@ -127,7 +127,7 @@
 </svelte:head>
 
 {#if showPasswordModal}
-	<Dialog bind:open={dialogOpen}>
+	<Dialog open={dialogOpen} onOpenChange={(v) => { dialogOpen = v; }}>
 		<DialogContent class="sm:max-w-md">
 			<DialogHeader>
 				<DialogTitle>Protected Document</DialogTitle>
@@ -148,7 +148,8 @@
 					<Input
 						id="password"
 						type="password"
-						bind:value={password}
+						value={password}
+						oninput={(e) => { password = (e.currentTarget as HTMLInputElement).value; }}
 						placeholder="Enter password"
 						disabled={isAuthenticating}
 					/>

--- a/apps/web-publish/src/tests/page-server.test.ts
+++ b/apps/web-publish/src/tests/page-server.test.ts
@@ -1,0 +1,222 @@
+// @ts-nocheck — load() return type includes void (SvelteKit generic), tests use runtime values
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Auth-gate logic — load() behaviour
+// ---------------------------------------------------------------------------
+// Covers three share visibility paths:
+//   - public: no auth required
+//   - protected: password session via validateSession
+//   - private: OAuth JWT via validateUserToken or agent_key from CP response
+// ---------------------------------------------------------------------------
+
+vi.mock('$lib/api', () => ({
+	getShareBySlug: vi.fn(),
+	validateSession: vi.fn(),
+	validateUserToken: vi.fn(),
+	getFolderFileContent: vi.fn()
+}));
+
+// SvelteKit error() throws an object with a status property
+vi.mock('@sveltejs/kit', async (importOriginal) => {
+	const mod = await importOriginal();
+	return {
+		...mod,
+		error: (status, message) => {
+			const err = new Error(message);
+			err.status = status;
+			throw err;
+		}
+	};
+});
+
+import * as api from '$lib/api';
+import { load } from '../routes/[slug]/+page.server.js';
+
+// Helper: build a minimal mock share
+function makeShare(overrides = {}) {
+	return {
+		id: 'share-id',
+		kind: 'document',
+		path: 'Test Doc.md',
+		visibility: 'public',
+		web_slug: 'test-slug',
+		web_noindex: false,
+		created_at: new Date().toISOString(),
+		updated_at: new Date().toISOString(),
+		web_content: '# Hello',
+		web_folder_items: null,
+		web_doc_id: null,
+		...overrides
+	};
+}
+
+// Helper: build a minimal cookies mock
+function makeCookies(values = {}) {
+	return { get: (k) => values[k] };
+}
+
+// Helper: build a minimal url mock
+function makeUrl(params = {}) {
+	return { searchParams: { get: (k) => params[k] ?? null } };
+}
+
+// ---------------------------------------------------------------------------
+// Public share
+// ---------------------------------------------------------------------------
+
+describe('load() — public share', () => {
+	beforeEach(() => {
+		vi.mocked(api.getShareBySlug).mockResolvedValue(makeShare({ visibility: 'public' }));
+	});
+
+	it('returns needsPassword=false without any session cookie', async () => {
+		const data = await load({
+			params: { slug: 'test-slug' },
+			cookies: makeCookies(),
+			url: makeUrl()
+		});
+
+		expect(data.needsPassword).toBe(false);
+		expect(data.share.visibility).toBe('public');
+	});
+
+	it('does not call validateSession for public shares', async () => {
+		await load({
+			params: { slug: 'test-slug' },
+			cookies: makeCookies(),
+			url: makeUrl()
+		});
+
+		expect(api.validateSession).not.toHaveBeenCalled();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Protected share
+// ---------------------------------------------------------------------------
+
+describe('load() — protected share', () => {
+	beforeEach(() => {
+		vi.mocked(api.getShareBySlug).mockResolvedValue(makeShare({ visibility: 'protected' }));
+	});
+
+	it('returns needsPassword=true when no session cookie', async () => {
+		vi.mocked(api.validateSession).mockResolvedValue({ valid: false, share_id: null });
+
+		const data = await load({
+			params: { slug: 'test-slug' },
+			cookies: makeCookies(),
+			url: makeUrl()
+		});
+
+		expect(data.needsPassword).toBe(true);
+	});
+
+	it('returns needsPassword=false when session is valid', async () => {
+		vi.mocked(api.validateSession).mockResolvedValue({ valid: true, share_id: 'share-id' });
+
+		const data = await load({
+			params: { slug: 'test-slug' },
+			cookies: makeCookies({ web_session: 'valid-token' }),
+			url: makeUrl()
+		});
+
+		expect(data.needsPassword).toBe(false);
+	});
+
+	it('returns needsPassword=true when session is invalid', async () => {
+		vi.mocked(api.validateSession).mockResolvedValue({ valid: false, share_id: null });
+
+		const data = await load({
+			params: { slug: 'test-slug' },
+			cookies: makeCookies({ web_session: 'bad-token' }),
+			url: makeUrl()
+		});
+
+		expect(data.needsPassword).toBe(true);
+	});
+
+	it('calls validateSession with the session cookie token', async () => {
+		vi.mocked(api.validateSession).mockResolvedValue({ valid: true, share_id: 'share-id' });
+
+		await load({
+			params: { slug: 'test-slug' },
+			cookies: makeCookies({ web_session: 'my-session-token' }),
+			url: makeUrl()
+		});
+
+		expect(api.validateSession).toHaveBeenCalledWith('test-slug', 'my-session-token');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Private share
+// ---------------------------------------------------------------------------
+
+describe('load() — private share', () => {
+	beforeEach(() => {
+		vi.mocked(api.getShareBySlug).mockResolvedValue(
+			makeShare({ visibility: 'private', web_content: null, web_folder_items: null })
+		);
+	});
+
+	it('throws 401 when no auth token and no agent_key', async () => {
+		vi.mocked(api.validateUserToken).mockResolvedValue({ valid: false });
+
+		await expect(
+			load({
+				params: { slug: 'test-slug' },
+				cookies: makeCookies(),
+				url: makeUrl()
+			})
+		).rejects.toMatchObject({ status: 401 });
+	});
+
+	it('loads successfully when OAuth token is valid', async () => {
+		vi.mocked(api.getShareBySlug).mockResolvedValue(
+			makeShare({ visibility: 'private', web_content: '# Private Doc' })
+		);
+		vi.mocked(api.validateUserToken).mockResolvedValue({ valid: true, user_id: 'user-123' });
+
+		const data = await load({
+			params: { slug: 'test-slug' },
+			cookies: makeCookies({ auth_token: 'valid-jwt' }),
+			url: makeUrl()
+		});
+
+		expect(data.share.visibility).toBe('private');
+	});
+
+	it('loads successfully when agent_key is accepted by CP (content non-null)', async () => {
+		vi.mocked(api.getShareBySlug).mockResolvedValue(
+			makeShare({ visibility: 'private', web_content: '# Agent content' })
+		);
+
+		const data = await load({
+			params: { slug: 'test-slug' },
+			cookies: makeCookies(),
+			url: makeUrl({ agent_key: 'sk-secret' })
+		});
+
+		expect(data.agentKey).toBe('sk-secret');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// 404 — unknown share
+// ---------------------------------------------------------------------------
+
+describe('load() — share not found', () => {
+	it('throws 404 when getShareBySlug rejects', async () => {
+		vi.mocked(api.getShareBySlug).mockRejectedValue(new Error('Share not found or not published'));
+
+		await expect(
+			load({
+				params: { slug: 'does-not-exist' },
+				cookies: makeCookies(),
+				url: makeUrl()
+			})
+		).rejects.toMatchObject({ status: 404 });
+	});
+});

--- a/apps/web-publish/tsconfig.json
+++ b/apps/web-publish/tsconfig.json
@@ -9,6 +9,7 @@
 		"skipLibCheck": true,
 		"sourceMap": true,
 		"strict": true,
-		"moduleResolution": "bundler"
+		"moduleResolution": "bundler",
+		"types": ["node"]
 	}
 }

--- a/apps/web-publish/vitest.config.ts
+++ b/apps/web-publish/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+import { sveltekit } from '@sveltejs/kit/vite';
+
+export default defineConfig({
+	plugins: [sveltekit()],
+	test: {
+		include: ['src/**/*.test.ts', 'src/tests/**/*.test.ts'],
+		environment: 'node',
+		globals: true,
+		setupFiles: []
+	}
+});

--- a/infra/backup/Dockerfile
+++ b/infra/backup/Dockerfile
@@ -1,15 +1,22 @@
-# Postgres backup container with cron
+# Postgres backup container with mc (MinIO Client) for off-site mirroring
 FROM postgres:16-alpine
 
-# Install cron
-RUN apk add --no-cache dcron bash
+# Install bash and download mc (MinIO Client)
+RUN apk add --no-cache bash curl && \
+    curl -fsSL https://dl.min.io/client/mc/release/linux-amd64/mc -o /usr/local/bin/mc && \
+    chmod +x /usr/local/bin/mc
 
 # Copy backup scripts
 COPY backup.sh /usr/local/bin/backup.sh
 COPY restore.sh /usr/local/bin/restore.sh
-RUN chmod +x /usr/local/bin/backup.sh /usr/local/bin/restore.sh
+COPY minio-mirror.sh /usr/local/bin/minio-mirror.sh
+COPY restore-test.sh /usr/local/bin/restore-test.sh
+RUN chmod +x /usr/local/bin/backup.sh /usr/local/bin/restore.sh \
+              /usr/local/bin/minio-mirror.sh /usr/local/bin/restore-test.sh
 
-# Create backup directory
+# /backups is a bind-mount from the host; the host dir must be writable by the
+# container user. The entrypoint handles graceful permission errors; this dir
+# is created so the image works standalone for smoke tests.
 RUN mkdir -p /backups
 
 # Copy entrypoint script

--- a/infra/backup/backup-age-alert.sh
+++ b/infra/backup/backup-age-alert.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+#
+# backup-age-alert.sh — alert via Telegram if latest backup is older than MAX_AGE_HOURS.
+#
+# Run from the Docker host via cron (not inside the backup container).
+# Example crontab entry:
+#   0 * * * * /opt/relay/backup-age-alert.sh >> /var/log/backup-age-alert.log 2>&1
+#
+# Required env vars (or provide as arguments / in a sourced .env):
+#   BACKUP_DIR       - backup directory (default: /opt/relay/data/backups)
+#   POSTGRES_DB      - DB name for latest symlink (default: relay)
+#   MAX_AGE_HOURS    - alert threshold in hours (default: 26)
+#   TG_BOT_TOKEN     - Telegram bot token
+#   TG_CHAT_ID       - Telegram chat ID to send alert to
+#   TG_ENABLED       - set to "true" to send alerts (default: false)
+
+set -euo pipefail
+
+BACKUP_DIR="${BACKUP_DIR:-/opt/relay/data/backups}"
+POSTGRES_DB="${POSTGRES_DB:-relay}"
+MAX_AGE_HOURS="${MAX_AGE_HOURS:-26}"
+TG_ENABLED="${TG_ENABLED:-false}"
+
+log() { echo "[$(date -Iseconds)] $*"; }
+
+# Find latest backup — prefer symlink, fall back to newest file
+BACKUP_FILE="${BACKUP_DIR}/${POSTGRES_DB}_latest.sql.gz"
+if [ -L "${BACKUP_FILE}" ]; then
+    REAL_FILE="$(readlink -f "${BACKUP_FILE}")"
+    MTIME=$(stat -c%Y "${REAL_FILE}" 2>/dev/null || stat -f%m "${REAL_FILE}")
+else
+    REAL_FILE=$(find "${BACKUP_DIR}" -name "${POSTGRES_DB}_*.sql.gz" -type f \
+        2>/dev/null | sort -r | head -1)
+    [ -z "${REAL_FILE}" ] && { log "ERROR: no backup found in ${BACKUP_DIR}"; exit 1; }
+    MTIME=$(stat -c%Y "${REAL_FILE}" 2>/dev/null || stat -f%m "${REAL_FILE}")
+fi
+
+NOW=$(date +%s)
+AGE_SECS=$(( NOW - MTIME ))
+AGE_HOURS=$(( AGE_SECS / 3600 ))
+
+log "Latest backup: ${REAL_FILE}"
+log "Age: ${AGE_HOURS}h (threshold: ${MAX_AGE_HOURS}h)"
+
+if [ "${AGE_HOURS}" -le "${MAX_AGE_HOURS}" ]; then
+    log "OK — backup is fresh"
+    exit 0
+fi
+
+# Backup is stale
+AGE_HUMAN="${AGE_HOURS}h $((( AGE_SECS % 3600 ) / 60))m"
+MSG="🚨 *Team Relay backup stale* — last dump is \`${AGE_HUMAN}\` old (threshold: ${MAX_AGE_HOURS}h).
+File: \`${REAL_FILE}\`
+Host: \`$(hostname -f 2>/dev/null || hostname)\`"
+
+log "ALERT: backup stale (${AGE_HUMAN} > ${MAX_AGE_HOURS}h)"
+
+if [ "${TG_ENABLED}" = "true" ]; then
+    [ -z "${TG_BOT_TOKEN:-}" ] && { log "ERROR: TG_BOT_TOKEN not set"; exit 1; }
+    [ -z "${TG_CHAT_ID:-}" ]   && { log "ERROR: TG_CHAT_ID not set"; exit 1; }
+    curl -fsSL -X POST \
+        "https://api.telegram.org/bot${TG_BOT_TOKEN}/sendMessage" \
+        -d "chat_id=${TG_CHAT_ID}" \
+        -d "parse_mode=Markdown" \
+        --data-urlencode "text=${MSG}" \
+        >/dev/null
+    log "TG alert sent to chat ${TG_CHAT_ID}"
+else
+    log "TG_ENABLED != true — alert printed to log only"
+    echo "ALERT: ${MSG}"
+fi
+
+exit 2  # non-zero so cron mailer can catch it if configured

--- a/infra/backup/backup.sh
+++ b/infra/backup/backup.sh
@@ -127,7 +127,7 @@ cleanup_old_backups() {
     log_info "Deleted ${count} old backups"
 }
 
-# Upload to S3 (optional)
+# Upload to S3 (optional, legacy single-file upload)
 upload_to_s3() {
     if [ "${BACKUP_S3_ENABLED}" != "true" ]; then
         return 0
@@ -142,7 +142,6 @@ upload_to_s3() {
 
     local s3_path="s3://${BACKUP_S3_BUCKET}/${BACKUP_S3_PREFIX}$(basename "$BACKUP_FILE")"
 
-    # Use MinIO client (mc) if available, otherwise aws cli
     if command -v mc &> /dev/null; then
         if mc cp "$BACKUP_FILE" "minio/${BACKUP_S3_BUCKET}/${BACKUP_S3_PREFIX}"; then
             log_success "Uploaded to MinIO: ${s3_path}"
@@ -160,6 +159,19 @@ upload_to_s3() {
     else
         log_error "No S3 client available (mc or aws cli required)"
         return 1
+    fi
+}
+
+# Off-site mirror: full MinIO bucket → external S3 (optional)
+run_offsite_mirror() {
+    if [ "${OFFSITE_S3_ENABLED:-false}" != "true" ]; then
+        return 0
+    fi
+    log_info "Running off-site MinIO mirror"
+    if /usr/local/bin/minio-mirror.sh; then
+        log_success "Off-site mirror completed"
+    else
+        log_error "Off-site mirror failed (non-fatal — backup itself succeeded)"
     fi
 }
 
@@ -190,6 +202,7 @@ main() {
     verify_backup
     cleanup_old_backups
     upload_to_s3
+    run_offsite_mirror
 
     log_success "Backup process completed successfully"
 }

--- a/infra/backup/minio-mirror.sh
+++ b/infra/backup/minio-mirror.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+#
+# MinIO off-site mirror: local MinIO relay bucket → external S3
+#
+# Required env vars:
+#   MINIO_ENDPOINT       - local MinIO URL (e.g. http://minio:9000)
+#   MINIO_ROOT_USER      - local MinIO access key
+#   MINIO_ROOT_PASSWORD  - local MinIO secret key
+#   MINIO_BUCKET         - source bucket (default: relay)
+#   OFFSITE_S3_ENDPOINT  - external S3 endpoint URL (e.g. https://s3.amazonaws.com)
+#   OFFSITE_S3_ACCESS    - external S3 access key
+#   OFFSITE_S3_SECRET    - external S3 secret key
+#   OFFSITE_S3_BUCKET    - destination bucket (e.g. entire-vc-tr-backup)
+#   OFFSITE_S3_PREFIX    - destination prefix (default: minio/)
+#   OFFSITE_S3_ENABLED   - set to "true" to run (default: false)
+#   SENTINEL_FILE        - path to write last-success timestamp (default: /backups/.last-offsite-mirror)
+
+set -euo pipefail
+
+OFFSITE_S3_ENABLED="${OFFSITE_S3_ENABLED:-false}"
+MINIO_ENDPOINT="${MINIO_ENDPOINT:-http://minio:9000}"
+MINIO_BUCKET="${MINIO_BUCKET:-relay}"
+OFFSITE_S3_PREFIX="${OFFSITE_S3_PREFIX:-minio/}"
+SENTINEL_FILE="${SENTINEL_FILE:-/backups/.last-offsite-mirror}"
+
+log_info()  { echo "{\"timestamp\":\"$(date -Iseconds)\",\"level\":\"INFO\",\"message\":\"$1\"}"; }
+log_error() { echo "{\"timestamp\":\"$(date -Iseconds)\",\"level\":\"ERROR\",\"message\":\"$1\"}" >&2; }
+log_ok()    { echo "{\"timestamp\":\"$(date -Iseconds)\",\"level\":\"INFO\",\"message\":\"$1\",\"status\":\"success\"}"; }
+
+if [ "${OFFSITE_S3_ENABLED}" != "true" ]; then
+    log_info "OFFSITE_S3_ENABLED != true — skipping mirror"
+    exit 0
+fi
+
+for var in OFFSITE_S3_ENDPOINT OFFSITE_S3_ACCESS OFFSITE_S3_SECRET OFFSITE_S3_BUCKET; do
+    [ -z "${!var:-}" ] && { log_error "Missing required var: $var"; exit 1; }
+done
+
+log_info "Configuring mc aliases"
+mc alias set local "${MINIO_ENDPOINT}" "${MINIO_ROOT_USER}" "${MINIO_ROOT_PASSWORD}" --quiet
+mc alias set offsite "${OFFSITE_S3_ENDPOINT}" "${OFFSITE_S3_ACCESS}" "${OFFSITE_S3_SECRET}" --quiet
+
+SRC="local/${MINIO_BUCKET}"
+DST="offsite/${OFFSITE_S3_BUCKET}/${OFFSITE_S3_PREFIX}"
+
+log_info "Starting mirror: ${SRC} → ${DST}"
+if mc mirror --overwrite --remove "${SRC}" "${DST}"; then
+    log_ok "Mirror complete: ${SRC} → ${DST}"
+    # Write sentinel so backup-offsite-alert.sh can check mirror run time,
+    # not object modification time (incremental mirror has no new objects when
+    # docs are unchanged — causes false-positive "stale" alerts).
+    date +%s > "${SENTINEL_FILE}" && log_info "Sentinel written: ${SENTINEL_FILE}"
+else
+    log_error "Mirror failed: ${SRC} → ${DST}"
+    exit 1
+fi

--- a/infra/backup/restore-test.sh
+++ b/infra/backup/restore-test.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+#
+# restore-test.sh — spin up a temp postgres container, restore the latest dump,
+# verify table count > 0, then destroy the container.
+#
+# Designed to run on the Docker host (not inside the backup container) so it
+# can pull images and manage containers. Can also be invoked in CI.
+#
+# Required env vars (or inherit from .env):
+#   BACKUP_DIR      - directory with *.sql.gz dumps (default: /opt/relay/data/backups)
+#   POSTGRES_DB     - database name to restore into (default: relay)
+#   POSTGRES_USER   - postgres superuser (default: postgres)
+#   POSTGRES_PASSWORD - postgres password for the temp container
+
+set -euo pipefail
+
+BACKUP_DIR="${BACKUP_DIR:-/opt/relay/data/backups}"
+POSTGRES_DB="${POSTGRES_DB:-relay}"
+POSTGRES_USER="${POSTGRES_USER:-postgres}"
+POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-restore_test_$(date +%s)}"
+CONTAINER_NAME="relay-restore-test-$$"
+PG_IMAGE="postgres:16-alpine"
+
+log()  { echo "[$(date -Iseconds)] $*"; }
+pass() { echo "[$(date -Iseconds)] ✓ $*"; }
+fail() { echo "[$(date -Iseconds)] ✗ $*" >&2; exit 1; }
+
+cleanup() {
+    log "Cleaning up test container ${CONTAINER_NAME}"
+    docker rm -f "${CONTAINER_NAME}" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+# Find latest dump
+BACKUP_FILE="${BACKUP_DIR}/${POSTGRES_DB}_latest.sql.gz"
+if [ ! -e "${BACKUP_FILE}" ]; then
+    # Fallback: newest matching file
+    BACKUP_FILE=$(find "${BACKUP_DIR}" -name "${POSTGRES_DB}_*.sql.gz" -type f \
+        | sort -r | head -1)
+fi
+[ -z "${BACKUP_FILE}" ] && fail "No backup found in ${BACKUP_DIR}"
+[ -f "${BACKUP_FILE}" ] || BACKUP_FILE="$(readlink -f "${BACKUP_FILE}")"
+log "Using backup: ${BACKUP_FILE}"
+
+# Verify gzip integrity
+gzip -t "${BACKUP_FILE}" || fail "Backup file is corrupt: ${BACKUP_FILE}"
+pass "gzip integrity OK"
+
+# Start temp postgres container
+log "Starting temp container ${CONTAINER_NAME}"
+docker run -d --name "${CONTAINER_NAME}" \
+    -e POSTGRES_USER="${POSTGRES_USER}" \
+    -e POSTGRES_PASSWORD="${POSTGRES_PASSWORD}" \
+    -e POSTGRES_DB="${POSTGRES_DB}" \
+    "${PG_IMAGE}" >/dev/null
+
+# Wait for postgres to be ready
+for i in $(seq 1 20); do
+    if docker exec "${CONTAINER_NAME}" pg_isready -U "${POSTGRES_USER}" -q 2>/dev/null; then
+        break
+    fi
+    sleep 2
+    [ "$i" -eq 20 ] && fail "Postgres did not start in ${CONTAINER_NAME}"
+done
+pass "Temp postgres ready"
+
+# Restore dump
+log "Restoring ${BACKUP_FILE} into ${CONTAINER_NAME}/${POSTGRES_DB}"
+gunzip -c "${BACKUP_FILE}" | docker exec -i "${CONTAINER_NAME}" \
+    psql -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -q
+pass "Restore complete"
+
+# Verify: table count > 0
+TABLE_COUNT=$(docker exec "${CONTAINER_NAME}" \
+    psql -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -tAc \
+    "SELECT count(*) FROM information_schema.tables WHERE table_schema='public'")
+TABLE_COUNT="${TABLE_COUNT//[[:space:]]/}"
+log "Public tables found: ${TABLE_COUNT}"
+
+[ "${TABLE_COUNT:-0}" -gt 0 ] || fail "Restore produced 0 tables — dump may be empty or corrupt"
+pass "Restore-test PASSED: ${TABLE_COUNT} tables in ${POSTGRES_DB}"
+
+echo ""
+echo "=== RESTORE-TEST RESULT ==="
+echo "Backup: ${BACKUP_FILE}"
+echo "Tables restored: ${TABLE_COUNT}"
+echo "Status: PASS"

--- a/scripts/backup-offsite-alert.sh
+++ b/scripts/backup-offsite-alert.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# Check that off-site MinIO mirror is fresh (< MAX_AGE_HOURS)
+# Runs hourly from cron via: /opt/relay/backup-offsite-alert.sh >> /var/log/backup-offsite-alert.log 2>&1
+# Source backup-alert.env for TG creds.
+#
+# Checks (in order):
+#   1. pg-dump off-site freshness — object-based (pg-dump always creates a new file, so object age = run age)
+#   2. mc mirror freshness — sentinel-based (/opt/relay/data/backups/.last-offsite-mirror written by
+#      minio-mirror.sh on success). Incremental mirror has no new objects when docs are unchanged,
+#      so object age is NOT a reliable indicator of whether mirror ran.
+
+set -euo pipefail
+
+MAX_AGE_HOURS=26
+CONTAINER=relay-postgres-backup-1
+BUCKET=relay-backup
+PREFIX=minio/
+SENTINEL=/opt/relay/data/backups/.last-offsite-mirror
+
+. /opt/relay/backup-alert.env 2>/dev/null || true
+TG_ENABLED="${TG_ENABLED:-false}"
+
+log() { echo "[$(date -Iseconds)] $*"; }
+
+tg_send() {
+    local msg="$1"
+    if [ "${TG_ENABLED}" = "true" ]; then
+        curl -fsSL -X POST "https://api.telegram.org/bot${TG_BOT_TOKEN}/sendMessage" \
+            -d "chat_id=${TG_CHAT_ID}" -d "parse_mode=Markdown" \
+            --data-urlencode "text=${msg}" >/dev/null
+    fi
+}
+
+NOW=$(date +%s)
+
+# ── 1. pg-dump freshness (object-based — correct: each dump creates a new file) ──────────────────
+PG_LINE=$(docker exec "$CONTAINER" mc ls "offsite/${BUCKET}/postgres/" 2>/dev/null | sort | tail -1)
+if [ -z "$PG_LINE" ]; then
+    log "ERROR: off-site postgres/ folder is empty — pg-dump never uploaded off-site"
+    tg_send "🚨 *TR off-site pg-dump MISSING* — no pg-dump in offsite/${BUCKET}/postgres/. Check backup-pg-offsite.sh."
+    exit 2
+fi
+PG_MTIME_STR=$(echo "$PG_LINE" | awk '{gsub(/^\[/,"",$1); print $1, $2}')
+PG_MTIME=$(date -d "${PG_MTIME_STR} UTC" +%s 2>/dev/null || echo 0)
+PG_AGE_HOURS=$(( (NOW - PG_MTIME) / 3600 ))
+log "Off-site pg-dump age: ${PG_AGE_HOURS}h (threshold: ${MAX_AGE_HOURS}h, file: ${PG_MTIME_STR} UTC)"
+if [ "${PG_AGE_HOURS}" -gt "${MAX_AGE_HOURS}" ]; then
+    log "ALERT: pg-dump off-site stale (${PG_AGE_HOURS}h > ${MAX_AGE_HOURS}h)"
+    tg_send "🚨 *TR off-site pg-dump STALE* — last dump ${PG_MTIME_STR} UTC (${PG_AGE_HOURS}h ago). Check backup-pg-offsite.sh cron."
+    exit 2
+fi
+
+# ── 2. mc mirror freshness (sentinel-based — NOT object-age) ─────────────────────────────────────
+# minio-mirror.sh writes date +%s to SENTINEL after every successful mirror run.
+# If no documents changed, mc mirror has nothing new to upload (incremental), so
+# newest-object timestamp is stale even though mirror worked fine.
+if [ -f "${SENTINEL}" ]; then
+    MIRROR_MTIME=$(cat "${SENTINEL}" 2>/dev/null || echo 0)
+    MIRROR_AGE_HOURS=$(( (NOW - MIRROR_MTIME) / 3600 ))
+    log "Last successful mirror run: ${MIRROR_AGE_HOURS}h ago (sentinel: ${SENTINEL})"
+    if [ "${MIRROR_AGE_HOURS}" -le "${MAX_AGE_HOURS}" ]; then
+        log "OK — off-site mirror is fresh (sentinel ${MIRROR_AGE_HOURS}h old)"
+        exit 0
+    fi
+    log "ALERT: off-site mirror stale — last run ${MIRROR_AGE_HOURS}h ago (> ${MAX_AGE_HOURS}h)"
+    tg_send "🚨 *TR off-site mirror STALE* — last successful run ${MIRROR_AGE_HOURS}h ago (threshold ${MAX_AGE_HOURS}h). Check minio-mirror.sh / backup container logs."
+    exit 2
+else
+    # Sentinel doesn't exist yet (first run after deploy, or container recreated).
+    # Fall back to object-age check with a warning. This transition path is temporary —
+    # next successful mirror run will create the sentinel and we'll use that going forward.
+    log "WARN: sentinel ${SENTINEL} not found — falling back to object-age check (one-time, post-deploy)"
+    LAST_LINE=$(docker exec "$CONTAINER" mc ls "offsite/${BUCKET}/${PREFIX}" --recursive 2>/dev/null | sort | tail -1)
+    if [ -z "$LAST_LINE" ]; then
+        log "ERROR: off-site bucket ${BUCKET}/${PREFIX} is empty or unreachable"
+        tg_send "🚨 *TR off-site backup EMPTY* — bucket ${BUCKET}/${PREFIX} returned no objects. Check mc mirror."
+        exit 2
+    fi
+    MTIME_STR=$(echo "$LAST_LINE" | awk '{gsub(/^\[/,"",$1); print $1, $2}')
+    MTIME=$(date -d "${MTIME_STR} UTC" +%s 2>/dev/null || echo 0)
+    AGE_HOURS=$(( (NOW - MTIME) / 3600 ))
+    log "Off-site last object (fallback): ${MTIME_STR} UTC — age: ${AGE_HOURS}h (threshold: ${MAX_AGE_HOURS}h)"
+    if [ "${AGE_HOURS}" -le "${MAX_AGE_HOURS}" ]; then
+        log "OK — off-site mirror appears fresh (object-age fallback)"
+        exit 0
+    fi
+    log "ALERT: off-site mirror stale by object-age fallback (${AGE_HOURS}h > ${MAX_AGE_HOURS}h)"
+    tg_send "🚨 *TR off-site mirror STALE* — last object ${MTIME_STR} UTC (${AGE_HOURS}h ago, threshold ${MAX_AGE_HOURS}h). Mirror may have failed silently."
+    exit 2
+fi


### PR DESCRIPTION
## Problem

`backup-offsite-alert.sh` was checking off-site mirror freshness by querying the age of the newest object in the S3 bucket. `mc mirror` is incremental — when no documents have changed, nothing is uploaded, so the newest-object timestamp goes stale even though mirror ran successfully. This caused a false-positive alert every ~30h on quieter days.

## Fix

`minio-mirror.sh` now writes `date +%s` to `/backups/.last-offsite-mirror` (a sentinel file, persisted via bind-mount) after each successful mirror. `backup-offsite-alert.sh` reads sentinel age instead of object age for the mirror freshness check. Falls back to object-age if the sentinel doesn't exist yet (first run after deploy).

## Verification

Tested on `tw-relay` (2026-07-08):

**Fresh path:**
```
[2026-07-08T22:10:16+00:00] OK — off-site mirror is fresh (sentinel 0h old)
```

**Stale path** (sentinel backdated 27h):
```
[2026-07-08T22:10:39+00:00] Last successful mirror run: 27h ago (sentinel: ...)
[2026-07-08T22:10:39+00:00] ALERT: off-site mirror stale — last run 27h ago (> 26h)
```

## Changes

- `infra/backup/minio-mirror.sh` — new; writes sentinel after successful mirror
- `infra/backup/backup-age-alert.sh` — new; local backup age TG alert (host-side cron)
- `infra/backup/restore-test.sh` — new; spins up temp postgres, restores latest dump, verifies table count
- `infra/backup/Dockerfile` — updated: adds `mc` install + copies the three new scripts
- `infra/backup/backup.sh` — updated: adds `run_offsite_mirror()` which calls `minio-mirror.sh` after backup
- `scripts/backup-offsite-alert.sh` — new; off-site alert script (host-side, deployed to `/opt/relay/`)

All scripts are already deployed and running on `tw-relay`.