### PR TITLE
security fix: relay-token TTL 30min→5min bounds remove_member write window (TR-22)

### DIFF
--- a/apps/control-plane/app/core/config.py
+++ b/apps/control-plane/app/core/config.py
@@ -32,7 +32,14 @@ class Settings(BaseSettings):
     refresh_token_expire_days: int = Field(default=30)
 
     relay_public_url: AnyUrl = Field(default="wss://relay.localhost")
-    relay_token_ttl_minutes: int = Field(default=30)
+    # TR-22: relay-token is a stateless CWT with no jti/revocation-list — remove_member
+    # cannot invalidate an already-issued token, so this TTL is the entire exposure
+    # window during which a removed member can still write to the CRDT doc. Keep this
+    # short; relay-server enforces exp per-message (not just at connect), confirmed in
+    # ghcr.io/entire-vc/evc-relay-server (crates/y-sweet-core/src/doc_connection.rs
+    # DocConnection::send + crates/relay/src/server.rs handle_socket), so shrinking this
+    # value directly shrinks the write-after-removal window.
+    relay_token_ttl_minutes: int = Field(default=5)
 
     # CORS settings
     cors_allowed_origins: str = Field(

--- a/apps/control-plane/app/core/security.py
+++ b/apps/control-plane/app/core/security.py
@@ -159,7 +159,8 @@ CWT_CLAIM_IAT = 6  # issued at
 CWT_CLAIM_SCOPE = -80201
 CWT_CLAIM_CHANNEL = -80202
 # Control-plane extension: share binding for confused-deputy mitigation (H6).
-# Relay-server (System3) must be verified to enforce this claim.
+# Confirmed NOT enforced by relay-server as of 2026-07-21 (TR-22 investigation) —
+# our fork's cwt.rs/auth.rs never reads claim -80203. Emitted for forward-compat only.
 CWT_CLAIM_SHARE = -80203
 
 # CBOR tags
@@ -185,12 +186,23 @@ def create_relay_token_cwt(
     - Claims: iss, iat, exp, scope (-80201), share (-80203)
     - Scope format: "doc:{doc_id}:rw" or "doc:{doc_id}:r"
 
-    Security notes (H6):
-    - exp is included for TTL enforcement; relay-server (System3) MUST be verified
-      to accept and enforce exp. If System3 rejects exp, file a System3 bug.
-    - share_id (-80203) binds the token to the issuing share for confused-deputy
-      mitigation. Relay-server enforcement of this claim is a System3 requirement
-      (currently unverified — track in H6 System3 follow-up task).
+    Security notes (H6, re-verified TR-22 2026-07-21 against our own fork —
+    ghcr.io/entire-vc/evc-relay-server, see docs/adr-relay-server-own-fork.md):
+    - exp is included for TTL enforcement and IS enforced by relay-server, both at
+      WS-connect (auth.rs verify_token_with_channel) and on every subsequent message
+      (y-sweet-core/src/doc_connection.rs DocConnection::send checks expiration_time
+      and closes the socket with "Token expired" — not a connect-only check). This is
+      no longer a System3 unknown; it's our own code, covered by
+      crates/relay/tests/token_expiration_integration_test.rs.
+    - share_id (-80203) is still NOT read or enforced by relay-server — confirmed by
+      inspection of crates/y-sweet-core/src/cwt.rs parse_claims_map and
+      crates/y-sweet-core/src/auth.rs (neither references claim -80203). It is emitted
+      here for forward-compat but provides no confused-deputy protection today. Real
+      fix requires relay-server changes — track separately, do NOT assume this claim
+      does anything yet.
+    - Because there is no jti/revocation-list, remove_member cannot invalidate a
+      token already handed to the ex-member — settings.relay_token_ttl_minutes (see
+      config.py) is the only lever bounding that exposure window (TR-22, #f63a2bea).
     - aud is omitted: y-sweet rejects tokens with the aud claim.
 
     Args:

--- a/apps/control-plane/app/services/token_service.py
+++ b/apps/control-plane/app/services/token_service.py
@@ -88,10 +88,13 @@ def issue_relay_token(
     # against.
     #
     # share_id is additionally embedded as CWT_CLAIM_SHARE (-80203) so the
-    # relay-server CAN cross-check the share→doc binding independently if it
-    # supports that claim. Relay-server (System3) enforcement of this claim is
-    # tracked separately — see TODO(H6-System3) follow-up task.
-    # TODO(H6-System3): verify relay-server enforces CWT_CLAIM_SHARE and scope.
+    # relay-server COULD cross-check the share→doc binding independently, but
+    # confirmed (TR-22, 2026-07-21) that our relay-server fork does not read this
+    # claim today — cwt.rs/auth.rs never reference -80203. It's inert, forward-compat
+    # only, until relay-server gains support.
+    # TODO(H6-relay-server): implement CWT_CLAIM_SHARE enforcement in
+    # ghcr.io/entire-vc/evc-relay-server (crates/y-sweet-core/src/cwt.rs
+    # parse_claims_map + auth.rs) — separate task from TR-22, file if not already open.
     private_key = request.app.state.relay_private_key
     key_id = request.app.state.relay_key_id
     relay_url = str(settings.relay_public_url).rstrip("/")

--- a/apps/control-plane/tests/test_security.py
+++ b/apps/control-plane/tests/test_security.py
@@ -254,3 +254,43 @@ def test_audit_logging_on_logout(client: TestClient) -> None:
     # Should have at least one user_logout event
     logout_logs = [log for log in logs if log["action"] == "user_logout"]
     assert len(logout_logs) > 0, "No logout events in audit log"
+
+
+# ── TR-22: relay-token TTL bounds the remove_member exposure window ──────────
+
+
+class TestTR22RelayTokenTTL:
+    """relay-token is a stateless CWT with no jti/revocation-list (#f63a2bea) —
+    remove_member cannot invalidate an already-issued token, so
+    relay_token_ttl_minutes is the entire window during which a removed member
+    can still write to the CRDT doc. Guard against this silently regressing
+    back to the old 30-minute default.
+    """
+
+    def test_default_ttl_is_short(self, monkeypatch):
+        from app.core.config import get_settings
+
+        monkeypatch.delenv("RELAY_TOKEN_TTL_MINUTES", raising=False)
+        get_settings.cache_clear()
+        try:
+            settings = get_settings()
+            assert settings.relay_token_ttl_minutes <= 10, (
+                "relay_token_ttl_minutes default grew past the TR-22 bound — this "
+                "directly widens the write-after-removal window since relay-tokens "
+                "cannot be revoked early (no jti/revocation-list)."
+            )
+        finally:
+            get_settings.cache_clear()
+
+    def test_ttl_is_configurable_via_env(self, monkeypatch):
+        """Deployments needing a different TTL can still override it explicitly."""
+        from app.core.config import get_settings
+
+        monkeypatch.setenv("RELAY_TOKEN_TTL_MINUTES", "2")
+        get_settings.cache_clear()
+        try:
+            settings = get_settings()
+            assert settings.relay_token_ttl_minutes == 2
+        finally:
+            monkeypatch.delenv("RELAY_TOKEN_TTL_MINUTES", raising=False)
+            get_settings.cache_clear()


### PR DESCRIPTION
## Summary

**TR-22 (P2, audit #96d804dd → task #f63a2bea):** `remove_member` doesn't invalidate an already-issued relay-token, so a removed member keeps write access to the CRDT doc until the token expires. relay-token is a stateless Ed25519 CWT with no jti/revocation-list — the only lever bounding that exposure window is the TTL, which defaulted to 30 minutes.

- `relay_token_ttl_minutes` default 30 → 5 (`app/core/config.py`, still overridable via `RELAY_TOKEN_TTL_MINUTES`).
- Confirmed against our own relay-server fork (`ghcr.io/entire-vc/evc-relay-server`, see `docs/adr-relay-server-own-fork.md`) that `exp` **is** enforced, both at WS-connect and on **every subsequent message** — `DocConnection::send` (`crates/y-sweet-core/src/doc_connection.rs`) checks `expiration_time` per write and closes the socket on expiry, not just at connect (`crates/relay/src/server.rs handle_socket`). Our own comments previously said this enforcement was "unverified/System3" — that's stale now that we own the fork; updated the docstrings in `security.py`/`token_service.py` to say what's actually confirmed.
- Also confirmed `CWT_CLAIM_SHARE` (-80203, the H6 confused-deputy claim) is **not** read by relay-server today — `cwt.rs::parse_claims_map` and `auth.rs` never reference it. Documented that honestly instead of leaving the old "TODO verify" language, and filed it as a separate relay-server follow-up (it doesn't carry per-member identity anyway, so implementing it wouldn't close TR-22).
- Added `TestTR22RelayTokenTTL` in `tests/test_security.py` guarding the default against silently regressing back to 30 minutes.

## Why this closes TR-22

Given confirmed per-message `exp` enforcement in the relay-server fork, shrinking the shared TTL directly and proportionally shrinks the write-after-removal window (30min → 5min). Per the finding's own verify step ("remove_member → WS-write attempt → rejected after the shortened window"), this is the intended fix shape — full jti/stateful revocation would need relay-server to call back to control-plane (or share a live denylist) on every message, which is a bigger cross-repo architecture change; flagged as a possible follow-up, not bundled into this P2 fix.

## Test plan

- [x] `pytest tests/test_security.py tests/test_cwt_tokens.py -v` — 42 passed
- [x] Full suite: `pytest tests/` — 503 passed, 1 skipped (pre-existing, unrelated)
- [x] New regression test (`test_default_ttl_is_short`) fails if the default TTL config regresses above 10 minutes