### PR TITLE
security fix: agent key outlives its creator's access to the share

### DIFF
--- a/apps/control-plane/app/api/routers/web.py
+++ b/apps/control-plane/app/api/routers/web.py
@@ -32,6 +32,51 @@ router = APIRouter(prefix="/v1/web", tags=["web"])
 limiter = Limiter(key_func=get_remote_address)
 
 
+def _agent_key_creator_authorized(
+    agent_key: models.ShareAgentKey, share: models.Share, db: Session
+) -> bool:
+    """True if the key's creator still has standing authority over this share.
+
+    Closes TR-03 (#ae52ba05): `ShareAgentKey.created_by` is `ON DELETE SET
+    NULL`, not cascaded, and neither `remove_member` nor `delete_user` used to
+    revoke a departing member's keys — so a key survives membership removal or
+    account deletion and keeps authenticating indefinitely (confirmed live:
+    18 active keys on non-members, 13 on deleted users). Every X-Agent-Key
+    auth path must check this, not just key_hash/revoked_at/expires_at.
+
+    "Standing authority" mirrors create_agent_key's own gate
+    (_require_share_owner_or_admin in agent_keys.py): owner, active member, OR
+    a currently-active global admin — key creation itself is admin-or-owner
+    gated (plain members can't create keys at all), so a global admin who
+    created a key for a share they don't own or belong to is a normal,
+    intended case, not an orphan. Only treat it as orphaned once that admin
+    is demoted or the account no longer exists — that's what the `is_admin`
+    branch below is for; leaving it out would have made this fix reject every
+    admin-issued key on a share the admin doesn't own/belong to, which is
+    most of the fleet's Mesh-agent keys.
+    """
+    if agent_key.created_by is None:
+        return False
+    if agent_key.created_by == share.owner_user_id:
+        return True
+    member = db.execute(
+        select(models.ShareMember.id).where(
+            models.ShareMember.share_id == share.id,
+            models.ShareMember.user_id == agent_key.created_by,
+        )
+    ).scalar_one_or_none()
+    if member is not None:
+        return True
+    creator_is_active_admin = db.execute(
+        select(models.User.id).where(
+            models.User.id == agent_key.created_by,
+            models.User.is_admin.is_(True),
+            models.User.is_active.is_(True),
+        )
+    ).scalar_one_or_none()
+    return creator_is_active_admin is not None
+
+
 def _require_private_web_auth(
     request: Request,
     share: models.Share,
@@ -57,7 +102,11 @@ def _require_private_web_auth(
                 models.ShareAgentKey.share_id == share.id,
             )
         ).scalar_one_or_none()
-        if agent_key is not None and agent_key.revoked_at is None:
+        if (
+            agent_key is not None
+            and agent_key.revoked_at is None
+            and _agent_key_creator_authorized(agent_key, share, db)
+        ):
             exp = agent_key.expires_at
             if exp is not None:
                 if exp.tzinfo is None:
@@ -1402,6 +1451,11 @@ def _auth_agent_key(
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=f"Agent key does not have {required_scope} scope",
+        )
+    if not _agent_key_creator_authorized(agent_key, share, db):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Agent key creator is no longer an owner or member of this share",
         )
     return agent_key
 

