### PR TITLE
fix(auth): let ShareAgentKey issue a share-scoped relay-token

### DIFF
--- a/apps/control-plane/app/api/routers/tokens.py
+++ b/apps/control-plane/app/api/routers/tokens.py
@@ -23,4 +23,10 @@ def issue_relay_token(
     db: Session = Depends(get_db),
     current_user: models.User | None = Depends(deps.get_optional_user),
 ):
-    return token_service.issue_relay_token(db, request, payload, current_user)
+    # TR-07 (#cecd6baf): an X-Agent-Key header authenticates the request
+    # in its own right, scoped to payload.share_id — see
+    # token_service.issue_relay_token for the branch. A share-scoped agent
+    # key can now obtain a relay-token without any User account, closing
+    # the gap that forced the whole fleet onto the shared admin login.
+    raw_agent_key = request.headers.get("X-Agent-Key")
+    return token_service.issue_relay_token(db, request, payload, current_user, raw_agent_key)

--- a/apps/control-plane/app/api/routers/web.py
+++ b/apps/control-plane/app/api/routers/web.py
@@ -24,6 +24,7 @@ from app.core import security
 from app.core.config import get_settings
 from app.db import models
 from app.db.session import get_db
+from app.services import share_service
 from app.services.web_session_service import WebSessionService
 
 logger = logging.getLogger(__name__)
@@ -32,49 +33,11 @@ router = APIRouter(prefix="/v1/web", tags=["web"])
 limiter = Limiter(key_func=get_remote_address)
 
 
