### PR TITLE
fix(web-publish): render markdown body server-side for SSR/GEO

### DIFF
--- a/apps/web-publish/src/lib/components/LiveMarkdownViewer.svelte
+++ b/apps/web-publish/src/lib/components/LiveMarkdownViewer.svelte
@@ -7,6 +7,10 @@
 	interface Props {
 		/** Static content (fallback when real-time not available) */
 		content: string;
+		/** Pre-rendered HTML for `content`, produced server-side — forwarded to the
+		 *  underlying MarkdownViewer so SSR output has a body before real-time sync
+		 *  (browser-only) ever connects (TR-37). */
+		initialHtml?: string;
 		/** Document ID for real-time sync (S3RN encoded) */
 		docId?: string | null;
 		/** Share slug for fetching relay token */
@@ -17,7 +21,7 @@
 		folderItems?: Array<{ path: string; name: string; type: string; content?: string }>;
 	}
 
-	let { content, docId, slug, sessionToken, class: className = '', folderItems }: Props = $props();
+	let { content, initialHtml, docId, slug, sessionToken, class: className = '', folderItems }: Props = $props();
 
 	let realtimeContent = $state<string | null>(null);
 	let connectionStatus = $state<'connecting' | 'connected' | 'disconnected' | 'unavailable'>(
@@ -80,7 +84,7 @@
 		</div>
 	{/if}
 
-	<MarkdownViewer content={displayContent} class={className} slug={slug} folderItems={folderItems} />
+	<MarkdownViewer content={displayContent} {initialHtml} class={className} slug={slug} folderItems={folderItems} />
 
 	{#if error && !realtimeContent}
 		<div class="sync-error">

--- a/apps/web-publish/src/lib/components/MarkdownViewer.svelte
+++ b/apps/web-publish/src/lib/components/MarkdownViewer.svelte
@@ -1,20 +1,35 @@
 <script lang="ts">
-	import { onMount, tick } from 'svelte';
+	import { onMount, tick, untrack } from 'svelte';
 	import { browser } from '$app/environment';
 	import { renderMarkdown } from '$lib/markdown';
 
 	interface Props {
 		content: string;
+		/**
+		 * Pre-rendered HTML for the initial paint, produced server-side (e.g. in a
+		 * +page.server.ts load()). Without this, the body only ever renders in
+		 * onMount/$effect — both browser-only — so SSR output (what non-JS
+		 * crawlers/AI scrapers/social unfurlers see) has no content at all (TR-37).
+		 */
+		initialHtml?: string;
 		class?: string;
 		slug?: string;
 		folderItems?: Array<{ path: string; name: string; type: string; content?: string }>;
 	}
 
-	let { content, class: className = '', slug, folderItems }: Props = $props();
+	let { content, initialHtml, class: className = '', slug, folderItems }: Props = $props();
 
-	let renderedHtml = $state('');
-	let isRendering = $state(true);
+	// These deliberately capture only the value initialHtml/content had when this
+	// component was created (an SSR seed, not a value that should reset already-
+	// rendered content if the parent's props happen to change later) — untrack()
+	// makes that one-time-snapshot intent explicit instead of a missed dependency.
+	let renderedHtml = $state(untrack(() => initialHtml ?? ''));
+	let isRendering = $state(untrack(() => initialHtml === undefined));
 	let contentEl: HTMLDivElement | undefined = $state();
+	// Tracks the content we've last rendered client-side, so the initial $effect run
+	// doesn't redundantly re-render (and flash the skeleton) when initialHtml already
+	// covers the current content.
+	let lastRenderedContent = untrack(() => (initialHtml !== undefined ? content : undefined));
 
 	/**
 	 * Initialize mermaid diagrams in the rendered content.
@@ -111,38 +126,39 @@
 		});
 	}
 
-	onMount(async () => {
+	async function renderAndEnhance() {
+		isRendering = true;
 		try {
 			renderedHtml = await renderMarkdown(content, { slug, folderItems });
-			await tick();
-			await initMermaid();
-			attachDelegatedHandlers();
 		} catch (error) {
 			console.error('Failed to render markdown:', error);
 			renderedHtml = '<p class="error">Failed to render document</p>';
 		} finally {
 			isRendering = false;
 		}
+		await tick();
+		await initMermaid();
+		attachDelegatedHandlers();
+	}
+
+	onMount(() => {
+		// initialHtml already covers the current content (server-rendered) — just
+		// wire up the client-only enhancements against the existing DOM.
+		if (initialHtml !== undefined) {
+			void (async () => {
+				await tick();
+				await initMermaid();
+				attachDelegatedHandlers();
+			})();
+		}
 	});
 
-	// Re-render when content changes
+	// Render on first mount when there's no server-rendered HTML to start from, and
+	// re-render whenever content changes thereafter (e.g. live edits).
 	$effect(() => {
-		if (content) {
-			isRendering = true;
-			renderMarkdown(content, { slug, folderItems })
-				.then(async (html) => {
-					renderedHtml = html;
-					await tick();
-					await initMermaid();
-					attachDelegatedHandlers();
-				})
-				.catch((error) => {
-					console.error('Failed to render markdown:', error);
-					renderedHtml = '<p class="error">Failed to render document</p>';
-				})
-				.finally(() => {
-					isRendering = false;
-				});
+		if (content && content !== lastRenderedContent) {
+			lastRenderedContent = content;
+			void renderAndEnhance();
 		}
 	});
 </script>

--- a/apps/web-publish/src/lib/markdown.test.ts
+++ b/apps/web-publish/src/lib/markdown.test.ts
@@ -190,3 +190,63 @@ describe('estimateReadingTime', () => {
 		expect(estimateReadingTime(md)).toBe(estimateReadingTime(noFm));
 	});
 });
+
+// ---------------------------------------------------------------------------
+// Concurrent-call isolation (TR-37)
+// ---------------------------------------------------------------------------
+// renderMarkdown() now runs inside SvelteKit's server load(), where one Node
+// process serves many requests concurrently. Math and embed/slug resolution
+// used to go through module-level mutable state (mathStore, _renderContext)
+// that a second concurrent call would reset/overwrite mid-render, bleeding
+// one document's content into another's. These prove two overlapping calls
+// never cross-contaminate.
+// ---------------------------------------------------------------------------
+
+describe('renderMarkdown — concurrent-call isolation', () => {
+	it('does not cross-contaminate math between two concurrent renders', async () => {
+		const docA = '$$x^2$$';
+		const docB = '$$y^3$$';
+
+		const [htmlA, htmlB] = await Promise.all([
+			renderMarkdown(docA),
+			renderMarkdown(docB)
+		]);
+
+		expect(htmlA).toContain('x^2');
+		expect(htmlA).not.toContain('y^3');
+		expect(htmlB).toContain('y^3');
+		expect(htmlB).not.toContain('x^2');
+	});
+
+	it('does not cross-contaminate embed/slug resolution between two concurrent renders', async () => {
+		const doc = '![[photo.png]]';
+
+		const [htmlA, htmlB] = await Promise.all([
+			renderMarkdown(doc, { slug: 'slug-A', folderItems: [] }),
+			renderMarkdown(doc, { slug: 'slug-B', folderItems: [] })
+		]);
+
+		expect(htmlA).toContain('/slug-A/_assets/photo.png');
+		expect(htmlA).not.toContain('/slug-B/_assets/photo.png');
+		expect(htmlB).toContain('/slug-B/_assets/photo.png');
+		expect(htmlB).not.toContain('/slug-A/_assets/photo.png');
+	});
+
+	it('does not cross-contaminate across many concurrent renders with mixed content', async () => {
+		const inputs = Array.from({ length: 10 }, (_, i) => ({
+			slug: `slug-${i}`,
+			math: `${i}^2`
+		}));
+
+		const results = await Promise.all(
+			inputs.map((input) =>
+				renderMarkdown(`![[photo.png]]\n\n$$${input.math}$$`, { slug: input.slug, folderItems: [] })
+			)
+		);
+
+		results.forEach((html, i) => {
+			expect(html).toContain(`/slug-${i}/_assets/photo.png`);
+			expect(html).toContain(inputs[i].math);
+		});
+	});
+});

--- a/apps/web-publish/src/lib/markdown.ts
+++ b/apps/web-publish/src/lib/markdown.ts
@@ -42,19 +42,25 @@ function escapeHtml(str: string): string {
 const MATH_PLACEHOLDER_PREFIX = '\x00MATH_';
 const MATH_PLACEHOLDER_SUFFIX = '\x00';
 
-/** Store for math expressions extracted during preprocessing */
-let mathStore: Map<string, { expression: string; displayMode: boolean }> = new Map();
-let mathCounter = 0;
+type MathStore = Map<string, { expression: string; displayMode: boolean }>;
 
-function resetMathStore(): void {
-	mathStore = new Map();
-	mathCounter = 0;
-}
-
-function createMathPlaceholder(expression: string, displayMode: boolean): string {
-	const id = `${MATH_PLACEHOLDER_PREFIX}${mathCounter++}${MATH_PLACEHOLDER_SUFFIX}`;
-	mathStore.set(id, { expression, displayMode });
-	return id;
+/**
+ * Creates a placeholder-writer scoped to a single renderMarkdown() call.
+ * MUST be call-scoped, not module state: renderMarkdown() now runs inside
+ * SvelteKit's server load() (TR-37), where one Node process serves many
+ * requests concurrently — a shared/module-level store gets reset and
+ * overwritten mid-flight by a *different* request's render, cross-
+ * contaminating math between two unrelated documents (confirmed via a
+ * concurrent-render test: two Promise.all'd renders with different math
+ * both resolved to the second call's expression).
+ */
+function createMathPlaceholderFactory(mathStore: MathStore) {
+	let counter = 0;
+	return (expression: string, displayMode: boolean): string => {
+		const id = `${MATH_PLACEHOLDER_PREFIX}${counter++}${MATH_PLACEHOLDER_SUFFIX}`;
+		mathStore.set(id, { expression, displayMode });
+		return id;
+	};
 }
 
 // ---------------------------------------------------------------------------
@@ -83,7 +89,7 @@ function stripFrontmatter(text: string): string {
  * Order: $$...$$ first (display), then $...$ (inline).
  * Skip anything inside code fences or inline code.
  */
-function protectMath(text: string): string {
+function protectMath(text: string, createPlaceholder: (expression: string, displayMode: boolean) => string): string {
 	// First, protect code blocks and inline code so we don't match $ inside them
 	const codeBlocks: { placeholder: string; content: string }[] = [];
 	let codeCounter = 0;
@@ -104,14 +110,14 @@ function protectMath(text: string): string {
 
 	// Replace display math ($$...$$) - can be multiline
 	result = result.replace(/\$\$([\s\S]+?)\$\$/g, (_match, expr: string) => {
-		return createMathPlaceholder(expr.trim(), true);
+		return createPlaceholder(expr.trim(), true);
 	});
 
 	// Replace inline math ($...$) - single line only, not empty
 	// Negative lookbehind for \ to avoid matching \$
 	// Must not start or end with space (Obsidian behavior)
 	result = result.replace(/(?<![\\$])\$([^\s$](?:[^$]*[^\s$])?)\$(?!\d)/g, (_match, expr: string) => {
-		return createMathPlaceholder(expr, false);
+		return createPlaceholder(expr, false);
 	});
 
 	// Restore code blocks
@@ -126,11 +132,11 @@ function protectMath(text: string): string {
  * Full preprocessing pipeline.
  * Returns cleaned markdown ready for marked.parse().
  */
-function preprocessMarkdown(raw: string): string {
+function preprocessMarkdown(raw: string, createPlaceholder: (expression: string, displayMode: boolean) => string): string {
 	let text = raw;
 	text = stripFrontmatter(text);
 	text = stripComments(text);
-	text = protectMath(text);
+	text = protectMath(text, createPlaceholder);
 	return text;
 }
 
@@ -141,7 +147,7 @@ function preprocessMarkdown(raw: string): string {
 /**
  * Replace math placeholders with rendered KaTeX HTML.
  */
-function restoreMath(html: string): string {
+function restoreMath(html: string, mathStore: MathStore): string {
 	for (const [placeholder, { expression, displayMode }] of mathStore.entries()) {
 		try {
 			const rendered = katex.renderToString(expression, {
@@ -326,88 +332,97 @@ const tagExtension = {
 
 /**
  * Inline extension for ![[embed]] syntax.
+ *
+ * Built fresh per renderMarkdown() call (via createEmbedExtension), closing
+ * over that call's own `context` — NOT module-level state. renderMarkdown()
+ * now runs inside SvelteKit's server load() (TR-37), where one Node process
+ * serves many requests concurrently; a shared module-level render context
+ * would get overwritten mid-render by a different request for a different
+ * share, leaking one document's embed/slug resolution into another's output.
  */
-const embedExtension = {
-	name: 'obsidianEmbed' as const,
-	level: 'inline' as const,
-	start(src: string) {
-		return src.indexOf('![[');
-	},
-	tokenizer(src: string) {
-		const match = src.match(/^!\[\[([^\]]+)\]\]/);
-		if (match) {
-			const content = match[1];
-			let target: string;
-			let size: string | null = null;
+function createEmbedExtension(context: RenderContext) {
+	return {
+		name: 'obsidianEmbed' as const,
+		level: 'inline' as const,
+		start(src: string) {
+			return src.indexOf('![[');
+		},
+		tokenizer(src: string) {
+			const match = src.match(/^!\[\[([^\]]+)\]\]/);
+			if (match) {
+				const content = match[1];
+				let target: string;
+				let size: string | null = null;
 
-			if (content.includes('|')) {
-				const parts = content.split('|');
-				target = parts[0].trim();
-				size = parts.slice(1).join('|').trim();
-			} else {
-				target = content.trim();
+				if (content.includes('|')) {
+					const parts = content.split('|');
+					target = parts[0].trim();
+					size = parts.slice(1).join('|').trim();
+				} else {
+					target = content.trim();
+				}
+
+				return {
+					type: 'obsidianEmbed',
+					raw: match[0],
+					target,
+					size
+				};
+			}
+			return undefined;
+		},
+		renderer(token: { target: string; size: string | null }) {
+			const { target, size } = token;
+			const safeTarget = escapeHtml(target);
+			const safeSize = size ? escapeHtml(size) : null;
+			const ext = target.split('.').pop()?.toLowerCase() || '';
+			const imageExts = ['png', 'jpg', 'jpeg', 'gif', 'svg', 'webp', 'bmp', 'ico'];
+			const videoExts = ['mp4', 'webm', 'ogv', 'mov'];
+			const audioExts = ['mp3', 'wav', 'ogg', 'flac', 'm4a'];
+
+			// Image embeds with asset proxy
+			if (imageExts.includes(ext)) {
+				if (context.slug) {
+					const styleAttr = safeSize ? ` style="max-width: ${safeSize}px"` : '';
+					return `<img class="obsidian-embed-image" src="/${context.slug}/_assets/${safeTarget}" alt="${safeTarget}"${styleAttr} />`;
+				}
+				// Fallback placeholder without slug
+				const sizeInfo = safeSize ? ` (${safeSize}px)` : '';
+				return `<div class="obsidian-embed obsidian-embed-image"><span class="obsidian-embed-icon">&#128444;</span> Image: <strong>${safeTarget}</strong>${sizeInfo}</div>`;
 			}
 
-			return {
-				type: 'obsidianEmbed',
-				raw: match[0],
-				target,
-				size
-			};
-		}
-		return undefined;
-	},
-	renderer(token: { target: string; size: string | null }) {
-		const { target, size } = token;
-		const safeTarget = escapeHtml(target);
-		const safeSize = size ? escapeHtml(size) : null;
-		const ext = target.split('.').pop()?.toLowerCase() || '';
-		const imageExts = ['png', 'jpg', 'jpeg', 'gif', 'svg', 'webp', 'bmp', 'ico'];
-		const videoExts = ['mp4', 'webm', 'ogv', 'mov'];
-		const audioExts = ['mp3', 'wav', 'ogg', 'flac', 'm4a'];
-
-		// Image embeds with asset proxy
-		if (imageExts.includes(ext)) {
-			if (_renderContext.slug) {
-				const styleAttr = safeSize ? ` style="max-width: ${safeSize}px"` : '';
-				return `<img class="obsidian-embed-image" src="/${_renderContext.slug}/_assets/${safeTarget}" alt="${safeTarget}"${styleAttr} />`;
+			// Video/audio embeds (placeholder for now)
+			if (videoExts.includes(ext)) {
+				return `<div class="obsidian-embed obsidian-embed-video"><span class="obsidian-embed-icon">&#127909;</span> Video: <strong>${safeTarget}</strong></div>`;
 			}
-			// Fallback placeholder without slug
-			const sizeInfo = safeSize ? ` (${safeSize}px)` : '';
-			return `<div class="obsidian-embed obsidian-embed-image"><span class="obsidian-embed-icon">&#128444;</span> Image: <strong>${safeTarget}</strong>${sizeInfo}</div>`;
-		}
 
-		// Video/audio embeds (placeholder for now)
-		if (videoExts.includes(ext)) {
-			return `<div class="obsidian-embed obsidian-embed-video"><span class="obsidian-embed-icon">&#127909;</span> Video: <strong>${safeTarget}</strong></div>`;
-		}
-
-		if (audioExts.includes(ext)) {
-			return `<div class="obsidian-embed obsidian-embed-audio"><span class="obsidian-embed-icon">&#127925;</span> Audio: <strong>${safeTarget}</strong></div>`;
-		}
-
-		// Note embeds - show enhanced placeholder if found in folder
-		// TODO: Inline note rendering requires async pre-processing pass
-		if (_renderContext.folderItems) {
-			const noteItem = _renderContext.folderItems.find(
-				item => item.path === target || item.path === `${target}.md`
-			);
-
-			if (noteItem) {
-				const noteName = escapeHtml(noteItem.name || target);
-				// Show styled placeholder for found notes
-				return `<div class="obsidian-embed obsidian-embed-note obsidian-embed-note-found">
-					<span class="obsidian-embed-icon">&#128196;</span>
-					<span class="obsidian-embed-note-name">${noteName}</span>
-					<span class="obsidian-embed-note-hint">(in this folder)</span>
-				</div>`;
+			if (audioExts.includes(ext)) {
+				return `<div class="obsidian-embed obsidian-embed-audio"><span class="obsidian-embed-icon">&#127925;</span> Audio: <strong>${safeTarget}</strong></div>`;
 			}
-		}
 
-		// Note embed not found - placeholder
-		return `<div class="obsidian-embed obsidian-embed-note"><span class="obsidian-embed-icon">&#128196;</span> Embedded note: <strong>${safeTarget}</strong></div>`;
-	}
-};
+			// Note embeds - show enhanced placeholder if found in folder
+			// TODO: Inline note rendering requires async pre-processing pass
+			if (context.folderItems) {
+				const noteItem = context.folderItems.find(
+					item => item.path === target || item.path === `${target}.md`
+				);
+
+				if (noteItem) {
+					const noteName = escapeHtml(noteItem.name || target);
+					// Show styled placeholder for found notes
+					return `<div class="obsidian-embed obsidian-embed-note obsidian-embed-note-found">
+						<span class="obsidian-embed-icon">&#128196;</span>
+						<span class="obsidian-embed-note-name">${noteName}</span>
+						<span class="obsidian-embed-note-hint">(in this folder)</span>
+					</div>`;
+				}
+			}
+
+			// Note embed not found - placeholder
+			return `<div class="obsidian-embed obsidian-embed-note"><span class="obsidian-embed-icon">&#128196;</span> Embedded note: <strong>${safeTarget}</strong></div>`;
+		}
+	};
+}
 
 // ---------------------------------------------------------------------------
 // Marked extensions: Callouts
@@ -527,38 +542,18 @@ function walkTokensForTaskLists(token: Token): void {
 // ---------------------------------------------------------------------------
 // Configure marked instance
 // ---------------------------------------------------------------------------
+//
+// Built fresh per renderMarkdown() call (see buildMarkedInstance below), NOT
+// as a shared module-level singleton — renderMarkdown() runs inside
+// SvelteKit's server load() (TR-37), and marked.use() mutates the instance
+// it's called on, so a shared instance reconfigured per-request would race
+// exactly like the module-level render context did (see createEmbedExtension
+// above). highlightExtension/wikilinkExtension/tagExtension/walkTokens/the
+// custom renderer below are all stateless (no per-call context), so they're
+// safe to reuse as-is across instances — only the Marked instance itself and
+// the context-dependent embedExtension are rebuilt per call.
 
-const marked = new Marked(
-	markedHighlight({
-		langPrefix: 'hljs language-',
-		highlight(code, lang) {
-			// Mermaid: pass through as a special div instead of highlighting
-			if (lang === 'mermaid') {
-				return code;
-			}
-			const language = hljs.getLanguage(lang) ? lang : 'plaintext';
-			return hljs.highlight(code, { language }).value;
-		}
-	}),
-	markedFootnote()
-);
-
-// Add inline extensions
-marked.use({
-	extensions: [highlightExtension, wikilinkExtension, tagExtension, embedExtension]
-});
-
-// Add walkTokens for callout and task list detection
-marked.use({
-	walkTokens(token: Token) {
-		walkTokensForCallouts(token);
-		walkTokensForTaskLists(token);
-	}
-});
-
-// Custom renderer for callouts, mermaid, code blocks, and task lists
-marked.use({
-	renderer: {
+const customRenderer = {
 		blockquote(this: unknown, token: Tokens.Blockquote) {
 			const callout = (token as unknown as Record<string, unknown>)._callout as
 				| { type: string; title: string; foldable: boolean; defaultOpen: boolean }
@@ -640,15 +635,46 @@ marked.use({
 			// Regular list item
 			return `<li>${body}</li>\n`;
 		}
-	}
-});
+	};
 
-// Configure marked options for GFM support
-marked.setOptions({
-	gfm: true,
-	breaks: false,
-	pedantic: false
-});
+/** Builds a fresh Marked instance scoped to a single renderMarkdown() call. */
+function buildMarkedInstance(context: RenderContext): Marked {
+	const instance = new Marked(
+		markedHighlight({
+			langPrefix: 'hljs language-',
+			highlight(code, lang) {
+				// Mermaid: pass through as a special div instead of highlighting
+				if (lang === 'mermaid') {
+					return code;
+				}
+				const language = hljs.getLanguage(lang) ? lang : 'plaintext';
+				return hljs.highlight(code, { language }).value;
+			}
+		}),
+		markedFootnote()
+	);
+
+	instance.use({
+		extensions: [highlightExtension, wikilinkExtension, tagExtension, createEmbedExtension(context)]
+	});
+
+	instance.use({
+		walkTokens(token: Token) {
+			walkTokensForCallouts(token);
+			walkTokensForTaskLists(token);
+		}
+	});
+
+	instance.use({ renderer: customRenderer });
+
+	instance.setOptions({
+		gfm: true,
+		breaks: false,
+		pedantic: false
+	});
+
+	return instance;
+}
 
 // ---------------------------------------------------------------------------
 // DOMPurify configuration
@@ -724,35 +750,33 @@ export interface RenderContext {
 	folderItems?: Array<{ path: string; name: string; type: string; content?: string }>;
 }
 
-/** Module-level storage for render context (accessed by embed extension renderer) */
-let _renderContext: RenderContext = {};
-
 /**
  * Parse and render markdown to HTML.
  * Supports Obsidian-flavored markdown features.
  * Sanitizes HTML output to prevent XSS.
+ *
+ * Fully self-contained per call (no module-level mutable state) — this runs
+ * inside SvelteKit's server load() (TR-37), where one Node process serves
+ * many concurrent requests; shared state here would let one document's
+ * render bleed into another's.
  */
 export async function renderMarkdown(markdown: string, context?: RenderContext): Promise<string> {
-	// Reset math store for this render
-	resetMathStore();
-
-	// Store context for embed extension renderer
-	_renderContext = context || {};
+	const renderContext = context || {};
+	const mathStore: MathStore = new Map();
+	const createPlaceholder = createMathPlaceholderFactory(mathStore);
 
 	// Step 1: Preprocess (strip frontmatter, comments, protect math)
-	const preprocessed = preprocessMarkdown(markdown);
+	const preprocessed = preprocessMarkdown(markdown, createPlaceholder);
 
 	// Step 2: Parse with marked (extensions handle highlights, wikilinks, callouts, footnotes, mermaid)
+	const marked = buildMarkedInstance(renderContext);
 	const rawHtml = await marked.parse(preprocessed);
 
 	// Step 3: Restore math placeholders with KaTeX-rendered HTML
-	const withMath = restoreMath(rawHtml);
+	const withMath = restoreMath(rawHtml, mathStore);
 
 	// Step 4: Sanitize
 	const sanitizedHtml = DOMPurify.sanitize(withMath, SANITIZE_CONFIG);
-
-	// Clear context after rendering
-	_renderContext = {};
 
 	return sanitizedHtml;
 }

--- a/apps/web-publish/src/routes/[slug]/+page.server.ts
+++ b/apps/web-publish/src/routes/[slug]/+page.server.ts
@@ -1,5 +1,6 @@
 import { error } from '@sveltejs/kit';
 import { getShareBySlug, validateSession, validateUserToken, getFolderFileContent, ShareNotFoundError } from '$lib/api';
+import { renderMarkdown } from '$lib/markdown';
 import type { PageServerLoad } from './$types';
 
 /**
@@ -67,11 +68,11 @@ export const load: PageServerLoad = async ({ params, cookies, url }) => {
 		const isFolder = share.kind === 'folder';
 		let content: string | null = null;
 		let readmeContent: string | null = null;
+		const folderItems = isFolder ? (share.web_folder_items || []) : [];
 
 		if (!isFolder) {
 			content = share.web_content ?? `# ${share.path}\n\n> **Content not yet synced**\n>\n> Refresh after syncing from Obsidian.`;
 		} else {
-			const folderItems = share.web_folder_items || [];
 			const readmePath = findReadme(folderItems);
 
 			if (readmePath) {
@@ -87,6 +88,16 @@ export const load: PageServerLoad = async ({ params, cookies, url }) => {
 			}
 		}
 
+		// Render markdown to HTML server-side so the document body is present in the
+		// SSR output (non-JS crawlers/AI scrapers/social unfurlers never run the
+		// client-side render in MarkdownViewer's onMount) — TR-37.
+		const contentHtml = content
+			? await renderMarkdown(content, { slug: share.web_slug, folderItems })
+			: null;
+		const readmeHtml = readmeContent
+			? await renderMarkdown(readmeContent, { slug: share.web_slug, folderItems })
+			: null;
+
 		const sessionToken = share.visibility === 'protected' && isAuthenticated
 			? cookies.get('web_session')
 			: undefined;
@@ -94,9 +105,11 @@ export const load: PageServerLoad = async ({ params, cookies, url }) => {
 		return {
 			share,
 			content,
+			contentHtml,
 			isFolder,
-			folderItems: isFolder ? (share.web_folder_items || []) : [],
+			folderItems,
 			readmeContent,
+			readmeHtml,
 			needsPassword,
 			sessionToken,
 			authToken,

--- a/apps/web-publish/src/routes/[slug]/+page.svelte
+++ b/apps/web-publish/src/routes/[slug]/+page.svelte
@@ -186,7 +186,7 @@
 				<div class="flex-1 min-w-0 max-w-[800px]">
 					{#if data.readmeContent}
 						<!-- Show README.md content -->
-						<MarkdownViewer content={data.readmeContent} slug={data.share.web_slug} folderItems={data.folderItems} />
+						<MarkdownViewer content={data.readmeContent} initialHtml={data.readmeHtml || undefined} slug={data.share.web_slug} folderItems={data.folderItems} />
 					{:else if data.folderItems.length === 0}
 						<Card class="text-center border-dashed">
 							<CardHeader class="pb-2">
@@ -235,6 +235,7 @@
 					{#if hasRealtimeSync}
 						<LiveMarkdownViewer
 							content={data.content || ''}
+							initialHtml={data.contentHtml || undefined}
 							docId={data.share.web_doc_id}
 							slug={data.share.web_slug}
 							sessionToken={data.sessionToken}
@@ -250,7 +251,7 @@
 							folderItems={data.folderItems}
 						/>
 					{:else}
-						<MarkdownViewer content={data.content || ''} slug={data.share.web_slug} folderItems={data.folderItems} />
+						<MarkdownViewer content={data.content || ''} initialHtml={data.contentHtml || undefined} slug={data.share.web_slug} folderItems={data.folderItems} />
 					{/if}
 				</div>
 			</div>

--- a/apps/web-publish/src/routes/[slug]/[...path]/+page.server.ts
+++ b/apps/web-publish/src/routes/[slug]/[...path]/+page.server.ts
@@ -3,6 +3,7 @@ import { env } from '$env/dynamic/private';
 import { getShareBySlug, validateSession, validateUserToken, getFolderFileContent, ShareNotFoundError } from '$lib/api';
 import { slugifyPath } from '$lib/file-tree';
 import { verifyEmbedToken } from '$lib/embed-token';
+import { renderMarkdown } from '$lib/markdown';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ params, cookies, url }) => {
@@ -92,10 +93,15 @@ export const load: PageServerLoad = async ({ params, cookies, url }) => {
 			content = `# ${file.name}\n\n> **Content not yet synced**`;
 		}
 
+		// Render markdown to HTML server-side so the document body is present in the
+		// SSR output, not only after client-side hydration (TR-37).
+		const contentHtml = await renderMarkdown(content, { slug: share.web_slug, folderItems });
+
 		return {
 			share,
 			file,
 			content,
+			contentHtml,
 			filePath: slugifyPath(originalPath),
 			parentSlug: slug,
 			folderItems,

--- a/apps/web-publish/src/routes/[slug]/[...path]/+page.svelte
+++ b/apps/web-publish/src/routes/[slug]/[...path]/+page.svelte
@@ -79,7 +79,7 @@
 
 		<div class="flex gap-8 items-start">
 			<div class="flex-1 min-w-0 max-w-[800px]">
-				<MarkdownViewer content={data.content} slug={data.share.web_slug} folderItems={data.folderItems} />
+				<MarkdownViewer content={data.content} initialHtml={data.contentHtml} slug={data.share.web_slug} folderItems={data.folderItems} />
 			</div>
 		</div>
 	</article>

--- a/apps/web-publish/src/tests/MarkdownViewer.ssr.test.ts
+++ b/apps/web-publish/src/tests/MarkdownViewer.ssr.test.ts
@@ -1,0 +1,38 @@
+// ---------------------------------------------------------------------------
+// MarkdownViewer — server-side rendering (TR-37)
+// ---------------------------------------------------------------------------
+// The body used to render only in onMount/$effect (both browser-only), so a
+// non-JS crawler/AI scraper got an HTML shell with no content. Proves the
+// actual SSR HTML output directly via Svelte's server renderer, not just the
+// load() data shape.
+// ---------------------------------------------------------------------------
+
+import { describe, it, expect } from 'vitest';
+import { render } from 'svelte/server';
+import MarkdownViewer from '../lib/components/MarkdownViewer.svelte';
+
+describe('MarkdownViewer SSR output', () => {
+	it('renders the document body in SSR when initialHtml is provided', () => {
+		const { body } = render(MarkdownViewer, {
+			props: {
+				content: '# Hello\n\nWorld.',
+				initialHtml: '<h1>Hello</h1><p>World.</p>'
+			}
+		});
+
+		expect(body).toContain('<h1>Hello</h1>');
+		expect(body).toContain('World.');
+		expect(body).not.toContain('markdown-loading');
+	});
+
+	it('falls back to the loading skeleton in SSR when no initialHtml is given', () => {
+		const { body } = render(MarkdownViewer, {
+			props: {
+				content: '# Hello\n\nWorld.'
+			}
+		});
+
+		expect(body).toContain('markdown-loading');
+		expect(body).not.toContain('<h1>Hello</h1>');
+	});
+});

--- a/apps/web-publish/src/tests/folder-file-page-server.test.ts
+++ b/apps/web-publish/src/tests/folder-file-page-server.test.ts
@@ -1,0 +1,93 @@
+// @ts-nocheck — load() return type includes void (SvelteKit generic), tests use runtime values
+import { describe, it, expect, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// [slug]/[...path] load() — server-rendered HTML body (TR-37)
+// ---------------------------------------------------------------------------
+// Same fix as the doc route: the folder-file viewer must render the markdown
+// to HTML in load() so non-JS crawlers/AI scrapers see real content, not just
+// the client-only MarkdownViewer skeleton.
+// ---------------------------------------------------------------------------
+
+vi.mock('$env/dynamic/private', () => ({ env: {} }));
+
+vi.mock('$lib/api', () => ({
+	getShareBySlug: vi.fn(),
+	validateSession: vi.fn(),
+	validateUserToken: vi.fn(),
+	getFolderFileContent: vi.fn()
+}));
+
+vi.mock('@sveltejs/kit', async (importOriginal) => {
+	const mod = await importOriginal();
+	return {
+		...mod,
+		error: (status, message) => {
+			const err = new Error(message);
+			err.status = status;
+			throw err;
+		}
+	};
+});
+
+import * as api from '$lib/api';
+import { load } from '../routes/[slug]/[...path]/+page.server.js';
+
+function makeShare(overrides = {}) {
+	return {
+		id: 'share-id',
+		kind: 'folder',
+		path: 'Test Folder',
+		visibility: 'public',
+		web_slug: 'test-slug',
+		web_noindex: false,
+		created_at: new Date().toISOString(),
+		updated_at: new Date().toISOString(),
+		web_content: null,
+		web_folder_items: [{ path: 'Notes/Doc.md', name: 'Doc.md', type: 'doc' }],
+		web_doc_id: null,
+		...overrides
+	};
+}
+
+function makeCookies(values = {}) {
+	return { get: (k) => values[k] };
+}
+
+function makeUrl(params = {}) {
+	return { searchParams: { get: (k) => params[k] ?? null } };
+}
+
+describe('folder-file load() — server-rendered HTML (contentHtml)', () => {
+	it('returns contentHtml rendered from the file body', async () => {
+		vi.mocked(api.getShareBySlug).mockResolvedValue(makeShare());
+		vi.mocked(api.getFolderFileContent).mockResolvedValue({
+			path: 'Notes/Doc.md',
+			name: 'Doc.md',
+			type: 'doc',
+			content: '# File Title\n\nBody text.'
+		});
+
+		const data = await load({
+			params: { slug: 'test-slug', path: 'Notes/Doc.md' },
+			cookies: makeCookies(),
+			url: makeUrl()
+		});
+
+		expect(data.contentHtml).toMatch(/<h1[^>]*>File Title<\/h1>/);
+		expect(data.contentHtml).toContain('Body text.');
+	});
+
+	it('renders the not-yet-synced placeholder when the file fetch fails', async () => {
+		vi.mocked(api.getShareBySlug).mockResolvedValue(makeShare());
+		vi.mocked(api.getFolderFileContent).mockRejectedValue(new Error('boom'));
+
+		const data = await load({
+			params: { slug: 'test-slug', path: 'Notes/Doc.md' },
+			cookies: makeCookies(),
+			url: makeUrl()
+		});
+
+		expect(data.contentHtml).toContain('not yet synced');
+	});
+});

--- a/apps/web-publish/src/tests/page-server.test.ts
+++ b/apps/web-publish/src/tests/page-server.test.ts
@@ -209,6 +209,76 @@ describe('load() — private share', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Server-rendered HTML body (TR-37)
+// ---------------------------------------------------------------------------
+// MarkdownViewer only ever rendered the body in onMount/$effect (browser-only),
+// so a non-JS crawler/AI scraper got a body-less HTML shell. load() must render
+// the markdown to HTML itself so the SSR output has real content.
+// ---------------------------------------------------------------------------
+
+describe('load() — server-rendered HTML (contentHtml/readmeHtml)', () => {
+	it('returns contentHtml rendered from the document body', async () => {
+		vi.mocked(api.getShareBySlug).mockResolvedValue(
+			makeShare({ visibility: 'public', web_content: '# Hello\n\nWorld.' })
+		);
+
+		const data = await load({
+			params: { slug: 'test-slug' },
+			cookies: makeCookies(),
+			url: makeUrl()
+		});
+
+		expect(data.contentHtml).toMatch(/<h1[^>]*>Hello<\/h1>/);
+		expect(data.contentHtml).toContain('World.');
+	});
+
+	it('returns readmeHtml rendered from a folder README', async () => {
+		vi.mocked(api.getShareBySlug).mockResolvedValue(
+			makeShare({
+				kind: 'folder',
+				visibility: 'public',
+				web_content: null,
+				web_folder_items: [{ path: 'README.md', name: 'README.md', type: 'doc' }]
+			})
+		);
+		vi.mocked(api.getFolderFileContent).mockResolvedValue({
+			path: 'README.md',
+			name: 'README.md',
+			type: 'doc',
+			content: '# Folder Overview'
+		});
+
+		const data = await load({
+			params: { slug: 'test-slug' },
+			cookies: makeCookies(),
+			url: makeUrl()
+		});
+
+		expect(data.readmeHtml).toMatch(/<h1[^>]*>Folder Overview<\/h1>/);
+	});
+
+	it('readmeHtml is null when the folder has no README', async () => {
+		vi.mocked(api.getShareBySlug).mockResolvedValue(
+			makeShare({
+				kind: 'folder',
+				visibility: 'public',
+				web_content: null,
+				web_folder_items: [{ path: 'notes.md', name: 'notes.md', type: 'doc' }]
+			})
+		);
+
+		const data = await load({
+			params: { slug: 'test-slug' },
+			cookies: makeCookies(),
+			url: makeUrl()
+		});
+
+		expect(data.readmeHtml).toBeNull();
+		expect(data.contentHtml).toBeNull();
+	});
+});
+
+// ---------------------------------------------------------------------------
 // 404 — unknown share
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- `MarkdownViewer.svelte` only ever rendered the document body inside `onMount`/`$effect` — both browser-only. A published doc page's SSR HTML had `<title>`/`<meta>`/`<h1>` but zero body content, so non-JS crawlers, AI scrapers, and social unfurlers saw an empty page.
- `renderMarkdown()` was already fully SSR-safe. Both `+page.server.ts` load() functions now call it and return `contentHtml`/`readmeHtml`; `MarkdownViewer` gained an optional `initialHtml` prop seeded via a `$state` initializer (which *does* run during SSR, unlike `onMount`/`$effect`). `LiveMarkdownViewer` forwards it through. `EditableMarkdownViewer` (separate render path) is deliberately untouched — it only renders for authenticated `canEdit` users, never crawler traffic.
- Consolidated the previous `onMount` + `$effect` pair (which both fired redundantly on every mount even before this change) into one guarded render path, so the SSR-seeded content isn't clobbered by a spurious re-render flash on hydration.
- **Also fixed a concurrency bug this change exposed**: `renderMarkdown()`'s math-placeholder store and embed render context were module-level mutable state — safe when only ever called from a single browser tab, but now invoked from a Node server handling concurrent requests, where a second in-flight render could reset/overwrite the first's state mid-render. Confirmed via a concurrent test that two documents with different math cross-contaminated pre-fix. Both are now call-scoped with no shared mutable state.

## Test plan
- [x] `npm test`: 60/60 passing — new coverage for `contentHtml`/`readmeHtml` in both load() functions, a direct component-level SSR test using Svelte 5's `svelte/server` `render()` (proves the actual HTML output, not just data shape), and 3 concurrency-isolation tests for `renderMarkdown()` (would fail against the pre-fix code — verified by reproducing the cross-contamination manually before the fix, then confirming it's gone after).
- [x] `npm run check` (svelte-check): 0 errors, 0 warnings.
- [x] `npm run build`: succeeds.
- [x] **End-to-end manual verification**: built the app, ran it against a stub control-plane, and `curl`'d a published doc page directly. The raw HTML response contains the fully rendered body (headings, paragraphs, lists) with zero JS execution — reproducing the audit's own verification method.

TR-37 (audit #96d804dd)