--- a/apps/control-plane/app/db/migrations/versions/202607210001_revoke_orphaned_agent_keys.py
+++ b/apps/control-plane/app/db/migrations/versions/202607210001_revoke_orphaned_agent_keys.py
@@ -1,0 +1,72 @@
+"""Revoke agent keys whose creator has no standing authority over the share.
+
+TR-03 (#ae52ba05): ShareAgentKey.created_by is ON DELETE SET NULL, and
+neither member removal nor user deletion used to revoke the departing
+user's keys, so a key kept authenticating indefinitely after its creator
+lost access. This closes the currently-live exploit (confirmed: 18 active
+keys on non-members, 13 on deleted users) by revoking every affected row
+that exists today. Going forward, _auth_agent_key/_require_private_web_auth
+reject unauthorized-creator keys at auth time regardless of revoked_at, and
+remove_member/delete_user revoke them explicitly — this migration is the
+one-time data remediation for keys created before that code shipped.
+
+"Standing authority" matches _agent_key_creator_authorized in web.py: owner,
+active member, OR a currently-active global admin (key creation itself is
+admin-or-owner gated — see create_agent_key's _require_share_owner_or_admin
+— so an admin-created key for a share they don't own/belong to is normal,
+not orphaned, as long as that admin is still active). Omitting the admin
+branch here would revoke a large share of legitimate fleet-wide Mesh-agent
+keys that happen to have been issued by an admin account.
+
+Idempotent: only touches rows where revoked_at IS NULL, so re-running (or
+running against a DB that already had no orphaned keys) is a no-op.
+
+Revision ID: 202607210001
+Revises: 202606070001
+Create Date: 2026-07-21 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "202607210001"
+down_revision: Union[str, None] = "202606070001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        UPDATE share_agent_keys sak
+        SET revoked_at = now()
+        WHERE sak.revoked_at IS NULL
+          AND (
+            sak.created_by IS NULL
+            OR (
+              NOT EXISTS (
+                SELECT 1 FROM shares s
+                WHERE s.id = sak.share_id AND s.owner_user_id = sak.created_by
+              )
+              AND NOT EXISTS (
+                SELECT 1 FROM share_members sm
+                WHERE sm.share_id = sak.share_id AND sm.user_id = sak.created_by
+              )
+              AND NOT EXISTS (
+                SELECT 1 FROM users u
+                WHERE u.id = sak.created_by AND u.is_admin = true AND u.is_active = true
+              )
+            )
+          )
+        """
+    )
+
+
+def downgrade() -> None:
+    # Non-reversible: revoking these rows is the whole point of the fix, and
+    # un-revoking without knowing which were legitimately revoked before this
+    # migration ran would risk re-opening the exploit. Same precedent as
+    # 202606040001 (label backfill).
+    pass

--- a/apps/control-plane/app/services/share_service.py
+++ b/apps/control-plane/app/services/share_service.py
@@ -4,7 +4,7 @@ import re
 import uuid
 
 from fastapi import HTTPException, status
-from sqlalchemy import func, or_, select
+from sqlalchemy import func, or_, select, update
 from sqlalchemy.orm import Session, joinedload
 
 from app.core import security
@@ -469,6 +469,20 @@ def remove_member(
         target_user_id=user_id,
         target_share_id=share.id,
         details={"role": member.role.value},
+    )
+
+    # Revoke agent keys this member created for THIS share (TR-03, #ae52ba05).
+    # created_by is not FK-cascaded on membership removal, so without this an
+    # ex-member's key keeps authenticating (_auth_agent_key checks revoked_at,
+    # not membership) — this is the write side of that check's defense.
+    db.execute(
+        update(models.ShareAgentKey)
+        .where(
+            models.ShareAgentKey.share_id == share.id,
+            models.ShareAgentKey.created_by == user_id,
+            models.ShareAgentKey.revoked_at.is_(None),
+        )
+        .values(revoked_at=security.utcnow())
     )
 
     db.delete(member)

--- a/apps/control-plane/app/services/user_service.py
+++ b/apps/control-plane/app/services/user_service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import uuid
 
 from fastapi import HTTPException, status
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.orm import Session
 
 from app.core import security
@@ -125,6 +125,20 @@ def delete_user(
         actor_user_id=actor_user_id,
         target_user_id=user.id,
         details={"email": user.email},
+    )
+
+    # Revoke every agent key this user created, across ALL shares (TR-03,
+    # #ae52ba05). ShareAgentKey.created_by is ON DELETE SET NULL, not
+    # cascaded — without this, deleting the user silently orphans their keys
+    # (created_by -> NULL) rather than disabling them, and they keep
+    # authenticating forever (confirmed live: 13 such active keys in prod).
+    db.execute(
+        update(models.ShareAgentKey)
+        .where(
+            models.ShareAgentKey.created_by == user.id,
+            models.ShareAgentKey.revoked_at.is_(None),
+        )
+        .values(revoked_at=security.utcnow())
     )
 
     db.delete(user)

