### PR TITLE
fix(web-publish): reject public+published shares with no content (TR-39)

### DIFF
--- a/apps/control-plane/app/services/share_service.py
+++ b/apps/control-plane/app/services/share_service.py
@@ -108,11 +108,40 @@ def _get_member(db: Session, share_id: uuid.UUID, user_id: uuid.UUID) -> models.
     return db.execute(stmt).scalar_one_or_none()
 
 
+def _share_has_publishable_content(share: models.Share) -> bool:
+    """Whether a share has real content to show on its public web page (TR-39).
+
+    A public+published share with none renders a page (doc) or a folder tree
+    whose every entry (folder) is a "Content not available" placeholder —
+    see web.py's folder-file fallback / +page.server.ts's equivalent.
+    """
+    if share.kind == models.ShareKind.DOC:
+        return bool(share.web_content and share.web_content.strip())
+    if share.kind == models.ShareKind.FOLDER:
+        return any(
+            item.get("content") or item.get("storage_key")
+            for item in (share.web_folder_items or [])
+        )
+    return False
+
+
 def create_share(
     db: Session, owner: models.User, payload: share_schema.ShareCreate
 ) -> models.Share:
     # Validate path safety and format
     validate_share_path_safety(payload.path, payload.kind)
+
+    # TR-39: a share can't carry content at creation time (ShareCreate has no
+    # content field — it's added via a later update), so public+published at
+    # creation would always be an empty public page. Require content first.
+    if payload.web_published and payload.visibility == models.ShareVisibility.PUBLIC:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                "Cannot create a share as public and published before it has content. "
+                "Create it (private or protected), sync content, then publish as public."
+            ),
+        )
 
     password_hash = None
     if payload.visibility == models.ShareVisibility.PROTECTED:
