### PR TITLE
fix(oauth): send session.created security email + webhook on OAuth login (TR-16)

### DIFF
--- a/apps/control-plane/app/api/routers/oauth.py
+++ b/apps/control-plane/app/api/routers/oauth.py
@@ -12,6 +12,7 @@ from app.db import models
 from app.db.session import get_db
 from app.schemas import oauth as oauth_schema
 from app.services import audit_service, oauth_service, session_service
+from app.services.notification_service import get_notification_service
 
 router = APIRouter(prefix="/auth/oauth", tags=["oauth"])
 
@@ -261,6 +262,18 @@ async def callback(
     )
 
     db.commit()
+
+    # TR-16: OAuth was the only login path NOT sending the security-alert email
+    # + session.created webhook after create_session() — password login (auth.py)
+    # already does this. Same device_name passed to create_session() above.
+    notification_service = get_notification_service()
+    await notification_service.notify_session_created(
+        db,
+        user,
+        f"OAuth ({provider})",
+        request.client.host if request.client else None,
+        request.headers.get("user-agent"),
+    )
 
     # If return_url is provided, redirect with cookie
     if hasattr(state_data, "return_url") and state_data.return_url:

--- a/apps/control-plane/tests/test_oauth.py
+++ b/apps/control-plane/tests/test_oauth.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -481,6 +481,142 @@ class TestOAuthEndpoints:
             data = response.json()
             state_data = oauth_service.decode_state(data["state"])
             assert state_data.redirect_uri == "http://localhost:58548/callback"
+
+
+class TestOAuthCallbackSessionNotification:
+    """TR-16: OAuth login must send the security-alert email + session.created
+    webhook after create_session(), same as the password-login path (auth.py)
+    already does. oauth.py's callback() previously called create_session()
+    directly with no notification_service call at all."""
+
+    def _make_provider(self, db_session: Session) -> models.OAuthProvider:
+        provider = models.OAuthProvider(
+            id=uuid.uuid4(),
+            name="casdoor",
+            provider_type=models.OAuthProviderType.OIDC,
+            issuer_url="https://casdoor.example.com",
+            client_id="test_client_id",
+            client_secret_encrypted="test_secret",
+            enabled=True,
+            auto_register=True,
+        )
+        db_session.add(provider)
+        db_session.commit()
+        return provider
+
+    def _make_global_webhook(self, db_session: Session, event_type: str) -> models.Webhook:
+        webhook = models.Webhook(
+            id=uuid.uuid4(),
+            user_id=None,  # admin/global webhook — matches any user per find_matching_webhooks
+            name="test session webhook",
+            url="https://example.com/hook",
+            secret="whsec_test",
+            events=[event_type],
+            active=True,
+        )
+        db_session.add(webhook)
+        db_session.commit()
+        return webhook
+
+    def _run_callback(
+        self, client: TestClient, db_session: Session, provider: models.OAuthProvider
+    ):
+        from app.schemas.oauth import OAuthStateData, OAuthUserInfo
+
+        state = oauth_service.encode_state(
+            OAuthStateData(
+                code_verifier="test-verifier-1234567890abcdefghijklmno",
+                redirect_uri="https://cp.example.com/callback",
+            )
+        )
+        userinfo = OAuthUserInfo(
+            sub="casdoor-user-1",
+            email="oauth-login@example.com",
+            name="OAuth Login User",
+            groups=[],
+        )
+        with (
+            patch(
+                "app.api.routers.oauth.oauth_service.exchange_code_for_tokens",
+                new_callable=AsyncMock,
+                return_value={"access_token": "fake-provider-access-token"},
+            ),
+            patch(
+                "app.api.routers.oauth.oauth_service.get_user_info",
+                new_callable=AsyncMock,
+                return_value=userinfo,
+            ),
+        ):
+            response = client.get(
+                f"/v1/auth/oauth/{provider.name}/callback",
+                params={"code": "fake-code", "state": state},
+            )
+        return response
+
+    def test_callback_queues_security_email(self, client: TestClient, db_session: Session):
+        provider = self._make_provider(db_session)
+
+        response = self._run_callback(client, db_session, provider)
+        assert response.status_code == 200, response.text
+
+        emails = (
+            db_session.query(models.EmailQueue)
+            .filter(models.EmailQueue.to_email == "oauth-login@example.com")
+            .all()
+        )
+        security_emails = [e for e in emails if e.email_type == "security_new_session"]
+        assert len(security_emails) == 1, [e.email_type for e in emails]
+
+    def test_callback_queues_session_created_webhook(self, client: TestClient, db_session: Session):
+        provider = self._make_provider(db_session)
+        self._make_global_webhook(db_session, "session.created")
+
+        response = self._run_callback(client, db_session, provider)
+        assert response.status_code == 200, response.text
+
+        deliveries = (
+            db_session.query(models.WebhookDelivery)
+            .filter(models.WebhookDelivery.event_type == "session.created")
+            .all()
+        )
+        assert len(deliveries) == 1
+        assert deliveries[0].payload["data"]["user"]["email"] == "oauth-login@example.com"
+
+    def test_callback_without_notification_fix_would_have_sent_nothing(
+        self, client: TestClient, db_session: Session
+    ):
+        """Guards against the exact regression: with notify_session_created()
+        stubbed out (simulating the pre-fix code), NEITHER channel fires —
+        proves the two tests above actually exercise the fix, not some other
+        path that would queue these regardless."""
+        provider = self._make_provider(db_session)
+        self._make_global_webhook(db_session, "session.created")
+
+        with patch(
+            "app.api.routers.oauth.get_notification_service"
+        ) as mock_get_notification_service:
+            mock_service = MagicMock()
+            mock_service.notify_session_created = AsyncMock()
+            mock_get_notification_service.return_value = mock_service
+
+            response = self._run_callback(client, db_session, provider)
+            assert response.status_code == 200, response.text
+            mock_service.notify_session_created.assert_awaited_once()
+
+        # With the real notification service swapped out, nothing should have
+        # actually landed in either queue.
+        emails = (
+            db_session.query(models.EmailQueue)
+            .filter(models.EmailQueue.to_email == "oauth-login@example.com")
+            .all()
+        )
+        assert emails == []
+        deliveries = (
+            db_session.query(models.WebhookDelivery)
+            .filter(models.WebhookDelivery.event_type == "session.created")
+            .all()
+        )
+        assert deliveries == []
 
 
 class TestOAuthGroupMapping:


### PR DESCRIPTION
## Summary
- `oauth.py`'s `callback()` called `session_service.create_session()` but never `notification_service.notify_session_created()` — the password-login path (`auth.py:96`, `:846`) already does both (security-alert email `security_new_session` + `session.created` webhook, both queued by the single `notify_session_created` call).
- Since OAuth is the only real production login path, this meant new-session security alerts and the `session.created` webhook had been effectively dead in prod since 2026-07-07 (`max(created_at)` on `security_new_session`), despite ≥7 real OAuth logins after 2026-07-10 — this is the resolution of the sync-audit's UNVERIFIED item about `security_new_session` stopping.
- Fix: add the same `notify_session_created(db, user, device_name, ip_address, user_agent)` call `auth.py` uses, placed right after `db.commit()` and before the redirect-vs-JSON response branch so it covers both response shapes the callback can return.

## Test plan
- [x] New `TestOAuthCallbackSessionNotification` in `tests/test_oauth.py` (3 tests): drives the actual `/v1/auth/oauth/{provider}/callback` endpoint (mocking only the true external boundary — the OAuth provider's token/userinfo exchange) and asserts a real `EmailQueue` row (`email_type=security_new_session`) and a real `WebhookDelivery` row (`event_type=session.created`, correct payload) are created; third test confirms neither lands when the notification call is stubbed out, proving the first two actually exercise the fix.
- [x] Verified meaningful: reverted the fix locally, reran — all 3 new tests failed as expected (one via `AttributeError` on the now-missing `get_notification_service` import, the other two on empty query results); restored, all green.
- [x] Full suite: `pytest` → 518 passed, 1 pre-existing skip (was 515 before this PR).
- [x] `ruff check app/ tests/` and `ruff format --check app/ tests/` clean (matches CI's `lint-python` job).

Mesh task #b093f60d (TR-16·P2), from audit #96d804dd.