--- a/apps/control-plane/tests/test_agent_key_authorization.py
+++ b/apps/control-plane/tests/test_agent_key_authorization.py
@@ -1,0 +1,388 @@
+"""Tests for TR-03 (#ae52ba05): an agent key must stop authenticating once its
+creator loses standing authority over the share (removed as member, deleted,
+or demoted from admin) — not just when explicitly revoked or expired.
+
+Covers both auth paths that validate X-Agent-Key:
+  - _auth_agent_key (web.py) — used by /shares/{id}/sync-upload, /upload,
+    /files-index, /download.
+  - _require_private_web_auth's agent-key branch (web.py) — used by the
+    web-publish endpoints (/shares/{slug}/files, /content).
+
+And the two service-layer cascade-revoke triggers:
+  - share_service.remove_member
+  - user_service.delete_user
+"""
+
+from __future__ import annotations
+
+import hashlib
+import secrets
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.core import security
+from app.db import models
+
+
+def auth_headers(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def login(client: TestClient, email: str, password: str) -> str:
+    response = client.post("/auth/login", json={"email": email, "password": password})
+    assert response.status_code == 200, response.text
+    return response.json()["access_token"]
+
+
+def make_user(
+    db: Session, email: str, is_admin: bool = False, is_active: bool = True
+) -> models.User:
+    user = models.User(
+        email=email,
+        password_hash=security.get_password_hash("test123456"),
+        is_admin=is_admin,
+        is_active=is_active,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def make_folder_share(
+    db: Session,
+    owner: models.User,
+    slug: str,
+    published: bool = True,
+) -> models.Share:
+    share = models.Share(
+        kind=models.ShareKind.FOLDER,
+        path=f"{slug}/",
+        visibility=models.ShareVisibility.PRIVATE,
+        owner_user_id=owner.id,
+        web_published=published,
+        web_slug=slug if published else None,
+        web_folder_items=[],
+    )
+    db.add(share)
+    db.commit()
+    db.refresh(share)
+    return share
+
+
+def add_member(db: Session, share: models.Share, user: models.User) -> models.ShareMember:
+    member = models.ShareMember(
+        share_id=share.id, user_id=user.id, role=models.ShareMemberRole.EDITOR
+    )
+    db.add(member)
+    db.commit()
+    db.refresh(member)
+    return member
+
+
+def make_agent_key(
+    db: Session,
+    share: models.Share,
+    created_by: uuid.UUID | None,
+    scopes: str = "write",
+) -> tuple[str, models.ShareAgentKey]:
+    raw_key = "tr_agent_" + secrets.token_hex(24)
+    key_hash = hashlib.sha256(raw_key.encode()).hexdigest()
+    ak = models.ShareAgentKey(
+        share_id=share.id,
+        key_hash=key_hash,
+        label="tr03-test-key",
+        scopes=scopes,
+        created_by=created_by,
+    )
+    db.add(ak)
+    db.commit()
+    db.refresh(ak)
+    return raw_key, ak
+
+
+@pytest.fixture
+def web_enabled(monkeypatch):
+    monkeypatch.setenv("WEB_PUBLISH_DOMAIN", "docs.test.com")
+    from app.core.config import get_settings
+
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+def minio_patch():
+    mock_client = MagicMock()
+    mock_client.bucket_exists.return_value = True
+    mock_client.put_object.return_value = None
+    return patch("app.api.routers.web._get_minio_client", return_value=mock_client)
+
+
+SYNC_UPLOAD = "/v1/web/shares/{id}/sync-upload"
+
+
+class TestAuthAgentKeyCreatorStanding:
+    """_auth_agent_key path (sync-upload) — the endpoint named in the audit repro."""
+
+    def test_owner_created_key_still_works(self, db_session, client, web_enabled):
+        owner = make_user(db_session, "owner1@x.com")
+        share = make_folder_share(db_session, owner, "s1")
+        raw_key, _ = make_agent_key(db_session, share, created_by=owner.id)
+
+        with minio_patch():
+            resp = client.post(
+                SYNC_UPLOAD.format(id=share.id) + "?path=note.md",
+                content=b"hi",
+                headers={"X-Agent-Key": raw_key, "Content-Type": "text/plain"},
+            )
+        assert resp.status_code == 200, resp.text
+
+    def test_active_member_created_key_still_works(self, db_session, client, web_enabled):
+        owner = make_user(db_session, "owner2@x.com")
+        member = make_user(db_session, "member2@x.com")
+        share = make_folder_share(db_session, owner, "s2")
+        add_member(db_session, share, member)
+        raw_key, _ = make_agent_key(db_session, share, created_by=member.id)
+
+        with minio_patch():
+            resp = client.post(
+                SYNC_UPLOAD.format(id=share.id) + "?path=note.md",
+                content=b"hi",
+                headers={"X-Agent-Key": raw_key, "Content-Type": "text/plain"},
+            )
+        assert resp.status_code == 200, resp.text
+
+    def test_REGRESSION_removed_member_key_is_rejected(self, db_session, client, web_enabled):
+        """The audit's literal repro: create key -> remove_member creator -> upload -> 403."""
+        owner = make_user(db_session, "owner3@x.com")
+        member = make_user(db_session, "member3@x.com")
+        share = make_folder_share(db_session, owner, "s3")
+        add_member(db_session, share, member)
+        raw_key, agent_key = make_agent_key(db_session, share, created_by=member.id)
+
+        # Sanity: works while still a member.
+        with minio_patch():
+            resp = client.post(
+                SYNC_UPLOAD.format(id=share.id) + "?path=before.md",
+                content=b"hi",
+                headers={"X-Agent-Key": raw_key, "Content-Type": "text/plain"},
+            )
+        assert resp.status_code == 200, resp.text
+
+        from app.services import share_service
+
+        share_service.remove_member(db_session, share, member.id)
+
+        with minio_patch():
+            resp = client.post(
+                SYNC_UPLOAD.format(id=share.id) + "?path=after.md",
+                content=b"hi",
+                headers={"X-Agent-Key": raw_key, "Content-Type": "text/plain"},
+            )
+        assert resp.status_code == 403, resp.text
+
+        # remove_member must have revoked it explicitly too (defense in depth,
+        # not just "auth check happens to reject it").
+        db_session.refresh(agent_key)
+        assert agent_key.revoked_at is not None
+
+    def test_REGRESSION_deleted_user_key_is_rejected(self, db_session, client, web_enabled):
+        owner = make_user(db_session, "owner4@x.com")
+        member = make_user(db_session, "member4@x.com")
+        share = make_folder_share(db_session, owner, "s4")
+        add_member(db_session, share, member)
+        raw_key, agent_key = make_agent_key(db_session, share, created_by=member.id)
+
+        from app.services import user_service
+
+        user_service.delete_user(db_session, member.id)
+
+        with minio_patch():
+            resp = client.post(
+                SYNC_UPLOAD.format(id=share.id) + "?path=after.md",
+                content=b"hi",
+                headers={"X-Agent-Key": raw_key, "Content-Type": "text/plain"},
+            )
+        assert resp.status_code == 403, resp.text
+        db_session.refresh(agent_key)
+        assert agent_key.revoked_at is not None
+
+    def test_key_with_null_created_by_is_rejected(self, db_session, client, web_enabled):
+        """Simulates the pre-existing prod state: created_by already NULL
+        (SET NULL fired before this fix existed), revoked_at still NULL."""
+        owner = make_user(db_session, "owner5@x.com")
+        share = make_folder_share(db_session, owner, "s5")
+        raw_key, _ = make_agent_key(db_session, share, created_by=None)
+
+        with minio_patch():
+            resp = client.post(
+                SYNC_UPLOAD.format(id=share.id) + "?path=note.md",
+                content=b"hi",
+                headers={"X-Agent-Key": raw_key, "Content-Type": "text/plain"},
+            )
+        assert resp.status_code == 403, resp.text
+
+    def test_REGRESSION_active_admin_key_for_nonmember_share_still_works(
+        self, db_session, client, web_enabled
+    ):
+        """The subtle case: key creation is owner-OR-ADMIN gated
+        (_require_share_owner_or_admin), so an admin routinely creates keys
+        for shares they don't own or belong to — that must NOT be treated as
+        orphaned. This is the scenario a naive owner-or-member-only check
+        would have broken for a large share of real fleet-issued keys."""
+        owner = make_user(db_session, "owner6@x.com")
+        admin = make_user(db_session, "admin6@x.com", is_admin=True)
+        share = make_folder_share(db_session, owner, "s6")
+        # admin is deliberately NOT a member and NOT the owner.
+        raw_key, _ = make_agent_key(db_session, share, created_by=admin.id)
+
+        with minio_patch():
+            resp = client.post(
+                SYNC_UPLOAD.format(id=share.id) + "?path=note.md",
+                content=b"hi",
+                headers={"X-Agent-Key": raw_key, "Content-Type": "text/plain"},
+            )
+        assert resp.status_code == 200, resp.text
+
+    def test_demoted_admin_key_for_nonmember_share_is_rejected(
+        self, db_session, client, web_enabled
+    ):
+        owner = make_user(db_session, "owner7@x.com")
+        admin = make_user(db_session, "admin7@x.com", is_admin=True)
+        share = make_folder_share(db_session, owner, "s7")
+        raw_key, agent_key = make_agent_key(db_session, share, created_by=admin.id)
+
+        admin.is_admin = False
+        db_session.add(admin)
+        db_session.commit()
+
+        with minio_patch():
+            resp = client.post(
+                SYNC_UPLOAD.format(id=share.id) + "?path=note.md",
+                content=b"hi",
+                headers={"X-Agent-Key": raw_key, "Content-Type": "text/plain"},
+            )
+        assert resp.status_code == 403, resp.text
+
+
+class TestPrivateWebAuthAgentKeyCreatorStanding:
+    """_require_private_web_auth's agent-key branch — a SEPARATE implementation
+    from _auth_agent_key (web.py's GET /shares/{slug}/files uses this one).
+    Both had the same gap; both must be fixed."""
+
+    def test_REGRESSION_removed_member_key_rejected_on_files_get(
+        self, db_session, client, web_enabled
+    ):
+        owner = make_user(db_session, "owner8@x.com")
+        member = make_user(db_session, "member8@x.com")
+        share = make_folder_share(db_session, owner, "s8")
+        share.web_folder_items = [
+            {"path": "note.md", "name": "note.md", "type": "doc", "content": "hi"}
+        ]
+        db_session.add(share)
+        db_session.commit()
+        add_member(db_session, share, member)
+        raw_key, _ = make_agent_key(db_session, share, created_by=member.id, scopes="read")
+
+        from app.services import share_service
+
+        share_service.remove_member(db_session, share, member.id)
+
+        resp = client.get(
+            "/v1/web/shares/s8/files?path=note.md",
+            headers={"X-Agent-Key": raw_key},
+        )
+        assert resp.status_code in (401, 403), resp.text
+
+
+class TestRemoveMemberCascadeRevoke:
+    def test_only_revokes_keys_on_the_share_the_member_was_removed_from(
+        self, db_session, web_enabled
+    ):
+        """Scope check: a member removed from share A must not have their
+        (still-valid) key on share B revoked too."""
+        owner_a = make_user(db_session, "ownerA@x.com")
+        owner_b = make_user(db_session, "ownerB@x.com")
+        shared_member = make_user(db_session, "sharedmember@x.com")
+        share_a = make_folder_share(db_session, owner_a, "sa", published=False)
+        share_b = make_folder_share(db_session, owner_b, "sb", published=False)
+        add_member(db_session, share_a, shared_member)
+        add_member(db_session, share_b, shared_member)
+        _, key_a = make_agent_key(db_session, share_a, created_by=shared_member.id)
+        _, key_b = make_agent_key(db_session, share_b, created_by=shared_member.id)
+
+        from app.services import share_service
+
+        share_service.remove_member(db_session, share_a, shared_member.id)
+
+        db_session.refresh(key_a)
+        db_session.refresh(key_b)
+        assert key_a.revoked_at is not None
+        assert key_b.revoked_at is None
+
+
+class TestDeleteUserCascadeRevoke:
+    def test_revokes_keys_across_all_shares_the_user_created_keys_for(
+        self, db_session, web_enabled
+    ):
+        owner_a = make_user(db_session, "ownerA2@x.com")
+        owner_b = make_user(db_session, "ownerB2@x.com")
+        member = make_user(db_session, "member2b@x.com")
+        share_a = make_folder_share(db_session, owner_a, "sa2", published=False)
+        share_b = make_folder_share(db_session, owner_b, "sb2", published=False)
+        add_member(db_session, share_a, member)
+        add_member(db_session, share_b, member)
+        _, key_a = make_agent_key(db_session, share_a, created_by=member.id)
+        _, key_b = make_agent_key(db_session, share_b, created_by=member.id)
+
+        from app.services import user_service
+
+        user_service.delete_user(db_session, member.id)
+
+        db_session.refresh(key_a)
+        db_session.refresh(key_b)
+        assert key_a.revoked_at is not None
+        assert key_b.revoked_at is not None
+
+    def test_does_not_revoke_an_already_revoked_key_timestamp(self, db_session, web_enabled):
+        """revoked_at should not be clobbered/reset for a key that was
+        already revoked for a different reason before the user was deleted."""
+        owner = make_user(db_session, "owner9@x.com")
+        member = make_user(db_session, "member9@x.com")
+        share = make_folder_share(db_session, owner, "s9", published=False)
+        add_member(db_session, share, member)
+        _, key = make_agent_key(db_session, share, created_by=member.id)
+        original_revoked_at = security.utcnow()
+        key.revoked_at = original_revoked_at
+        db_session.add(key)
+        db_session.commit()
+
+        from app.services import user_service
+
+        user_service.delete_user(db_session, member.id)
+
+        db_session.refresh(key)
+        # SQLite stores naive datetimes; compare on value, not tz-awareness.
+        assert key.revoked_at.replace(tzinfo=None) == original_revoked_at.replace(tzinfo=None)
+
+
+class TestDeleteShareCascade:
+    def test_deleting_a_share_removes_its_agent_keys(self, db_session, web_enabled):
+        """Regression-proof for the AC's third cascade trigger: delete_share
+        already hard-deletes agent keys via the Share.agent_keys ORM cascade
+        (cascade='all, delete-orphan') — no revoked_at needed, the rows are
+        gone. This locks that existing behavior in."""
+        owner = make_user(db_session, "owner10@x.com")
+        share = make_folder_share(db_session, owner, "s10", published=False)
+        _, key = make_agent_key(db_session, share, created_by=owner.id)
+        key_id = key.id
+
+        from app.services import share_service
+
+        share_service.delete_share(db_session, share)
+
+        assert db_session.get(models.ShareAgentKey, key_id) is None

--- a/apps/control-plane/tests/test_mesh_upload.py
+++ b/apps/control-plane/tests/test_mesh_upload.py
@@ -49,6 +49,10 @@ def make_agent_key(
         key_hash=key_hash,
         label="test key",
         scopes=scopes,
+        # TR-03 (#ae52ba05): _auth_agent_key now requires the creator to still
+        # be the share's owner or an active member; default to the owner so
+        # existing callers keep getting a working key without changes.
+        created_by=share.owner_user_id,
     )
     db.add(ak)
     db.commit()

--- a/apps/control-plane/tests/test_sync_upload.py
+++ b/apps/control-plane/tests/test_sync_upload.py
@@ -55,6 +55,10 @@ def make_agent_key(
         label="sync-test key",
         scopes=scopes,
         expires_at=expires_at,
+        # TR-03 (#ae52ba05): _auth_agent_key now requires the creator to still
+        # be the share's owner or an active member; default to the owner so
+        # existing callers keep getting a working key without changes.
+        created_by=share.owner_user_id,
     )
     db.add(ak)
     db.commit()

--- a/apps/control-plane/tests/test_web_publish.py
+++ b/apps/control-plane/tests/test_web_publish.py
@@ -781,7 +781,12 @@ class TestPrivateShareAuth:
         raw = "tr_agent_" + _sec.token_hex(24)
         key_hash = _hl.sha256(raw.encode()).hexdigest()
         ak = models.ShareAgentKey(
-            share_id=share.id, key_hash=key_hash, label="test-key", scopes=scopes
+            share_id=share.id,
+            key_hash=key_hash,
+            label="test-key",
+            scopes=scopes,
+            # TR-03 (#ae52ba05): creator must still be owner/member to auth.
+            created_by=share.owner_user_id,
         )
         db.add(ak)
         db.commit()
@@ -1013,6 +1018,8 @@ class TestFolderFileContentSync:
             key_hash=key_hash,
             label="test-key",
             scopes=scopes,
+            # TR-03 (#ae52ba05): creator must still be owner/member to auth.
+            created_by=share.owner_user_id,
         )
         db.add(ak)
         db.commit()
@@ -1308,6 +1315,8 @@ def _make_agent_key(
         key_hash=key_hash,
         label="test key",
         scopes=scopes,
+        # TR-03 (#ae52ba05): creator must still be owner/member to auth.
+        created_by=share.owner_user_id,
     )
     db.add(ak)
     db.commit()
@@ -1608,6 +1617,8 @@ class TestPrivateShareWebAuth:
             key_hash=key_hash,
             label="test-key",
             scopes=scopes,
+            # TR-03 (#ae52ba05): creator must still be owner/member to auth.
+            created_by=share.owner_user_id,
         )
         db.add(ak)
         db.commit()