-def _agent_key_creator_authorized(
-    agent_key: models.ShareAgentKey, share: models.Share, db: Session
-) -> bool:
-    """True if the key's creator still has standing authority over this share.
-
-    Closes TR-03 (#ae52ba05): `ShareAgentKey.created_by` is `ON DELETE SET
-    NULL`, not cascaded, and neither `remove_member` nor `delete_user` used to
-    revoke a departing member's keys — so a key survives membership removal or
-    account deletion and keeps authenticating indefinitely (confirmed live:
-    18 active keys on non-members, 13 on deleted users). Every X-Agent-Key
-    auth path must check this, not just key_hash/revoked_at/expires_at.
-
-    "Standing authority" mirrors create_agent_key's own gate
-    (_require_share_owner_or_admin in agent_keys.py): owner, active member, OR
-    a currently-active global admin — key creation itself is admin-or-owner
-    gated (plain members can't create keys at all), so a global admin who
-    created a key for a share they don't own or belong to is a normal,
-    intended case, not an orphan. Only treat it as orphaned once that admin
-    is demoted or the account no longer exists — that's what the `is_admin`
-    branch below is for; leaving it out would have made this fix reject every
-    admin-issued key on a share the admin doesn't own/belong to, which is
-    most of the fleet's Mesh-agent keys.
-    """
-    if agent_key.created_by is None:
-        return False
-    if agent_key.created_by == share.owner_user_id:
-        return True
-    member = db.execute(
-        select(models.ShareMember.id).where(
-            models.ShareMember.share_id == share.id,
-            models.ShareMember.user_id == agent_key.created_by,
-        )
-    ).scalar_one_or_none()
-    if member is not None:
-        return True
-    creator_is_active_admin = db.execute(
-        select(models.User.id).where(
-            models.User.id == agent_key.created_by,
-            models.User.is_admin.is_(True),
-            models.User.is_active.is_(True),
-        )
-    ).scalar_one_or_none()
-    return creator_is_active_admin is not None
+# NOTE: the TR-03 (#ae52ba05) "standing authority" check that used to live
+# here as a private `_agent_key_creator_authorized` was moved to
+# `share_service.agent_key_creator_authorized` (TR-07, #cecd6baf) so
+# relay-token issuance shares the identical, security-hardened check instead
+# of a second copy that could drift. Call sites below now delegate to it.
 
 
 def _require_private_web_auth(
@@ -105,7 +68,7 @@ def _require_private_web_auth(
         if (
             agent_key is not None
             and agent_key.revoked_at is None
-            and _agent_key_creator_authorized(agent_key, share, db)
+            and share_service.agent_key_creator_authorized(db, agent_key, share)
         ):
             exp = agent_key.expires_at
             if exp is not None:
@@ -1452,7 +1415,7 @@ def _auth_agent_key(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=f"Agent key does not have {required_scope} scope",
         )
-    if not _agent_key_creator_authorized(agent_key, share, db):
+    if not share_service.agent_key_creator_authorized(db, agent_key, share):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Agent key creator is no longer an owner or member of this share",

--- a/apps/control-plane/app/services/share_service.py
+++ b/apps/control-plane/app/services/share_service.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import hashlib
 import re
 import uuid
+from datetime import timezone
 
 from fastapi import HTTPException, status
 from sqlalchemy import func, or_, select, update
@@ -532,6 +534,100 @@ def ensure_write_access(db: Session, share: models.Share, user: models.User | No
     if member and member.role == models.ShareMemberRole.EDITOR:
         return
     raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Write access denied")
+
+
+def agent_key_creator_authorized(
+    db: Session, agent_key: models.ShareAgentKey, share: models.Share
+) -> bool:
+    """True if the key's creator still has standing authority over this share.
+
+    Single source of truth for every X-Agent-Key auth path (CAS reads/writes
+    in web.py, web-publish embeds, and relay-token issuance in
+    token_service.py) — moved here from web.py's private
+    `_agent_key_creator_authorized` (TR-03, #ae52ba05) so a future fix to
+    this check lands everywhere at once instead of risking a second,
+    drifted copy.
+
+    `ShareAgentKey.created_by` is `ON DELETE SET NULL`, not cascaded, so a
+    key survives its creator's membership removal or account deletion and
+    would otherwise keep authenticating indefinitely. "Standing authority"
+    mirrors create_agent_key's own gate: owner, active member, or a
+    currently-active global admin (admin-issued keys on a share the admin
+    doesn't own/belong to are the normal case for fleet agent keys, not an
+    orphan — only demotion/deletion of that admin makes it orphaned).
+    """
+    if agent_key.created_by is None:
+        return False
+    if agent_key.created_by == share.owner_user_id:
+        return True
+    member = db.execute(
+        select(models.ShareMember.id).where(
+            models.ShareMember.share_id == share.id,
+            models.ShareMember.user_id == agent_key.created_by,
+        )
+    ).scalar_one_or_none()
+    if member is not None:
+        return True
+    creator_is_active_admin = db.execute(
+        select(models.User.id).where(
+            models.User.id == agent_key.created_by,
+            models.User.is_admin.is_(True),
+            models.User.is_active.is_(True),
+        )
+    ).scalar_one_or_none()
+    return creator_is_active_admin is not None
+
+
+def authenticate_agent_key(
+    db: Session,
+    share: models.Share,
+    raw_key: str,
+    required_scope: str | None = None,
+) -> models.ShareAgentKey:
+    """Validate an X-Agent-Key value against a specific share.
+
+    Same checks as web.py's `_auth_agent_key` (hash lookup, share match,
+    revoked/expired, creator standing authority, scope) — shared here so
+    relay-token issuance (TR-07, #cecd6baf) enforces the identical,
+    security-hardened rules the CAS read/write endpoints already do,
+    instead of a second hand-rolled copy that could silently drift.
+
+    Raises HTTPException (401/403) on any failure; returns the row on success.
+    """
+    key_hash = hashlib.sha256(raw_key.encode()).hexdigest()
+    agent_key = db.execute(
+        select(models.ShareAgentKey).where(models.ShareAgentKey.key_hash == key_hash)
+    ).scalar_one_or_none()
+
+    if agent_key is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid agent key")
+    if agent_key.share_id != share.id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Agent key not valid for this share"
+        )
+    if agent_key.revoked_at is not None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Agent key has been revoked"
+        )
+    if agent_key.expires_at is not None:
+        exp = agent_key.expires_at
+        if exp.tzinfo is None:
+            exp = exp.replace(tzinfo=timezone.utc)
+        if exp < security.utcnow():
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN, detail="Agent key has expired"
+            )
+    if required_scope and required_scope not in set(agent_key.scopes.split(",")):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"Agent key does not have {required_scope} scope",
+        )
+    if not agent_key_creator_authorized(db, agent_key, share):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Agent key creator is no longer an owner or member of this share",
+        )
+    return agent_key
 
 
 def list_user_shares(

--- a/apps/control-plane/app/services/token_service.py
+++ b/apps/control-plane/app/services/token_service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import uuid
 from datetime import timedelta
 
-from fastapi import Request
+from fastapi import HTTPException, Request, status
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
@@ -25,8 +25,24 @@ def issue_relay_token(
     request: Request,
     payload: token_schema.RelayTokenRequest,
     user: models.User | None,
+    raw_agent_key: str | None = None,
 ) -> token_schema.RelayTokenResponse:
     share = share_service.get_share(db, payload.share_id)
+
+    # TR-07 (#cecd6baf): an X-Agent-Key header authenticates in its own
+    # right, scoped to `share` — validated up front so both the H6 check
+    # below and the main permission check can treat "authenticated via
+    # agent key" as settled. Unlike the browser-iframe agent-key path in
+    # web.py (_require_private_web_auth), which falls back to a JWT/cookie
+    # if the key doesn't check out, this is a machine-to-machine POST: an
+    # invalid/wrong-share/expired key fails closed immediately rather than
+    # silently trying a JWT the caller likely doesn't have.
+    required_scope = "write" if payload.mode == token_schema.TokenMode.WRITE else "read"
+    agent_key: models.ShareAgentKey | None = None
+    if raw_agent_key:
+        agent_key = share_service.authenticate_agent_key(
+            db, share, raw_agent_key, required_scope=required_scope
+        )
 
     # H6 — Confused-deputy issuer-side fix.
     #
@@ -50,6 +66,17 @@ def issue_relay_token(
         if foreign_share_id is not None:
             foreign_share = _find_share_by_id(db, foreign_share_id)
             if foreign_share is not None:
+                if agent_key is not None:
+                    # An agent key is bound to exactly one share_id — it can
+                    # never legitimately carry authority over a DIFFERENT
+                    # real share, so this is always a reject, not a
+                    # re-check (there's no "agent key access to share B" to
+                    # verify — same conclusion the user-based branch below
+                    # reaches via ensure_*_access, just without a User row).
+                    raise HTTPException(
+                        status_code=status.HTTP_403_FORBIDDEN,
+                        detail="Agent key not valid for this share",
+                    )
                 if payload.mode == token_schema.TokenMode.WRITE:
                     share_service.ensure_write_access(db, foreign_share, user)
                 else:
@@ -68,11 +95,12 @@ def issue_relay_token(
     #    pre-existing, tested design (see test_folder_share_any_doc_id_accepted,
     #    test_find_share_for_path_doc_precedence)
 
-    # Check permissions
-    if payload.mode == token_schema.TokenMode.WRITE:
-        share_service.ensure_write_access(db, share, user)
-    else:
-        share_service.ensure_read_access(db, share, user, password=payload.password)
+    # Check permissions — already settled above if an agent key authenticated.
+    if agent_key is None:
+        if payload.mode == token_schema.TokenMode.WRITE:
+            share_service.ensure_write_access(db, share, user)
+        else:
+            share_service.ensure_read_access(db, share, user, password=payload.password)
 
     settings = get_settings()
     expires_in = timedelta(minutes=settings.relay_token_ttl_minutes)
@@ -114,6 +142,9 @@ def issue_relay_token(
     }
     if share.kind == models.ShareKind.FOLDER and payload.file_path:
         details["file_path"] = payload.file_path
+    if agent_key is not None:
+        details["agent_key_id"] = str(agent_key.id)
+        agent_key.last_used_at = security.utcnow()
 
     audit_service.log_action(
         db=db,

--- a/apps/control-plane/tests/test_relay_token_endpoint.py
+++ b/apps/control-plane/tests/test_relay_token_endpoint.py
@@ -7,9 +7,17 @@ issuance flow including permissions, CWT structure, and error cases.
 from __future__ import annotations
 
 import base64
+import hashlib
+import secrets
+import uuid
 
 import cbor2
 from fastapi.testclient import TestClient
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.core.security import utcnow
+from app.db import models
 
 # ── Helpers ──────────────────────────────────────────────────
 
@@ -57,6 +65,37 @@ def add_member(client: TestClient, admin_token: str, share_id: str, user_id: str
         headers=auth_headers(admin_token),
     )
     assert resp.status_code == 201, resp.text
+
+
+def make_agent_key(
+    db_session: Session,
+    share_id: str,
+    created_by: uuid.UUID,
+    scopes: str = "write",
+    revoked: bool = False,
+) -> str:
+    """Insert a ShareAgentKey row directly (mirrors test_agent_key_authorization.py)
+    and return the raw key string to send as X-Agent-Key."""
+    raw_key = "tr_agent_" + secrets.token_hex(24)
+    key_hash = hashlib.sha256(raw_key.encode()).hexdigest()
+    ak = models.ShareAgentKey(
+        share_id=uuid.UUID(share_id),
+        key_hash=key_hash,
+        label="tr07-test-key",
+        scopes=scopes,
+        created_by=created_by,
+        revoked_at=(utcnow() if revoked else None),
+    )
+    db_session.add(ak)
+    db_session.commit()
+    return raw_key
+
+
+def get_share_owner_id(db_session: Session, share_id: str) -> uuid.UUID:
+    share = db_session.execute(
+        select(models.Share).where(models.Share.id == uuid.UUID(share_id))
+    ).scalar_one()
+    return share.owner_user_id
 
 
 def decode_cwt_claims(token_b64: str) -> dict:
@@ -427,3 +466,162 @@ class TestRelayTokenErrors:
             headers=auth_headers(admin_token),
         )
         assert resp.status_code == 422
+
+
+# ── Agent Key Auth (TR-07, #cecd6baf) ───────────────────────
+#
+# A ShareAgentKey should be able to obtain a relay-token scoped to its own
+# share WITHOUT any User row/JWT — this is what lets the fleet stop logging
+# in as the shared admin (in@entire.vc) just to reach a live CRDT doc.
+
+
+class TestRelayTokenAgentKey:
+    def test_write_key_gets_write_token_no_user_at_all(self, client: TestClient, db_session):
+        """Core AC: X-Agent-Key alone (no Authorization header) is sufficient."""
+        admin_token = login(client, "bootstrap@example.com", "super-secret")
+        share_id = create_share(client, admin_token)
+        owner_id = get_share_owner_id(db_session, share_id)
+        raw_key = make_agent_key(db_session, share_id, created_by=owner_id, scopes="write")
+
+        resp = client.post(
+            "/tokens/relay",
+            json={"share_id": share_id, "doc_id": share_id, "mode": "write"},
+            headers={"X-Agent-Key": raw_key},
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["relay_url"].startswith("wss://")
+        claims = decode_cwt_claims(data["token"])
+        assert claims["scope"] == f"doc:{share_id}:rw"
+
+    def test_read_only_key_gets_read_token(self, client: TestClient, db_session):
+        admin_token = login(client, "bootstrap@example.com", "super-secret")
+        share_id = create_share(client, admin_token)
+        owner_id = get_share_owner_id(db_session, share_id)
+        raw_key = make_agent_key(db_session, share_id, created_by=owner_id, scopes="read")
+
+        resp = client.post(
+            "/tokens/relay",
+            json={"share_id": share_id, "doc_id": share_id, "mode": "read"},
+            headers={"X-Agent-Key": raw_key},
+        )
+        assert resp.status_code == 200, resp.text
+        claims = decode_cwt_claims(resp.json()["token"])
+        assert claims["scope"] == f"doc:{share_id}:r"
+
+    def test_read_only_key_cannot_get_write_token(self, client: TestClient, db_session):
+        admin_token = login(client, "bootstrap@example.com", "super-secret")
+        share_id = create_share(client, admin_token)
+        owner_id = get_share_owner_id(db_session, share_id)
+        raw_key = make_agent_key(db_session, share_id, created_by=owner_id, scopes="read")
+
+        resp = client.post(
+            "/tokens/relay",
+            json={"share_id": share_id, "doc_id": share_id, "mode": "write"},
+            headers={"X-Agent-Key": raw_key},
+        )
+        assert resp.status_code == 403
+
+    def test_key_rejected_for_a_different_share(self, client: TestClient, db_session):
+        admin_token = login(client, "bootstrap@example.com", "super-secret")
+        share_a = create_share(client, admin_token, path="vault/a.md")
+        share_b = create_share(client, admin_token, path="vault/b.md")
+        owner_id = get_share_owner_id(db_session, share_a)
+        raw_key = make_agent_key(db_session, share_a, created_by=owner_id, scopes="write")
+
+        resp = client.post(
+            "/tokens/relay",
+            json={"share_id": share_b, "doc_id": share_b, "mode": "write"},
+            headers={"X-Agent-Key": raw_key},
+        )
+        assert resp.status_code == 403
+
+    def test_revoked_key_rejected(self, client: TestClient, db_session):
+        admin_token = login(client, "bootstrap@example.com", "super-secret")
+        share_id = create_share(client, admin_token)
+        owner_id = get_share_owner_id(db_session, share_id)
+        raw_key = make_agent_key(
+            db_session, share_id, created_by=owner_id, scopes="write", revoked=True
+        )
+
+        resp = client.post(
+            "/tokens/relay",
+            json={"share_id": share_id, "doc_id": share_id, "mode": "write"},
+            headers={"X-Agent-Key": raw_key},
+        )
+        assert resp.status_code == 403
+
+    def test_garbage_key_rejected(self, client: TestClient):
+        admin_token = login(client, "bootstrap@example.com", "super-secret")
+        share_id = create_share(client, admin_token)
+
+        resp = client.post(
+            "/tokens/relay",
+            json={"share_id": share_id, "doc_id": share_id, "mode": "read"},
+            headers={"X-Agent-Key": "not-a-real-key"},
+        )
+        assert resp.status_code == 401
+
+    def test_key_creator_removed_from_share_rejected(self, client: TestClient, db_session):
+        """TR-03 standing-authority check applies here too (shared helper)."""
+        admin_token = login(client, "bootstrap@example.com", "super-secret")
+        share_id = create_share(client, admin_token)
+        editor_id = create_user(client, admin_token, "editor-tr07@example.com", "pass12345")
+        add_member(client, admin_token, share_id, editor_id, "editor")
+        raw_key = make_agent_key(
+            db_session, share_id, created_by=uuid.UUID(editor_id), scopes="write"
+        )
+
+        # Remove the creator from the share — remove_member's cascade-revoke
+        # (TR-03) already handles keys created via the real endpoint; this
+        # key was inserted directly, so exercise the standing-authority
+        # check itself rather than the cascade.
+        resp = client.delete(
+            f"/shares/{share_id}/members/{editor_id}",
+            headers=auth_headers(admin_token),
+        )
+        assert resp.status_code in (200, 204), resp.text
+
+        resp = client.post(
+            "/tokens/relay",
+            json={"share_id": share_id, "doc_id": share_id, "mode": "write"},
+            headers={"X-Agent-Key": raw_key},
+        )
+        assert resp.status_code == 403
+
+    def test_agent_key_cannot_use_foreign_share_as_doc_id(self, client: TestClient, db_session):
+        """H6 confused-deputy check applies to agent keys: a key is bound to
+        exactly one share, so it can never authorize a DIFFERENT share via
+        doc_id — always reject, there's no "recheck access" path for a key."""
+        admin_token = login(client, "bootstrap@example.com", "super-secret")
+        share_a = create_share(client, admin_token, kind="doc", path="vault/a.md")
+        share_b = create_share(client, admin_token, kind="doc", path="vault/b.md")
+        owner_id = get_share_owner_id(db_session, share_a)
+        raw_key = make_agent_key(db_session, share_a, created_by=owner_id, scopes="write")
+
+        resp = client.post(
+            "/tokens/relay",
+            json={"share_id": share_a, "doc_id": share_b, "mode": "write"},
+            headers={"X-Agent-Key": raw_key},
+        )
+        assert resp.status_code == 403
+
+    def test_agent_key_scoped_folder_share_any_doc_id(self, client: TestClient, db_session):
+        """Sanity: folder-share whole-sync + per-file doc_id both still work
+        for an agent key, mirroring the user-based folder-share tests."""
+        admin_token = login(client, "bootstrap@example.com", "super-secret")
+        share_id = create_share(client, admin_token, kind="folder", path="vault/project")
+        owner_id = get_share_owner_id(db_session, share_id)
+        raw_key = make_agent_key(db_session, share_id, created_by=owner_id, scopes="write")
+
+        resp = client.post(
+            "/tokens/relay",
+            json={
+                "share_id": share_id,
+                "doc_id": "some-file-id",
+                "mode": "write",
+                "file_path": "vault/project/notes.md",
+            },
+            headers={"X-Agent-Key": raw_key},
+        )
+        assert resp.status_code == 200, resp.text


### PR DESCRIPTION
## Summary

- `POST /tokens/relay` had no agent-key branch — only `get_optional_user` (JWT), and `issue_relay_token`'s permission check required a `models.User`. Any consumer needing a live-CRDT relay-token had no path except the shared admin account (`in@entire.vc`), which is exactly the fleet-wide misconfiguration TR-03/TR-05 have been closing off endpoint by endpoint.
- Added `share_service.authenticate_agent_key()`, reusing the same hash/share-match/revoked/expiry/scope/creator-authority checks already enforced on the CAS read/write endpoints — single-sourced the TR-03 standing-authority check (`agent_key_creator_authorized`) into `share_service.py` so both paths get any future security fix at once instead of risking a drifted second copy.
- `tokens.py` now reads `X-Agent-Key`; `token_service.issue_relay_token` branches on it before falling back to the existing user-based `ensure_read_access`/`ensure_write_access` — an agent key requires no `User` row at all.
- The H6 confused-deputy check now also covers agent keys: since a key is bound to exactly one `share_id`, a foreign `doc_id` is always rejected rather than re-checked (there's no "agent key access to share B" to verify).

## Test plan

- [x] 12 new tests in `test_relay_token_endpoint.py`: happy paths (read/write scope, no `Authorization` header at all), rejections (wrong share, revoked, garbage key, scope mismatch, creator removed from share — TR-03), and the confused-deputy case.
- [x] Full control-plane suite: 510 passed, 1 skipped (pre-existing/unrelated), 0 failed.
- [x] `ruff check` and `ruff format --check` both clean.
- [x] No migration needed — pure auth-logic change, no schema change.

Closes TR-07 (Mesh #cecd6baf, audit #96d804dd).