### PR TITLE
fix(security): protected-share password no longer grants web-content write

### DIFF
--- a/apps/control-plane/app/api/routers/web.py
+++ b/apps/control-plane/app/api/routers/web.py
@@ -710,8 +710,11 @@ def update_share_content(
     Only works for document shares (not folders).
 
     Access control:
-    - Requires authentication via session cookie (for protected shares) or JWT token
-    - User must have editor role on the share
+    - Requires a JWT (Bearer token) proving the caller is the share owner or
+      an editor-role member — for BOTH protected and private shares. A
+      protected share's web_session cookie (knowledge of the view password)
+      is a read-only credential and is never sufficient for write (TR-13,
+      #7d32a104).
     """
     settings = get_settings()
     if not settings.web_publish_enabled:
@@ -740,26 +743,35 @@ def update_share_content(
             detail="Only document shares can be edited via web",
         )
 
-    # Check authentication and editor role
-    # For protected shares, validate session
-    if share.visibility == models.ShareVisibility.PROTECTED:
-        session_token = request.cookies.get("web_session")
-        if not session_token:
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="Authentication required",
-            )
-        if not WebSessionService.validate_web_session(session_token, share.id):
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="Invalid or expired session",
-            )
-        # For protected shares with password, we can't determine editor role
-        # So we allow editing if authenticated
-    elif share.visibility == models.ShareVisibility.PRIVATE:
-        # For private shares, require JWT token and check editor role
+    # Check authentication and editor role.
+    #
+    # TR-13 (#7d32a104): PROTECTED shares used to be allowed to write here
+    # just by presenting a valid web_session cookie — i.e. by knowing the
+    # share's view password. The old comment even said the quiet part
+    # aloud: "we can't determine editor role [from a password alone], so
+    # we allow editing if authenticated" — but knowing a share's password
+    # is proof of VIEW access, not of editor identity. A protected share's
+    # password only ever governed read visibility; write has always
+    # required a real user account with owner/editor role, exactly like
+    # PRIVATE shares — the visibility distinction is irrelevant for write,
+    # so both now go through the identical JWT + owner-or-editor check.
+    if share.visibility in (
+        models.ShareVisibility.PROTECTED,
+        models.ShareVisibility.PRIVATE,
+    ):
         auth_header = request.headers.get("Authorization")
         if not auth_header or not auth_header.startswith("Bearer "):
+            # A PROTECTED share's web_session cookie proves only that the
+            # caller knows the view password — distinguish "presented a
+            # credential, just not a strong enough one" (403) from "no
+            # credential of any kind" (401) for clearer client feedback.
+            if share.visibility == models.ShareVisibility.PROTECTED and request.cookies.get(
+                "web_session"
+            ):
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="Editor role required to edit this share",
+                )
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="Authentication required",

--- a/apps/control-plane/tests/test_web_publish.py
+++ b/apps/control-plane/tests/test_web_publish.py
@@ -1179,31 +1179,96 @@ class TestWebContentEditing:
         )
         assert response.status_code == 404
 
-    def test_update_content_protected_share_with_session(
+    def test_update_content_protected_share_session_alone_is_rejected(
         self, client: TestClient, doc_share: models.Share, monkeypatch
     ):
-        """Test updating content with valid session for protected share."""
-        # Enable web publishing
+        """TR-13 (#7d32a104): a valid web_session cookie proves only that the
+        caller knows the share's VIEW password — it must never be sufficient
+        for write on its own. Regression test for the exact vulnerability:
+        this used to return 200."""
         monkeypatch.setenv("WEB_PUBLISH_DOMAIN", "docs.test.com")
         from app.core.config import get_settings
 
         get_settings.cache_clear()
 
-        # Authenticate to get session
         from app.services.web_session_service import WebSessionService
 
         session_token = WebSessionService.create_web_session(doc_share.id, hours=24)
 
-        # Update content
+        response = client.put(
+            f"/v1/web/shares/{doc_share.web_slug}/content",
+            json={"content": "# Attacker-controlled content"},
+            cookies={"web_session": session_token},
+        )
+        assert response.status_code == 403
+        body = response.json()
+        # Error may be wrapped by middleware (see test_update_content_folder_share_rejected).
+        detail = body.get("detail") or body.get("error", {}).get("message", "")
+        assert detail == "Editor role required to edit this share"
+
+        get_settings.cache_clear()
+
+    def test_update_content_protected_share_owner_with_jwt_still_works(
+        self, client: TestClient, db_session: Session, doc_share: models.Share, monkeypatch
+    ):
+        """The legitimate case must keep working: the share owner, real JWT
+        session, can still edit their own protected share — with or without
+        also presenting the web_session cookie."""
+        monkeypatch.setenv("WEB_PUBLISH_DOMAIN", "docs.test.com")
+        from app.core.config import get_settings
+
+        get_settings.cache_clear()
+
+        owner = db_session.get(models.User, doc_share.owner_user_id)
+        login_response = client.post(
+            "/auth/login", json={"email": owner.email, "password": "test123456"}
+        )
+        token = login_response.json()["access_token"]
+
         response = client.put(
             f"/v1/web/shares/{doc_share.web_slug}/content",
             json={"content": "# Updated Content\n\nNew text here."},
-            cookies={"web_session": session_token},
+            headers={"Authorization": f"Bearer {token}"},
         )
         assert response.status_code == 200
         data = response.json()
         assert "message" in data
         assert "updated_at" in data
+
+        get_settings.cache_clear()
+
+    def test_update_content_protected_share_non_editor_jwt_rejected(
+        self, client: TestClient, db_session: Session, doc_share: models.Share, monkeypatch
+    ):
+        """A real logged-in user who is neither owner nor an editor member
+        must still be rejected, even with a valid JWT."""
+        monkeypatch.setenv("WEB_PUBLISH_DOMAIN", "docs.test.com")
+        from app.core.config import get_settings
+
+        get_settings.cache_clear()
+
+        stranger = models.User(
+            email="stranger-tr13@example.com",
+            password_hash=get_password_hash("test123456"),
+            is_active=True,
+        )
+        db_session.add(stranger)
+        db_session.commit()
+
+        login_response = client.post(
+            "/auth/login", json={"email": stranger.email, "password": "test123456"}
+        )
+        token = login_response.json()["access_token"]
+
+        response = client.put(
+            f"/v1/web/shares/{doc_share.web_slug}/content",
+            json={"content": "# Should be rejected"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 403
+        body = response.json()
+        detail = body.get("detail") or body.get("error", {}).get("message", "")
+        assert detail == "Editor role required to edit this share"
 
         get_settings.cache_clear()
 


### PR DESCRIPTION
## Summary

- `PUT /v1/web/shares/{slug}/content` only checked the `web_session` cookie for PROTECTED shares — anyone who knew the share's view password could overwrite its published content. The old code comment said as much: *"we can't determine editor role [from a password alone], so we allow editing if authenticated"* — but knowing a share's password proves view access, not editor identity.
- A protected share's password has only ever governed **read** visibility; write has always required a real user account with owner/editor role, exactly like PRIVATE shares. Collapsed the PROTECTED and PRIVATE branches into one JWT + owner-or-editor check — the visibility distinction is irrelevant for write.
- A `web_session` cookie presented without a JWT now returns **403** (a credential was presented, just not a strong enough one); no credential of any kind still returns **401**, unchanged.

## Test plan

- [x] Rewrote the one existing test that had codified the vulnerability as expected behavior (it asserted `200` for a protected-session-only write) into a regression test asserting `403`.
- [x] Added: legitimate case still works (share owner, real JWT, protected share → `200`), and a logged-in stranger with neither owner nor editor role is still rejected (`403`).
- [x] Verified discriminating power: the regression test fails against the pre-fix code (confirmed via `git stash` on just the source file), passes with the fix.
- [x] Full suite: 503/503 (501 baseline, net +2 after removing the vulnerability-codifying test and adding three). `ruff check`/`ruff format` clean.
- [x] No schema change, no migration needed.

Closes TR-13 (Mesh #7d32a104, audit #96d804dd).