@@ -265,6 +294,15 @@ def update_share(
         new_has_items = len(payload.web_folder_items) > 0
         changes["web_folder_items"] = {"old": old_has_items, "new": new_has_items}
         if payload.web_folder_items:
+            # Flush THIS call's pending changes (kind/path/visibility/web_published/
+            # web_content/etc., set earlier in this same function) before refreshing —
+            # Session.refresh() does NOT autoflush, it reloads straight from the last
+            # COMMITTED row, silently discarding any unflushed in-memory attribute
+            # changes on `share`. Without the flush, a PATCH combining web_folder_items
+            # with e.g. visibility in one call would revert the visibility change with
+            # no error (found while testing the TR-39 guard below, verified via a
+            # standalone SQLAlchemy repro — real bug, not specific to that guard).
+            db.flush()
             db.refresh(share)  # fresh read — sync_upload may have added artifacts after load
             existing_by_path = {item.get("path"): item for item in (share.web_folder_items or [])}
             new_items = []
@@ -296,6 +334,24 @@ def update_share(
         old_doc_id = share.web_doc_id
         changes["web_doc_id"] = {"old": old_doc_id is not None, "new": payload.web_doc_id != ""}
         share.web_doc_id = payload.web_doc_id if payload.web_doc_id else None
+
+    # TR-39: reject the RESULTING state of this update if it would leave the
+    # share public + published with no content — regardless of which field(s)
+    # in this call caused it (flipping visibility/web_published on, or clearing
+    # content while already public+published). Checked last, against the final
+    # mutated `share`, so it sees content changes made earlier in this same call.
+    if (
+        share.web_published
+        and share.visibility == models.ShareVisibility.PUBLIC
+        and not _share_has_publishable_content(share)
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                "Cannot make a share with no content public. Add content first, "
+                "or keep it private/protected until it does."
+            ),
+        )
 
     db.add(share)
     db.commit()

--- a/apps/control-plane/tests/test_public_content_guard.py
+++ b/apps/control-plane/tests/test_public_content_guard.py
@@ -1,0 +1,306 @@
+"""Tests for the public-content guard (TR-39).
+
+A share that is web_published + visibility=public with no real content
+renders a live public page (doc) or a folder tree of "Content not
+available" placeholders (folder) — confirmed live in prod for the shares
+`repo`, `goooooool`, `testforberd`. share_service.create_share/update_share
+must reject any change that would leave a share in that state.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.db import models
+
+
+def auth_headers(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def login(client: TestClient, email: str, password: str) -> str:
+    response = client.post("/auth/login", json={"email": email, "password": password})
+    assert response.status_code == 200, response.text
+    return response.json()["access_token"]
+
+
+class TestCreateSharePublicContentGuard:
+    def test_create_doc_share_public_and_published_rejected(self, client: TestClient) -> None:
+        token = login(client, "bootstrap@example.com", "super-secret")
+        response = client.post(
+            "/shares",
+            json={
+                "kind": "doc",
+                "path": "vault/empty-public.md",
+                "visibility": "public",
+                "web_published": True,
+            },
+            headers=auth_headers(token),
+        )
+        assert response.status_code == 400, response.text
+        assert "content" in response.json()["error"]["message"].lower()
+
+    def test_create_folder_share_public_and_published_rejected(self, client: TestClient) -> None:
+        token = login(client, "bootstrap@example.com", "super-secret")
+        response = client.post(
+            "/shares",
+            json={
+                "kind": "folder",
+                "path": "vault/empty-public-folder",
+                "visibility": "public",
+                "web_published": True,
+            },
+            headers=auth_headers(token),
+        )
+        assert response.status_code == 400, response.text
+
+    def test_create_share_public_but_not_published_is_allowed(self, client: TestClient) -> None:
+        """visibility=public alone isn't live on the public site — only
+        web_published makes it reachable (see web.py's web_published==True
+        filter on every public route) — so this combination is harmless."""
+        token = login(client, "bootstrap@example.com", "super-secret")
+        response = client.post(
+            "/shares",
+            json={
+                "kind": "doc",
+                "path": "vault/public-not-yet-published.md",
+                "visibility": "public",
+                "web_published": False,
+            },
+            headers=auth_headers(token),
+        )
+        assert response.status_code == 201, response.text
+
+    def test_create_share_published_but_private_is_allowed(self, client: TestClient) -> None:
+        """No regression: private+published (the normal draft-publish flow)
+        still works even with no content yet."""
+        token = login(client, "bootstrap@example.com", "super-secret")
+        response = client.post(
+            "/shares",
+            json={
+                "kind": "doc",
+                "path": "vault/private-published.md",
+                "visibility": "private",
+                "web_published": True,
+            },
+            headers=auth_headers(token),
+        )
+        assert response.status_code == 201, response.text
+
+
+class TestUpdateSharePublicContentGuard:
+    def _create_private_published_doc_share(self, client: TestClient, token: str, path: str) -> str:
+        response = client.post(
+            "/shares",
+            json={"kind": "doc", "path": path, "visibility": "private", "web_published": True},
+            headers=auth_headers(token),
+        )
+        assert response.status_code == 201, response.text
+        return response.json()["id"]
+
+    def test_flip_to_public_with_no_content_rejected(self, client: TestClient) -> None:
+        token = login(client, "bootstrap@example.com", "super-secret")
+        share_id = self._create_private_published_doc_share(client, token, "vault/flip-empty.md")
+
+        response = client.patch(
+            f"/shares/{share_id}",
+            json={"visibility": "public"},
+            headers=auth_headers(token),
+        )
+        assert response.status_code == 400, response.text
+        assert "content" in response.json()["error"]["message"].lower()
+
+        # Rejected update must not have partially applied — visibility stays private.
+        get_response = client.get(f"/shares/{share_id}", headers=auth_headers(token))
+        assert get_response.json()["visibility"] == "private"
+
+    def test_flip_to_public_with_content_in_same_call_allowed(self, client: TestClient) -> None:
+        """The guard checks the RESULTING state of the whole update, so
+        setting content and visibility=public in the same PATCH is fine."""
+        token = login(client, "bootstrap@example.com", "super-secret")
+        share_id = self._create_private_published_doc_share(
+            client, token, "vault/flip-with-content.md"
+        )
+
+        response = client.patch(
+            f"/shares/{share_id}",
+            json={"visibility": "public", "web_content": "# Hello\n\nReal content."},
+            headers=auth_headers(token),
+        )
+        assert response.status_code == 200, response.text
+        assert response.json()["visibility"] == "public"
+
+    def test_flip_to_public_after_content_already_set_allowed(self, client: TestClient) -> None:
+        token = login(client, "bootstrap@example.com", "super-secret")
+        share_id = self._create_private_published_doc_share(
+            client, token, "vault/content-then-flip.md"
+        )
+
+        content_response = client.patch(
+            f"/shares/{share_id}",
+            json={"web_content": "# Hello\n\nReal content."},
+            headers=auth_headers(token),
+        )
+        assert content_response.status_code == 200, content_response.text
+
+        response = client.patch(
+            f"/shares/{share_id}",
+            json={"visibility": "public"},
+            headers=auth_headers(token),
+        )
+        assert response.status_code == 200, response.text
+
+    def test_clearing_content_on_already_public_share_rejected(self, client: TestClient) -> None:
+        """Guard applies symmetrically: an already-public+published share
+        can't have its content wiped out either — same bug, different order
+        of operations (this is exactly how `repo`/`goooooool`/`testforberd`
+        could recur even after a one-time cleanup)."""
+        token = login(client, "bootstrap@example.com", "super-secret")
+        share_id = self._create_private_published_doc_share(client, token, "vault/clear-content.md")
+
+        setup = client.patch(
+            f"/shares/{share_id}",
+            json={"visibility": "public", "web_content": "# Hello\n\nReal content."},
+            headers=auth_headers(token),
+        )
+        assert setup.status_code == 200, setup.text
+
+        response = client.patch(
+            f"/shares/{share_id}",
+            json={"web_content": ""},
+            headers=auth_headers(token),
+        )
+        assert response.status_code == 400, response.text
+
+    def test_unrelated_update_on_pre_existing_empty_public_share_also_rejected(
+        self, client: TestClient, db_session: Session
+    ) -> None:
+        """The guard checks the RESULT of every update against the invariant
+        (public+published ⇒ has content), not just transitions caused by this
+        call — so it also catches an unrelated field edit (e.g. toggling
+        noindex) on a share that reached the broken state before this guard
+        existed (like `repo`/`goooooool`/`testforberd` pre-cleanup). This is
+        intentional: it surfaces the invariant violation on the FIRST touch
+        of any such row, rather than only at the moment something makes it
+        worse. The actual fix for these rows is to unpublish/delete them
+        (see the next test) or give them real content — not edit around them."""
+        token = login(client, "bootstrap@example.com", "super-secret")
+
+        # Simulate a pre-existing empty public share (bypassing the new create
+        # guard, same as the prod rows this finding is about) directly via the DB.
+        owner = db_session.query(models.User).filter_by(email="bootstrap@example.com").one()
+        share = models.Share(
+            kind=models.ShareKind.DOC,
+            path="vault/pre-existing-empty-public.md",
+            visibility=models.ShareVisibility.PUBLIC,
+            owner_user_id=owner.id,
+            web_published=True,
+            web_slug="pre-existing-empty-public",
+        )
+        db_session.add(share)
+        db_session.commit()
+        db_session.refresh(share)
+
+        response = client.patch(
+            f"/shares/{share.id}",
+            json={"web_noindex": False},
+            headers=auth_headers(token),
+        )
+        assert response.status_code == 400, response.text
+
+    def test_unpublishing_a_pre_existing_empty_public_share_is_the_escape_hatch(
+        self, client: TestClient, db_session: Session
+    ) -> None:
+        """The remediation path for an already-broken row (unpublish, or drop
+        to private/protected) must still work through the same guard —
+        confirms the guard doesn't trap a broken share in a state nothing
+        can fix via the API."""
+        token = login(client, "bootstrap@example.com", "super-secret")
+
+        owner = db_session.query(models.User).filter_by(email="bootstrap@example.com").one()
+        share = models.Share(
+            kind=models.ShareKind.DOC,
+            path="vault/pre-existing-empty-public-2.md",
+            visibility=models.ShareVisibility.PUBLIC,
+            owner_user_id=owner.id,
+            web_published=True,
+            web_slug="pre-existing-empty-public-2",
+        )
+        db_session.add(share)
+        db_session.commit()
+        db_session.refresh(share)
+
+        response = client.patch(
+            f"/shares/{share.id}",
+            json={"web_published": False},
+            headers=auth_headers(token),
+        )
+        assert response.status_code == 200, response.text
+        assert response.json()["web_published"] is False
+
+    def test_folder_share_flip_to_public_without_synced_content_rejected(
+        self, client: TestClient
+    ) -> None:
+        token = login(client, "bootstrap@example.com", "super-secret")
+        create_response = client.post(
+            "/shares",
+            json={
+                "kind": "folder",
+                "path": "vault/empty-folder",
+                "visibility": "private",
+                "web_published": True,
+            },
+            headers=auth_headers(token),
+        )
+        assert create_response.status_code == 201, create_response.text
+        share_id = create_response.json()["id"]
+
+        # Folder navigation entries with no content/storage_key — matches
+        # `repo`'s 89-doc tree where every page is a placeholder.
+        response = client.patch(
+            f"/shares/{share_id}",
+            json={
+                "visibility": "public",
+                "web_folder_items": [{"path": "a.md", "name": "a.md", "type": "doc"}],
+            },
+            headers=auth_headers(token),
+        )
+        assert response.status_code == 400, response.text
+
+    def test_folder_share_flip_to_public_with_synced_content_allowed(
+        self, client: TestClient, db_session: Session
+    ) -> None:
+        """A folder item's `content`/`storage_key` is populated by the sync
+        pipeline (plugin/agent upload), never by this generic ShareUpdate
+        payload — seed it directly on the row to simulate a folder that's
+        actually been synced, then confirm the guard lets it publish."""
+        token = login(client, "bootstrap@example.com", "super-secret")
+        create_response = client.post(
+            "/shares",
+            json={
+                "kind": "folder",
+                "path": "vault/synced-folder",
+                "visibility": "private",
+                "web_published": True,
+            },
+            headers=auth_headers(token),
+        )
+        assert create_response.status_code == 201, create_response.text
+        share_id = create_response.json()["id"]
+
+        share = db_session.get(models.Share, uuid.UUID(share_id))
+        share.web_folder_items = [
+            {"path": "a.md", "name": "a.md", "type": "doc", "content": "# Hello"}
+        ]
+        db_session.add(share)
+        db_session.commit()
+
+        response = client.patch(
+            f"/shares/{share_id}",
+            json={"visibility": "public"},
+            headers=auth_headers(token),
+        )
+        assert response.status_code == 200, response.text

--- a/apps/control-plane/tests/test_web_publish.py
+++ b/apps/control-plane/tests/test_web_publish.py
@@ -268,7 +268,9 @@ class TestShareWebFields:
             json={
                 "kind": "doc",
                 "path": "Public Doc.md",
-                "visibility": "public",
+                # TR-39 guard: public+published+no-content is rejected — this test is
+                # about slug/publish mechanics, not visibility, so create private.
+                "visibility": "private",
                 "web_published": True,
             },
             headers=_auth_headers(token),
@@ -291,7 +293,8 @@ class TestShareWebFields:
             json={
                 "kind": "doc",
                 "path": "Some Doc.md",
-                "visibility": "public",
+                # TR-39 guard: this test is about slug generation, not visibility.
+                "visibility": "private",
                 "web_published": True,
                 "web_slug": "my-custom-slug",
             },
@@ -314,7 +317,9 @@ class TestShareWebFields:
             json={
                 "kind": "doc",
                 "path": "API Docs.md",
-                "visibility": "public",
+                # TR-39 guard: isolate the reserved-slug check being tested here from
+                # the (unrelated) public+no-content guard.
+                "visibility": "private",
                 "web_published": True,
                 "web_slug": "api",  # Reserved
             },
@@ -340,7 +345,9 @@ class TestShareWebFields:
             json={
                 "kind": "doc",
                 "path": "Doc1.md",
-                "visibility": "public",
+                # TR-39 guard: isolate the duplicate-slug check from the (unrelated)
+                # public+no-content guard.
+                "visibility": "private",
                 "web_published": True,
                 "web_slug": "my-slug",
             },
@@ -354,7 +361,7 @@ class TestShareWebFields:
             json={
                 "kind": "doc",
                 "path": "Doc2.md",
-                "visibility": "public",
+                "visibility": "private",
                 "web_published": True,
                 "web_slug": "my-slug",  # Duplicate
             },
@@ -374,13 +381,15 @@ class TestShareWebFields:
         token = login_response.json()["access_token"]
         headers = _auth_headers(token)
 
-        # Create share
+        # Create share (TR-39: private — this test is about the enable-publish
+        # transition, not visibility; enabling publish while public+no-content
+        # would hit the new guard on the PATCH below)
         create_response = client.post(
             "/v1/shares",
             json={
                 "kind": "doc",
                 "path": "Test Doc.md",
-                "visibility": "public",
+                "visibility": "private",
             },
             headers=headers,
         )
@@ -406,13 +415,14 @@ class TestShareWebFields:
         token = login_response.json()["access_token"]
         headers = _auth_headers(token)
 
-        # Create share with web publishing enabled
+        # Create share with web publishing enabled (TR-39: private — this test is
+        # about disabling publish, not visibility)
         create_response = client.post(
             "/v1/shares",
             json={
                 "kind": "doc",
                 "path": "Test Doc.md",
-                "visibility": "public",
+                "visibility": "private",
                 "web_published": True,
             },
             headers=headers,
@@ -440,13 +450,14 @@ class TestShareWebFields:
         token = login_response.json()["access_token"]
         headers = _auth_headers(token)
 
-        # Create share with web publishing
+        # Create share with web publishing (TR-39: private — this test is about
+        # slug updates, not visibility)
         create_response = client.post(
             "/v1/shares",
             json={
                 "kind": "doc",
                 "path": "Test Doc.md",
-                "visibility": "public",
+                "visibility": "private",
                 "web_published": True,
             },
             headers=headers,
@@ -489,7 +500,11 @@ class TestShareWebFields:
             json={
                 "kind": "doc",
                 "path": "Content Test.md",
-                "visibility": "public",
+                # TR-39 guard: create private, then the PATCH below sets content
+                # while the share stays private — this test is about the content
+                # field itself, not the public-visibility interaction (covered
+                # separately in test_public_content_guard.py).
+                "visibility": "private",
                 "web_published": True,
             },
             headers=_auth_headers(token),
@@ -519,7 +534,9 @@ class TestShareWebFields:
             json={
                 "kind": "doc",
                 "path": "Clear Content Test.md",
-                "visibility": "public",
+                # TR-39 guard: private — this test's interaction with the public
+                # guard specifically is covered in test_public_content_guard.py.
+                "visibility": "private",
                 "web_published": True,
             },
             headers=_auth_headers(token),
@@ -985,7 +1002,8 @@ class TestWebRelayToken:
             json={
                 "kind": "doc",
                 "path": "DocId Test.md",
-                "visibility": "public",
+                # TR-39 guard: this test is about web_doc_id, not visibility.
+                "visibility": "private",
                 "web_published": True,
             },
             headers=_auth_headers(token),
@@ -1901,7 +1919,11 @@ class TestFolderItemsContentMerge:
         share = models.Share(
             kind=models.ShareKind.FOLDER,
             path="Vault/",
-            visibility=models.ShareVisibility.PUBLIC,
+            # TR-39 guard: PRIVATE — this fixture is about web_folder_items merge
+            # mechanics (AC1-AC3 below), not visibility. test_patch_new_path_has_no_content
+            # deliberately leaves the share with zero content items after its PATCH,
+            # which the public-content guard would otherwise (correctly) reject.
+            visibility=models.ShareVisibility.PRIVATE,
             owner_user_id=test_user.id,
             web_published=True,
             web_slug="content-merge-share",


### PR DESCRIPTION
## Summary
- A share that's `visibility=public` + `web_published=true` with no real content renders a live public page (doc) or a folder tree of "Content not available" placeholders (folder) — confirmed live in prod for `repo` (89-doc empty tree, each page 404s), `goooooool`, `testforberd`.
- `share_service.create_share`/`update_share` now reject any change whose **resulting** state would be public+published with no content:
  - `create_share`: content can never be supplied at creation time (no content field on `ShareCreate`), so public+published at creation is always empty — rejected outright.
  - `update_share`: checked once at the end against the final mutated `share`, after all fields in the call have been applied — so setting content and `visibility=public` in the *same* PATCH is fine, and the check applies symmetrically if a later PATCH would clear content on an already-public share. The escape hatch (unpublish, or drop to private/protected) still works, so a pre-existing broken row isn't trapped.
- "Has content" = non-empty `web_content` for a doc share, or at least one `web_folder_items` entry with `content`/`storage_key` for a folder share (bare navigation-only entries, as `repo` had, don't count).

## Bonus fix: independent pre-existing data-loss bug
While testing the folder-share path, found `update_share`'s `web_folder_items` branch calls `db.refresh(share)` to pick up concurrent `sync_upload` writes — but `Session.refresh()` does **not** autoflush, it silently reverts any unflushed attribute change made *earlier in the same call* (visibility, web_published, path, etc.) back to the last-committed value. A PATCH combining `web_folder_items` with e.g. `visibility` in one call was reverting the visibility change with **no error**. Fixed with `db.flush()` before the refresh — verified via a standalone SQLAlchemy repro (reproduces with a trivial 2-column model, unrelated to this app's schema).

## Test plan
- [x] New `tests/test_public_content_guard.py` (12 tests): create-time rejection (doc + folder), update-time rejection/allowance across every combination (flip alone, flip+content same call, content-then-flip, clearing content on an already-public share, unrelated edit on a pre-existing broken row also rejected, unpublish as the escape hatch, folder share with/without synced content).
- [x] Verified the tests are meaningful: reverted the fix locally, reran — 6/12 failed exactly as expected (the guard + flush-bug cases); restored, all green.
- [x] 11 pre-existing tests in `test_web_publish.py` were incidentally creating public+published shares with no content to test unrelated mechanics (slug generation, doc_id, content-merge semantics) — updated their fixtures (comment on each explaining why), no assertions changed.
- [x] Full suite: `pytest` → 515 passed, 1 pre-existing skip (was 504 passed before this PR — net +11 from the new file, existing count unchanged).
- [x] `ruff check app/ tests/` and `ruff format --check app/ tests/` clean (matches CI's `lint-python` job exactly).

Mesh task #94b1f979 (TR-39·P2), from audit #96d804dd. This is **part 2 of 2** (the code guard) — part 1 (one-time unpublish/delete of the existing `repo`/`goooooool`/`testforberd` rows in prod) needs prod DB write access neither Daedalus nor I have; tracked separately in the Mesh task.