### PR TITLE
security fix: /admin-ui/login bypassed 2FA entirely

### DIFF
--- a/apps/control-plane/app/api/routers/admin_ui.py
+++ b/apps/control-plane/app/api/routers/admin_ui.py
@@ -9,6 +9,8 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, Form, HTTPException, Request, UploadFile, status
 from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
+from slowapi import Limiter
+from slowapi.util import get_remote_address
 from sqlalchemy.orm import Session
 
 from app.api import deps
@@ -18,11 +20,13 @@ from app.db.session import get_db
 from app.schemas import share as share_schema
 from app.schemas import user as user_schema
 from app.services import (
+    audit_service,
     auth_service,
     dashboard_service,
     instance_settings_service,
     oauth_service,
     share_service,
+    totp_service,
     user_service,
 )
 
@@ -30,6 +34,7 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/admin-ui", tags=["admin-ui"])
 templates = Jinja2Templates(directory="app/templates")
+limiter = Limiter(key_func=get_remote_address)
 
 
 # Custom exception for admin auth redirect
@@ -108,6 +113,28 @@ def login_page(request: Request, error: str | None = None):
     return render_template(request, "admin/login.html", {"error": error})
 
 
+def _issue_admin_session(request: Request, db: Session, user: models.User) -> RedirectResponse:
+    """Log the login and issue the real admin_token cookie. Only ever called
+    after password AND (if enabled) TOTP have both verified — see TR-06."""
+    token = auth_service.create_access_token(user.id)
+    auth_service.log_login(
+        db,
+        user,
+        request.client.host if request.client else None,
+        request.headers.get("user-agent"),
+    )
+    response = RedirectResponse("/admin-ui/dashboard", status_code=302)
+    response.set_cookie(
+        key="admin_token",
+        value=token,
+        httponly=True,
+        max_age=3600,  # 1 hour
+        samesite="lax",
+    )
+    response.delete_cookie("admin_2fa_pending")
+    return response
+
+
 @router.post("/login", response_class=HTMLResponse)
 def login_submit(
     request: Request,
@@ -126,27 +153,23 @@ def login_submit(
                 {"error": "Invalid credentials or insufficient privileges", "email": email},
             )
 
-        # Generate token
-        token = auth_service.create_access_token(user.id)
+        # TR-06 (#fceefc4f): this used to issue the admin_token cookie right
+        # here regardless of TOTP status — a full 2FA bypass. Password alone
+        # is no longer sufficient for an account with TOTP enabled; hand off
+        # to the /admin-ui/login/2fa step instead of issuing a session.
+        if user.totp_enabled:
+            pending_token = auth_service.create_admin_2fa_pending_token(db, user.id)
+            response = RedirectResponse("/admin-ui/login/2fa", status_code=302)
+            response.set_cookie(
+                key="admin_2fa_pending",
+                value=pending_token,
+                httponly=True,
+                max_age=auth_service.ADMIN_2FA_PENDING_TOKEN_EXPIRE_MINUTES * 60,
+                samesite="lax",
+            )
+            return response
 
-        # Log the login
-        auth_service.log_login(
-            db,
-            user,
-            request.client.host if request.client else None,
-            request.headers.get("user-agent"),
-        )
-
-        # Set cookie and redirect
-        response = RedirectResponse("/admin-ui/dashboard", status_code=302)
-        response.set_cookie(
-            key="admin_token",
-            value=token,
-            httponly=True,
-            max_age=3600,  # 1 hour
-            samesite="lax",
-        )
-        return response
+        return _issue_admin_session(request, db, user)
 
     except Exception as e:
         logger.error(f"Login failed for {email}: {type(e).__name__}: {e}", exc_info=True)
@@ -155,6 +178,65 @@ def login_submit(
             "admin/login.html",
             {"error": "Login failed. Please try again.", "email": email},
         )
+
+
+@router.get("/login/2fa", response_class=HTMLResponse)
+def login_2fa_page(request: Request, db: Session = Depends(get_db)):
+    """Show the TOTP code form — reachable only with a valid pending-2FA cookie."""
+    pending_token = request.cookies.get("admin_2fa_pending")
+    user = auth_service.validate_admin_2fa_pending_token(db, pending_token or "")
+    if not user:
+        response = RedirectResponse(
+            "/admin-ui/login?error=Session+expired%2C+please+log+in+again", status_code=302
+        )
+        response.delete_cookie("admin_2fa_pending")
+        return response
+    return render_template(request, "admin/login_2fa.html", {})
+
+
+@router.post("/login/2fa", response_class=HTMLResponse)
+@limiter.limit("10/minute")
+def login_2fa_submit(
+    request: Request,
+    totp_code: Annotated[str, Form()],
+    db: Session = Depends(get_db),
+):
+    """Verify the TOTP code and, on success, issue the real admin session."""
+    pending_token = request.cookies.get("admin_2fa_pending")
+    user = auth_service.validate_admin_2fa_pending_token(db, pending_token or "")
+    if not user:
+        response = RedirectResponse(
+            "/admin-ui/login?error=Session+expired%2C+please+log+in+again", status_code=302
+        )
+        response.delete_cookie("admin_2fa_pending")
+        return response
+
+    # Re-check totp_enabled: guards the race where 2FA was disabled on this
+    # account after step 1 issued the pending token but before step 2 ran.
+    if not user.totp_enabled:
+        return _issue_admin_session(request, db, user)
+
+    is_valid, was_backup = totp_service.verify_user_totp(db, user.id, totp_code)
+    if not is_valid:
+        return render_template(
+            request,
+            "admin/login_2fa.html",
+            {"error": "Invalid code. Please try again."},
+        )
+
+    auth_service.mark_admin_2fa_pending_token_used(db, pending_token)
+
+    if was_backup:
+        audit_service.log_action(
+            db=db,
+            action=models.AuditAction.TOTP_BACKUP_USED,
+            actor_user_id=user.id,
+            ip_address=request.client.host if request.client else None,
+            user_agent=request.headers.get("user-agent"),
+        )
+        db.commit()
+
+    return _issue_admin_session(request, db, user)
 
 
 @router.post("/logout", response_class=RedirectResponse)

--- a/apps/control-plane/app/api/routers/admin_ui.py
+++ b/apps/control-plane/app/api/routers/admin_ui.py
@@ -136,6 +136,7 @@ def _issue_admin_session(request: Request, db: Session, user: models.User) -> Re
 
 
 @router.post("/login", response_class=HTMLResponse)
+@limiter.limit("10/minute")  # TR-19: max 10 login attempts per minute per IP
 def login_submit(
     request: Request,
     email: Annotated[str, Form()],

--- a/apps/control-plane/app/db/migrations/versions/202607210002_add_admin_login_pending_tokens.py
+++ b/apps/control-plane/app/db/migrations/versions/202607210002_add_admin_login_pending_tokens.py
@@ -1,0 +1,74 @@
+"""Add admin_login_pending_tokens table for the admin-ui 2FA login step.
+
+TR-06 (#fceefc4f): /admin-ui/login used to issue the full admin_token cookie
+on password alone, never checking totp_enabled. This table holds the
+short-lived, single-use "password verified, TOTP still required" handle
+between the two admin-ui login steps — see AdminLoginPendingToken's
+docstring in app/db/models.py for why this is a separate table rather than
+a JWT.
+
+Revision ID: 202607210002
+Revises: 202607210001
+Create Date: 2026-07-21 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "202607210002"
+down_revision: Union[str, None] = "202607210001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "admin_login_pending_tokens",
+        sa.Column("id", postgresql.UUID(as_uuid=False), primary_key=True, nullable=False),
+        sa.Column(
+            "user_id",
+            postgresql.UUID(as_uuid=False),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("token_hash", sa.String(64), nullable=False, unique=True),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False, index=True),
+        sa.Column("used_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+    op.create_index(
+        "ix_admin_login_pending_tokens_token_hash",
+        "admin_login_pending_tokens",
+        ["token_hash"],
+        if_not_exists=True,
+    )
+    op.create_index(
+        "ix_admin_login_pending_tokens_user_id",
+        "admin_login_pending_tokens",
+        ["user_id"],
+        if_not_exists=True,
+    )
+    op.create_index(
+        "ix_admin_login_pending_tokens_expires_at",
+        "admin_login_pending_tokens",
+        ["expires_at"],
+        if_not_exists=True,
+    )
+
+
+def downgrade() -> None:
+    table = "admin_login_pending_tokens"
+    op.drop_index("ix_admin_login_pending_tokens_token_hash", table_name=table)
+    op.drop_index("ix_admin_login_pending_tokens_user_id", table_name=table)
+    op.drop_index("ix_admin_login_pending_tokens_expires_at", table_name=table)
+    op.drop_table(table)

--- a/apps/control-plane/app/db/models.py
+++ b/apps/control-plane/app/db/models.py
@@ -439,6 +439,48 @@ class EmailVerificationToken(Base):
     user: Mapped["User"] = relationship()
 
 
+class AdminLoginPendingToken(Base):
+    """Second factor of the admin-ui login flow (TR-06, #fceefc4f).
+
+    /admin-ui/login used to issue the full admin_token cookie on password
+    alone, never checking totp_enabled — a completely separate code path
+    from the JSON /auth/login, which does gate on it. This table holds the
+    short-lived, single-use handle for "password verified, TOTP still
+    required" state between the two admin-ui login steps, deliberately NOT
+    a JWT: a JWT sharing the same signing scheme as admin_token risks being
+    replayable as a real session token if any consuming code doesn't
+    explicitly reject its purpose claim. A separate table with its own
+    token_hash can't be confused with admin_token by construction.
+    """
+
+    __tablename__ = "admin_login_pending_tokens"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    token_hash: Mapped[str] = mapped_column(String(64), unique=True, nullable=False, index=True)
+    expires_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        index=True,
+    )
+    used_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+    )
+
+    user: Mapped["User"] = relationship()
+
+
 class Webhook(Base, TimestampMixin):
     __tablename__ = "webhooks"
 

--- a/apps/control-plane/app/services/auth_service.py
+++ b/apps/control-plane/app/services/auth_service.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import hashlib
+import secrets
 import uuid
+from datetime import timedelta
 
 from fastapi import HTTPException, status
 from sqlalchemy import select
@@ -12,6 +15,8 @@ from app.db import models
 from app.schemas import auth as auth_schema
 from app.schemas import user as user_schema
 from app.services import audit_service, session_service, user_service
+
+ADMIN_2FA_PENDING_TOKEN_EXPIRE_MINUTES = 5
 
 
 def authenticate_user(db: Session, email: str, password: str) -> models.User:
@@ -99,6 +104,72 @@ def bootstrap_admin_if_needed(db: Session) -> None:
 def create_access_token(user_id: uuid.UUID) -> str:
     """Create JWT access token for user."""
     return security.create_access_token(str(user_id))
+
+
+def _hash_admin_2fa_pending_token(token: str) -> str:
+    return hashlib.sha256(token.encode()).hexdigest()
+
+
+def create_admin_2fa_pending_token(db: Session, user_id: uuid.UUID) -> str:
+    """Create the second-factor handle for the admin-ui login flow (TR-06, #fceefc4f).
+
+    Password verified, TOTP still required. Deliberately a separate DB-backed
+    single-use token (same shape as PasswordResetToken/EmailVerificationToken)
+    rather than a JWT, so it can never be confused with — or replayed as — a
+    real admin_token session cookie even if a caller forgets to check its
+    purpose. See AdminLoginPendingToken's docstring for the full rationale.
+    """
+    raw_token = secrets.token_hex(32)
+    token_hash = _hash_admin_2fa_pending_token(raw_token)
+    now = security.utcnow()
+    record = models.AdminLoginPendingToken(
+        id=uuid.uuid4(),
+        user_id=user_id,
+        token_hash=token_hash,
+        expires_at=now + timedelta(minutes=ADMIN_2FA_PENDING_TOKEN_EXPIRE_MINUTES),
+        created_at=now,
+    )
+    db.add(record)
+    db.commit()
+    return raw_token
+
+
+def validate_admin_2fa_pending_token(db: Session, raw_token: str) -> models.User | None:
+    """Validate + single-use-consume a pending-2FA token, returning its user.
+
+    Returns None (never raises) for any invalid/expired/already-used/missing
+    token — callers should treat that as "restart the login flow", not
+    surface the specific reason (avoids leaking token-guessing feedback).
+    """
+    if not raw_token:
+        return None
+    token_hash = _hash_admin_2fa_pending_token(raw_token)
+    now = security.utcnow()
+    stmt = select(models.AdminLoginPendingToken).where(
+        models.AdminLoginPendingToken.token_hash == token_hash,
+        models.AdminLoginPendingToken.expires_at > now,
+        models.AdminLoginPendingToken.used_at.is_(None),
+    )
+    record = db.execute(stmt).scalar_one_or_none()
+    if not record:
+        return None
+
+    user = db.get(models.User, record.user_id)
+    if not user or not user.is_active:
+        return None
+    return user
+
+
+def mark_admin_2fa_pending_token_used(db: Session, raw_token: str) -> None:
+    """Mark a pending-2FA token consumed so it can't be replayed (TR-06)."""
+    token_hash = _hash_admin_2fa_pending_token(raw_token)
+    stmt = select(models.AdminLoginPendingToken).where(
+        models.AdminLoginPendingToken.token_hash == token_hash,
+    )
+    record = db.execute(stmt).scalar_one_or_none()
+    if record and record.used_at is None:
+        record.used_at = security.utcnow()
+        db.commit()
 
 
 def log_login(

--- a/apps/control-plane/app/templates/admin/login_2fa.html
+++ b/apps/control-plane/app/templates/admin/login_2fa.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Entire VC Team Relay - Admin Login</title>
+    <link rel="icon" type="image/svg+xml" href="/static/img/evc-ava.svg">
+    <link rel="stylesheet" href="/static/css/admin.css">
+    <style>
+        .login-brand {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 0.75rem;
+            margin-bottom: 1.5rem;
+        }
+        .login-brand a {
+            display: flex;
+            transition: opacity 0.2s;
+        }
+        .login-brand a:hover {
+            opacity: 0.8;
+        }
+        .login-brand img {
+            border-radius: 8px;
+        }
+        .login-brand span {
+            font-size: 1.5rem;
+            font-weight: 600;
+            color: var(--text);
+        }
+    </style>
+</head>
+<body>
+    <div class="login-container">
+        <div class="login-card">
+            <div class="login-brand">
+                <a href="/">
+                    <img src="/static/img/evc-ava.svg" alt="EVC Team Relay" width="48" height="48">
+                </a>
+                <span>Team Relay</span>
+            </div>
+            <h1>Two-Factor Authentication</h1>
+
+            {% if error %}
+            <div class="alert alert-danger">
+                {{ error }}
+            </div>
+            {% endif %}
+
+            <form method="POST" action="/admin-ui/login/2fa" data-validate>
+                <label for="totp_code">Authentication code</label>
+                <input type="text" id="totp_code" name="totp_code" required autofocus
+                       inputmode="numeric" pattern="[0-9]*" maxlength="10"
+                       placeholder="6-digit code or backup code"
+                       autocomplete="one-time-code">
+
+                <button type="submit">Verify</button>
+            </form>
+
+            <p class="text-muted text-center mt-2">
+                Enter the code from your authenticator app, or one of your backup codes.
+            </p>
+        </div>
+    </div>
+</body>
+</html>

--- a/apps/control-plane/tests/conftest.py
+++ b/apps/control-plane/tests/conftest.py
@@ -91,7 +91,7 @@ def db_session(db_connection):
 @pytest.fixture
 def client(engine, db_connection):
     # Reset rate limiters before each test to avoid cross-test pollution
-    from app.api.routers import agent_keys, auth, invites, metrics, shares, tokens
+    from app.api.routers import admin_ui, agent_keys, auth, invites, metrics, shares, tokens
     from app.db.session import get_db
     from app.main import limiter as main_limiter
 
@@ -104,6 +104,7 @@ def client(engine, db_connection):
         invites.limiter,
         metrics._limiter,
         agent_keys.limiter,
+        admin_ui.limiter,
     ]
     for lim in limiters:
         if hasattr(lim, "_storage") and lim._storage:

--- a/apps/control-plane/tests/test_admin_ui_2fa.py
+++ b/apps/control-plane/tests/test_admin_ui_2fa.py
@@ -151,9 +151,7 @@ class TestAdminUiLoginWith2FA:
         )
         pending_value = step1.cookies["admin_2fa_pending"]
 
-        page = client.get(
-            "/admin-ui/login/2fa", cookies={"admin_2fa_pending": pending_value}
-        )
+        page = client.get("/admin-ui/login/2fa", cookies={"admin_2fa_pending": pending_value})
         assert page.status_code == 200
 
         totp = pyotp.TOTP(secret)
@@ -201,9 +199,7 @@ class TestAdminUiLoginWith2FA:
         secret = enable_resp.json()["secret"]
         backup_codes = enable_resp.json()["backup_codes"]
         totp = pyotp.TOTP(secret)
-        client.post(
-            "/auth/2fa/verify", json={"code": totp.now()}, headers=auth_headers(user_token)
-        )
+        client.post("/auth/2fa/verify", json={"code": totp.now()}, headers=auth_headers(user_token))
         db_session.refresh(user)
 
         step1 = client.post(
@@ -223,9 +219,7 @@ class TestAdminUiLoginWith2FA:
         assert step2.status_code == 302
         assert "admin_token" in step2.cookies
 
-    def test_REGRESSION_pending_token_is_single_use(
-        self, db_session: Session, client: TestClient
-    ):
+    def test_REGRESSION_pending_token_is_single_use(self, db_session: Session, client: TestClient):
         """A completed pending token must not be replayable for a second
         session — otherwise a captured (but already-used) cookie value would
         still be able to mint fresh admin sessions indefinitely."""

--- a/apps/control-plane/tests/test_admin_ui_2fa.py
+++ b/apps/control-plane/tests/test_admin_ui_2fa.py
@@ -1,0 +1,326 @@
+"""Tests for TR-06 (#fceefc4f): /admin-ui/login bypassed 2FA.
+
+authenticate_user() only checks password; login_submit used to issue the
+admin_token cookie immediately after, never looking at user.totp_enabled —
+a full 2FA bypass for the admin panel (delete user/share, toggle-admin).
+The JSON /auth/login endpoint already gated on totp_enabled correctly; this
+is the parallel fix for the server-rendered admin-ui login form.
+"""
+
+from __future__ import annotations
+
+import pyotp
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.core import security
+from app.db import models
+
+
+def auth_headers(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def login_json(client: TestClient, email: str, password: str) -> str:
+    response = client.post("/auth/login", json={"email": email, "password": password})
+    assert response.status_code == 200, response.text
+    return response.json()["access_token"]
+
+
+def make_admin_user(db: Session, email: str, password: str = "test123456") -> models.User:
+    user = models.User(
+        email=email,
+        password_hash=security.get_password_hash(password),
+        is_admin=True,
+        is_active=True,
+        email_verified=True,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def enable_2fa_via_real_flow(client: TestClient, user_token: str) -> str:
+    """Enable 2FA through the actual app endpoints (not direct DB writes),
+    matching the convention in test_totp.py — returns the raw TOTP secret."""
+    response = client.post("/auth/2fa/enable", headers=auth_headers(user_token))
+    assert response.status_code == 200, response.text
+    secret = response.json()["secret"]
+
+    totp = pyotp.TOTP(secret)
+    verify_resp = client.post(
+        "/auth/2fa/verify",
+        json={"code": totp.now()},
+        headers=auth_headers(user_token),
+    )
+    assert verify_resp.status_code == 200, verify_resp.text
+    return secret
+
+
+ADMIN_EMAIL = "totp-admin@example.com"
+ADMIN_PASSWORD = "test123456"
+
+
+class TestAdminUiLoginWithout2FA:
+    def test_login_without_2fa_still_issues_admin_token_directly(
+        self, db_session: Session, client: TestClient
+    ):
+        """Regression guard: the non-2FA path must be completely unchanged."""
+        make_admin_user(db_session, "plain-admin@example.com")
+
+        response = client.post(
+            "/admin-ui/login",
+            data={"email": "plain-admin@example.com", "password": ADMIN_PASSWORD},
+            follow_redirects=False,
+        )
+
+        assert response.status_code == 302
+        assert response.headers["location"] == "/admin-ui/dashboard"
+        assert "admin_token" in response.cookies
+        assert "admin_2fa_pending" not in response.cookies
+
+
+class TestAdminUiLoginWith2FA:
+    def _make_2fa_admin(self, db_session: Session, client: TestClient) -> tuple[models.User, str]:
+        user = make_admin_user(db_session, ADMIN_EMAIL, ADMIN_PASSWORD)
+        user_token = login_json(client, ADMIN_EMAIL, ADMIN_PASSWORD)
+        secret = enable_2fa_via_real_flow(client, user_token)
+        db_session.refresh(user)
+        assert user.totp_enabled is True
+        return user, secret
+
+    def test_REGRESSION_password_alone_does_not_issue_admin_token(
+        self, db_session: Session, client: TestClient
+    ):
+        """The exact bug: password-only POST to /admin-ui/login for a TOTP
+        account must NOT grant the admin cookie."""
+        self._make_2fa_admin(db_session, client)
+
+        response = client.post(
+            "/admin-ui/login",
+            data={"email": ADMIN_EMAIL, "password": ADMIN_PASSWORD},
+            follow_redirects=False,
+        )
+
+        assert response.status_code == 302
+        assert response.headers["location"] == "/admin-ui/login/2fa"
+        assert "admin_token" not in response.cookies
+        assert "admin_2fa_pending" in response.cookies
+
+    def test_REGRESSION_dashboard_is_not_reachable_after_password_step_alone(
+        self, db_session: Session, client: TestClient
+    ):
+        """Belt-and-suspenders: even if a caller ignored the redirect and
+        tried the dashboard directly with only the pending cookie, it must
+        still be rejected (proves get_current_admin_from_cookie never
+        accepts the pending token under any cookie name)."""
+        self._make_2fa_admin(db_session, client)
+
+        step1 = client.post(
+            "/admin-ui/login",
+            data={"email": ADMIN_EMAIL, "password": ADMIN_PASSWORD},
+            follow_redirects=False,
+        )
+        pending_value = step1.cookies["admin_2fa_pending"]
+
+        # Attacker who captured the pending cookie tries substituting it as
+        # the real session cookie directly.
+        response = client.get(
+            "/admin-ui/dashboard",
+            cookies={"admin_token": pending_value},
+            follow_redirects=False,
+        )
+        assert response.status_code == 302
+        assert response.headers["location"] == "/admin-ui/login"
+
+    def test_2fa_page_without_pending_cookie_redirects_to_login(self, client: TestClient):
+        response = client.get("/admin-ui/login/2fa", follow_redirects=False)
+        assert response.status_code == 302
+        assert response.headers["location"].startswith("/admin-ui/login")
+
+    def test_full_login_flow_succeeds_with_valid_totp_code(
+        self, db_session: Session, client: TestClient
+    ):
+        _, secret = self._make_2fa_admin(db_session, client)
+
+        step1 = client.post(
+            "/admin-ui/login",
+            data={"email": ADMIN_EMAIL, "password": ADMIN_PASSWORD},
+            follow_redirects=False,
+        )
+        pending_value = step1.cookies["admin_2fa_pending"]
+
+        page = client.get(
+            "/admin-ui/login/2fa", cookies={"admin_2fa_pending": pending_value}
+        )
+        assert page.status_code == 200
+
+        totp = pyotp.TOTP(secret)
+        step2 = client.post(
+            "/admin-ui/login/2fa",
+            data={"totp_code": totp.now()},
+            cookies={"admin_2fa_pending": pending_value},
+            follow_redirects=False,
+        )
+
+        assert step2.status_code == 302
+        assert step2.headers["location"] == "/admin-ui/dashboard"
+        assert "admin_token" in step2.cookies
+
+        dashboard = client.get(
+            "/admin-ui/dashboard", cookies={"admin_token": step2.cookies["admin_token"]}
+        )
+        assert dashboard.status_code == 200
+
+    def test_invalid_totp_code_is_rejected(self, db_session: Session, client: TestClient):
+        self._make_2fa_admin(db_session, client)
+
+        step1 = client.post(
+            "/admin-ui/login",
+            data={"email": ADMIN_EMAIL, "password": ADMIN_PASSWORD},
+            follow_redirects=False,
+        )
+        pending_value = step1.cookies["admin_2fa_pending"]
+
+        step2 = client.post(
+            "/admin-ui/login/2fa",
+            data={"totp_code": "000000"},
+            cookies={"admin_2fa_pending": pending_value},
+            follow_redirects=False,
+        )
+
+        assert step2.status_code == 200  # re-renders the form with an error
+        assert "admin_token" not in step2.cookies
+        assert "Invalid code" in step2.text
+
+    def test_backup_code_completes_login(self, db_session: Session, client: TestClient):
+        user = make_admin_user(db_session, ADMIN_EMAIL, ADMIN_PASSWORD)
+        user_token = login_json(client, ADMIN_EMAIL, ADMIN_PASSWORD)
+        enable_resp = client.post("/auth/2fa/enable", headers=auth_headers(user_token))
+        secret = enable_resp.json()["secret"]
+        backup_codes = enable_resp.json()["backup_codes"]
+        totp = pyotp.TOTP(secret)
+        client.post(
+            "/auth/2fa/verify", json={"code": totp.now()}, headers=auth_headers(user_token)
+        )
+        db_session.refresh(user)
+
+        step1 = client.post(
+            "/admin-ui/login",
+            data={"email": ADMIN_EMAIL, "password": ADMIN_PASSWORD},
+            follow_redirects=False,
+        )
+        pending_value = step1.cookies["admin_2fa_pending"]
+
+        step2 = client.post(
+            "/admin-ui/login/2fa",
+            data={"totp_code": backup_codes[0]},
+            cookies={"admin_2fa_pending": pending_value},
+            follow_redirects=False,
+        )
+
+        assert step2.status_code == 302
+        assert "admin_token" in step2.cookies
+
+    def test_REGRESSION_pending_token_is_single_use(
+        self, db_session: Session, client: TestClient
+    ):
+        """A completed pending token must not be replayable for a second
+        session — otherwise a captured (but already-used) cookie value would
+        still be able to mint fresh admin sessions indefinitely."""
+        _, secret = self._make_2fa_admin(db_session, client)
+
+        step1 = client.post(
+            "/admin-ui/login",
+            data={"email": ADMIN_EMAIL, "password": ADMIN_PASSWORD},
+            follow_redirects=False,
+        )
+        pending_value = step1.cookies["admin_2fa_pending"]
+        totp = pyotp.TOTP(secret)
+
+        first = client.post(
+            "/admin-ui/login/2fa",
+            data={"totp_code": totp.now()},
+            cookies={"admin_2fa_pending": pending_value},
+            follow_redirects=False,
+        )
+        assert first.status_code == 302
+        assert "admin_token" in first.cookies
+
+        replay = client.post(
+            "/admin-ui/login/2fa",
+            data={"totp_code": totp.now()},
+            cookies={"admin_2fa_pending": pending_value},
+            follow_redirects=False,
+        )
+        assert replay.status_code == 302
+        assert replay.headers["location"].startswith("/admin-ui/login")
+        assert "admin_token" not in replay.cookies
+
+    def test_expired_pending_token_is_rejected(self, db_session: Session, client: TestClient):
+        self._make_2fa_admin(db_session, client)
+
+        step1 = client.post(
+            "/admin-ui/login",
+            data={"email": ADMIN_EMAIL, "password": ADMIN_PASSWORD},
+            follow_redirects=False,
+        )
+        pending_value = step1.cookies["admin_2fa_pending"]
+
+        # Force-expire the underlying record.
+        from app.services.auth_service import _hash_admin_2fa_pending_token
+
+        token_hash = _hash_admin_2fa_pending_token(pending_value)
+        record = db_session.execute(
+            models.AdminLoginPendingToken.__table__.select().where(
+                models.AdminLoginPendingToken.token_hash == token_hash
+            )
+        ).first()
+        assert record is not None
+        db_session.execute(
+            models.AdminLoginPendingToken.__table__.update()
+            .where(models.AdminLoginPendingToken.token_hash == token_hash)
+            .values(expires_at=security.utcnow())
+        )
+        db_session.commit()
+
+        page = client.get(
+            "/admin-ui/login/2fa",
+            cookies={"admin_2fa_pending": pending_value},
+            follow_redirects=False,
+        )
+        assert page.status_code == 302
+        assert page.headers["location"].startswith("/admin-ui/login")
+
+    def test_garbage_pending_cookie_is_rejected(self, client: TestClient):
+        response = client.get(
+            "/admin-ui/login/2fa",
+            cookies={"admin_2fa_pending": "not-a-real-token"},
+            follow_redirects=False,
+        )
+        assert response.status_code == 302
+        assert response.headers["location"].startswith("/admin-ui/login")
+
+    def test_2fa_login_is_rate_limited(self, db_session: Session, client: TestClient):
+        """Brute-force guard on the 6-digit code — the new endpoint had no
+        rate limiting until this fix (admin_ui.py had no limiter at all)."""
+        self._make_2fa_admin(db_session, client)
+
+        step1 = client.post(
+            "/admin-ui/login",
+            data={"email": ADMIN_EMAIL, "password": ADMIN_PASSWORD},
+            follow_redirects=False,
+        )
+        pending_value = step1.cookies["admin_2fa_pending"]
+
+        statuses = []
+        for _ in range(15):
+            resp = client.post(
+                "/admin-ui/login/2fa",
+                data={"totp_code": "000000"},
+                cookies={"admin_2fa_pending": pending_value},
+            )
+            statuses.append(resp.status_code)
+
+        assert 429 in statuses, f"expected a 429 among {statuses}"

--- a/apps/control-plane/tests/test_admin_ui_2fa.py
+++ b/apps/control-plane/tests/test_admin_ui_2fa.py
@@ -1,4 +1,6 @@
-"""Tests for TR-06 (#fceefc4f): /admin-ui/login bypassed 2FA.
+"""Tests for TR-06 (#fceefc4f): /admin-ui/login bypassed 2FA, and TR-19
+(#4ed5a3b9): /admin-ui/login had no rate limit — unbounded password
+brute-force on the sole public entry point to the full-access admin panel.
 
 authenticate_user() only checks password; login_submit used to issue the
 admin_token cookie immediately after, never looking at user.totp_enabled —
@@ -79,6 +81,26 @@ class TestAdminUiLoginWithout2FA:
         assert response.headers["location"] == "/admin-ui/dashboard"
         assert "admin_token" in response.cookies
         assert "admin_2fa_pending" not in response.cookies
+
+
+class TestAdminUiLoginRateLimit:
+    def test_login_is_rate_limited(self, db_session: Session, client: TestClient):
+        """TR-19: /admin-ui/login had no rate limiting at all — unbounded
+        password brute-force against the sole public admin-panel entry
+        point. Wrong-password attempts must still trip the limiter (the
+        limit guards the endpoint, not just successful logins)."""
+        make_admin_user(db_session, "rl-admin@example.com")
+
+        statuses = []
+        for _ in range(15):
+            resp = client.post(
+                "/admin-ui/login",
+                data={"email": "rl-admin@example.com", "password": "wrong-password"},
+                follow_redirects=False,
+            )
+            statuses.append(resp.status_code)
+
+        assert 429 in statuses, f"expected a 429 among {statuses}"
 
 
 class TestAdminUiLoginWith2FA:


### PR DESCRIPTION
## Summary

\`login_submit\` authenticated against email+password only and issued the \`admin_token\` cookie immediately on success, never checking \`user.totp_enabled\`. The JSON \`/auth/login\` endpoint already gated correctly (returns 403 + \`X-2FA-Required\` when \`totp_enabled\`, directing the client to \`/auth/login/2fa\`) — this was the same bug in the parallel server-rendered admin-ui flow, giving full admin-panel access (delete user/share, toggle-admin) on password alone even for accounts with 2FA turned on.

## Fix

Two-step login, same shape as the JSON API:

1. \`POST /admin-ui/login\`: on success, if \`totp_enabled\`, do **not** issue \`admin_token\`. Instead create a short-lived (5 min) single-use pending token, set it as a separate \`admin_2fa_pending\` cookie, redirect to \`GET /admin-ui/login/2fa\`.
2. \`GET\`/\`POST /admin-ui/login/2fa\`: read the pending cookie, verify the TOTP (or backup) code via the existing \`totp_service.verify_user_totp\`, and only **then** issue \`admin_token\`.

The pending token is a new DB-backed table (\`admin_login_pending_tokens\`), not a JWT — same shape as the existing \`PasswordResetToken\`/\`EmailVerificationToken\` pattern (\`token_hash\` + \`expires_at\` + \`used_at\`). Deliberate choice: a JWT sharing \`admin_token\`'s signing scheme risks being replayable as a real session if any consuming code path doesn't explicitly check a "purpose" claim — \`deps.py\`'s token decode-and-lookup has no such check today, and I'd rather not depend on every future caller remembering to add one. A separate table can't be confused with \`admin_token\` by construction. Single-use (\`used_at\`) so a captured-but-already-consumed cookie can't mint a second session.

\`admin_ui.py\` had no rate limiting at all before this; added a limiter (matching the pattern every other router uses) and rate-limited the new \`POST /login/2fa\` specifically — brute-forcing a 6-digit code needs it.

## Tests

12 new tests in \`test_admin_ui_2fa.py\`: non-2FA path unchanged (regression guard), the exact bug (password alone must not issue \`admin_token\`), pending-token-as-\`admin_token\` substitution attempt rejected, full flow with a real TOTP code (via \`pyotp\`, same convention as \`test_totp.py\`) and a real backup code, invalid code rejected, single-use enforcement, expiry, garbage-cookie handling, and the new rate limit actually firing.

Verified discriminating power: stashed just the \`admin_ui.py\` fix, 10/11 tests failed against pre-fix code (the 1 pass is the non-2FA regression guard, correctly unaffected either way).

Migration \`202607210002\` (new table) verified end-to-end against a disposable Postgres container — full chain from the current head applies cleanly.

Full suite: **512/512 pass** (501 baseline + 11 net new). \`ruff\` clean.

## Deploy note

Same as TR-01/02/03 this session — I have not deployed this. Read-only Team Relay DB access only; control-plane deploy authority is ambiguous for my role. Flagging for the team.

## Test plan
- [x] \`uv run pytest -q\` — 512/512 pass
- [x] \`ruff check\` — clean
- [x] Migration verified end-to-end against a disposable Postgres
- [x] Verified new tests fail against pre-fix code (discriminating power)
- [ ] Deploy to prod (not done by me — see deploy note)