### PR DESCRIPTION
## Summary

\`ShareAgentKey.created_by\` is \`ON DELETE SET NULL\`, not cascaded, and neither \`remove_member\` nor \`delete_user\` revoked the departing user's keys. Both X-Agent-Key auth paths (\`_auth_agent_key\` and \`_require_private_web_auth\`'s agent-key branch — two separate implementations, both had the gap) only checked \`key_hash\`/\`share_id\`/\`revoked_at\`/\`expires_at\`/scope — never whether the key's creator still has any standing over the share. An ex-member's or deleted user's key kept authenticating write access indefinitely.

## Fix

- New \`_agent_key_creator_authorized(agent_key, share, db)\` (\`web.py\`), used by both auth paths: authorized if the creator is the share owner, an active member, **or a currently-active global admin**.
- The admin branch matters: \`create_agent_key\` is owner-OR-ADMIN gated (\`_require_share_owner_or_admin\`) — plain members can't create keys at all — so an admin routinely creates keys for shares they don't own or belong to. That's the normal case, not orphaned. An earlier draft of this fix omitted the admin branch and would have broken every such key fleet-wide; caught before writing tests, by reading \`create_agent_key\`'s own permission gate rather than assuming a naive owner-or-member check was sufficient.
- \`share_service.remove_member\` and \`user_service.delete_user\` now explicitly revoke the departing user's keys (defense in depth — the auth-time check alone already closes the hole, this makes it visible in \`revoked_at\` too and doesn't depend on the check never regressing).
- \`delete_share\` needed no change: \`Share.agent_keys\` already cascades via the ORM relationship (\`cascade="all, delete-orphan"\`) — verified with a regression test, not assumed.
- Data migration \`202607210001\`: one-time revoke of every currently-orphaned key (same "standing authority" logic, admin branch included). Idempotent (\`WHERE revoked_at IS NULL\`). Verified end-to-end against a disposable Postgres container seeded with all 6 relevant states (owner, active member, removed member, deleted user, active admin non-member, demoted ex-admin non-member) — exactly the 2 illegitimate ones got revoked, the other 4 (including the admin edge case) were left alone.

Every existing test that constructs a \`ShareAgentKey\` directly (6 call sites across 3 files) never set \`created_by\`, so they were all unknowingly exercising the exact vulnerable state — a plain owner-or-member check would have broken the entire existing suite. Fixed by defaulting \`created_by\` to \`share.owner_user_id\` at each site (the correct default: these keys represent the owner using their own share).

## Tests

12 new tests in \`test_agent_key_authorization.py\`, covering both auth paths, both cascade triggers, the \`delete_share\` regression-proof, and — importantly — the active-admin-key-still-works case the corrected fix depends on.

Verified discriminating power: stashed the source fix, 7/12 new tests failed against old code for the right reason (the 5 "should still work" tests correctly passed either way, since they cover behavior that was never broken).

Full suite: **501/501 pass** (489 baseline + 12 new). \`ruff\` clean.

## Deploy note

This fixes the source and provides the migration for the data remediation, but I have not deployed it — I only have read-only Team Relay DB access, and control-plane deploy authority is ambiguous for my role. Flagging for the team to deploy + run the data remediation rather than guessing at deploy access on a live security-sensitive service.

## Test plan
- [x] \`uv run pytest -q\` — 501/501 pass
- [x] \`ruff check\` — clean
- [x] Migration verified end-to-end against a disposable Postgres (6-state seed, exact expected rows revoked)
- [x] Verified new tests fail against pre-fix code (discriminating power)
- [ ] Deploy to prod + run migration (not done by me — see deploy note)
- [ ] Post-deploy SQL verification (see migration docstring for the corrected query — the original literal AC query needs the admin-status correction too)