### PR TITLE
fix(web-publish): map upstream/network failures to 503, not 404

### DIFF
--- a/apps/web-publish/src/lib/api.test.ts
+++ b/apps/web-publish/src/lib/api.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { fetchWithTimeout, getShareBySlug, authenticateShare, validateSession } from './api.js';
+import { fetchWithTimeout, getShareBySlug, authenticateShare, validateSession, ShareNotFoundError } from './api.js';
 
 // ---------------------------------------------------------------------------
 // fetchWithTimeout — timeout behaviour
@@ -73,22 +73,24 @@ describe('getShareBySlug', () => {
 		vi.unstubAllGlobals();
 	});
 
-	it('throws "Share not found" on 404', async () => {
+	it('throws ShareNotFoundError on 404', async () => {
 		vi.stubGlobal(
 			'fetch',
 			vi.fn(() => Promise.resolve(new Response('not found', { status: 404 })))
 		);
 
 		await expect(getShareBySlug('missing-slug')).rejects.toThrow('Share not found or not published');
+		await expect(getShareBySlug('missing-slug')).rejects.toBeInstanceOf(ShareNotFoundError);
 	});
 
-	it('throws generic error on other non-ok status', async () => {
+	it('throws a plain (non-ShareNotFoundError) error on other non-ok status', async () => {
 		vi.stubGlobal(
 			'fetch',
 			vi.fn(() => Promise.resolve(new Response('error', { status: 500, statusText: 'Internal Server Error' })))
 		);
 
 		await expect(getShareBySlug('some-slug')).rejects.toThrow('Failed to fetch share');
+		await expect(getShareBySlug('some-slug')).rejects.not.toBeInstanceOf(ShareNotFoundError);
 	});
 
 	it('returns parsed share on 200', async () => {

--- a/apps/web-publish/src/lib/api.ts
+++ b/apps/web-publish/src/lib/api.ts
@@ -24,6 +24,18 @@ const CONTROL_PLANE_URL =
 		? process.env.CONTROL_PLANE_URL
 		: 'http://control-plane:8000';
 
+/**
+ * Thrown when the Control Plane confirms the share genuinely does not exist
+ * (its 404). Distinct from network/timeout/5xx failures, which should be
+ * surfaced to the reader as a transient outage, not a missing page.
+ */
+export class ShareNotFoundError extends Error {
+	constructor(message = 'Share not found or not published') {
+		super(message);
+		this.name = 'ShareNotFoundError';
+	}
+}
+
 export interface FolderItem {
 	path: string;
 	name: string;
@@ -76,7 +88,7 @@ export async function getShareBySlug(slug: string, agentKey?: string): Promise<W
 
 	if (!response.ok) {
 		if (response.status === 404) {
-			throw new Error('Share not found or not published');
+			throw new ShareNotFoundError();
 		}
 		throw new Error(`Failed to fetch share: ${response.statusText}`);
 	}

--- a/apps/web-publish/src/routes/[slug]/+page.server.ts
+++ b/apps/web-publish/src/routes/[slug]/+page.server.ts
@@ -1,5 +1,5 @@
 import { error } from '@sveltejs/kit';
-import { getShareBySlug, validateSession, validateUserToken, getFolderFileContent } from '$lib/api';
+import { getShareBySlug, validateSession, validateUserToken, getFolderFileContent, ShareNotFoundError } from '$lib/api';
 import type { PageServerLoad } from './$types';
 
 /**
@@ -105,7 +105,11 @@ export const load: PageServerLoad = async ({ params, cookies, url }) => {
 		};
 	} catch (err) {
 		if (err && typeof err === 'object' && 'status' in err) throw err;
-		console.error('Failed to load share:', err);
-		throw error(404, 'Share not found or not published');
+		if (err instanceof ShareNotFoundError) {
+			console.error('Share not found:', err);
+			throw error(404, 'Share not found or not published');
+		}
+		console.error('Upstream error loading share:', err);
+		throw error(503, 'Service temporarily unavailable. Please try again shortly.');
 	}
 };

--- a/apps/web-publish/src/routes/[slug]/[...path]/+page.server.ts
+++ b/apps/web-publish/src/routes/[slug]/[...path]/+page.server.ts
@@ -1,6 +1,6 @@
 import { error } from '@sveltejs/kit';
 import { env } from '$env/dynamic/private';
-import { getShareBySlug, validateSession, validateUserToken, getFolderFileContent } from '$lib/api';
+import { getShareBySlug, validateSession, validateUserToken, getFolderFileContent, ShareNotFoundError } from '$lib/api';
 import { slugifyPath } from '$lib/file-tree';
 import { verifyEmbedToken } from '$lib/embed-token';
 import type { PageServerLoad } from './$types';
@@ -105,7 +105,11 @@ export const load: PageServerLoad = async ({ params, cookies, url }) => {
 		};
 	} catch (err) {
 		if (err && typeof err === 'object' && 'status' in err) throw err;
-		console.error('Failed to load file:', err);
-		throw error(404, 'File not found');
+		if (err instanceof ShareNotFoundError) {
+			console.error('Share not found:', err);
+			throw error(404, 'File not found');
+		}
+		console.error('Upstream error loading file:', err);
+		throw error(503, 'Service temporarily unavailable. Please try again shortly.');
 	}
 };

--- a/apps/web-publish/src/tests/page-server.test.ts
+++ b/apps/web-publish/src/tests/page-server.test.ts
@@ -10,12 +10,16 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 //   - private: OAuth JWT via validateUserToken or agent_key from CP response
 // ---------------------------------------------------------------------------
 
-vi.mock('$lib/api', () => ({
-	getShareBySlug: vi.fn(),
-	validateSession: vi.fn(),
-	validateUserToken: vi.fn(),
-	getFolderFileContent: vi.fn()
-}));
+vi.mock('$lib/api', async (importOriginal) => {
+	const mod = await importOriginal();
+	return {
+		...mod,
+		getShareBySlug: vi.fn(),
+		validateSession: vi.fn(),
+		validateUserToken: vi.fn(),
+		getFolderFileContent: vi.fn()
+	};
+});
 
 // SvelteKit error() throws an object with a status property
 vi.mock('@sveltejs/kit', async (importOriginal) => {
@@ -31,6 +35,7 @@ vi.mock('@sveltejs/kit', async (importOriginal) => {
 });
 
 import * as api from '$lib/api';
+import { ShareNotFoundError } from '$lib/api';
 import { load } from '../routes/[slug]/+page.server.js';
 
 // Helper: build a minimal mock share
@@ -208,8 +213,8 @@ describe('load() — private share', () => {
 // ---------------------------------------------------------------------------
 
 describe('load() — share not found', () => {
-	it('throws 404 when getShareBySlug rejects', async () => {
-		vi.mocked(api.getShareBySlug).mockRejectedValue(new Error('Share not found or not published'));
+	it('throws 404 when getShareBySlug rejects with ShareNotFoundError', async () => {
+		vi.mocked(api.getShareBySlug).mockRejectedValue(new ShareNotFoundError());
 
 		await expect(
 			load({
@@ -218,5 +223,35 @@ describe('load() — share not found', () => {
 				url: makeUrl()
 			})
 		).rejects.toMatchObject({ status: 404 });
+	});
+});
+
+// ---------------------------------------------------------------------------
+// 503 — upstream/network failure (TR-38: must NOT be mapped to 404)
+// ---------------------------------------------------------------------------
+
+describe('load() — upstream/network failure', () => {
+	it('throws 503 when getShareBySlug rejects with a 5xx-style error', async () => {
+		vi.mocked(api.getShareBySlug).mockRejectedValue(new Error('Failed to fetch share: Internal Server Error'));
+
+		await expect(
+			load({
+				params: { slug: 'test-slug' },
+				cookies: makeCookies(),
+				url: makeUrl()
+			})
+		).rejects.toMatchObject({ status: 503 });
+	});
+
+	it('throws 503 when getShareBySlug rejects with a network/timeout error', async () => {
+		vi.mocked(api.getShareBySlug).mockRejectedValue(new DOMException('The operation was aborted', 'AbortError'));
+
+		await expect(
+			load({
+				params: { slug: 'test-slug' },
+				cookies: makeCookies(),
+				url: makeUrl()
+			})
+		).rejects.toMatchObject({ status: 503 });
 	});
 });


### PR DESCRIPTION
## Summary
- `getShareBySlug()` threw an indistinguishable plain `Error` for both a genuine Control Plane 404 and any other failure (5xx, timeout, network drop).
- Both `[slug]/+page.server.ts` and `[slug]/[...path]/+page.server.ts` `load()` handlers caught anything that wasn't already a SvelteKit `HttpError` and blanket-mapped it to `404` — so a CP outage made a live, published doc look deleted (readers get "not found", Google can deindex it).
- Added `ShareNotFoundError` (thrown only on a confirmed upstream 404) and updated both `load()` handlers to throw `503` for any other failure.

## Test plan
- [x] `npm test` in `apps/web-publish` — 52/52 passing, including new cases: `getShareBySlug` 404 → `ShareNotFoundError` instance, non-404 upstream error → plain `Error`; `load()` 5xx-style error → 503, network/AbortError → 503; existing "share not found" case still → 404.
- [x] `npm run check` (svelte-check) — 0 errors, 0 warnings.
- [x] Manual repro per acceptance criteria: simulate CP down → doc page load throws 503, not 404.

TR-38 (audit #96d804dd)