### PR TITLE
fix(health): /health/ready returns 503 on DB-down, healthcheck watches readiness (TR-17)

### DIFF
--- a/apps/control-plane/app/api/routers/health.py
+++ b/apps/control-plane/app/api/routers/health.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, status
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from sqlalchemy import text
 from sqlalchemy.orm import Session
@@ -48,10 +49,10 @@ def liveness_probe() -> HealthStatus:
 
 
 @router.get("/health/ready", response_model=DetailedHealthStatus)
-def readiness_probe(db: Session = Depends(get_db)) -> DetailedHealthStatus:
+def readiness_probe(db: Session = Depends(get_db)) -> DetailedHealthStatus | JSONResponse:
     """
     Kubernetes readiness probe.
-    Returns 200 if the application is ready to serve traffic.
+    Returns 200 if the application is ready to serve traffic, 503 otherwise.
     Checks database connectivity and relay keys.
     """
     settings = get_settings()
@@ -72,13 +73,27 @@ def readiness_probe(db: Session = Depends(get_db)) -> DetailedHealthStatus:
     # Return unhealthy status if any check fails
     overall_status = "healthy" if db_status == "healthy" else "unhealthy"
 
-    return DetailedHealthStatus(
+    body = DetailedHealthStatus(
         status=overall_status,
         timestamp=datetime.utcnow(),
         version=settings.api_version,
         database=db_status,
         relay_keys=relay_keys_status,
     )
+
+    # TR-17: the body already carried status="unhealthy" on DB-down, but the
+    # HTTP status code stayed 200 — Docker's healthcheck (and any LB/monitor
+    # that reads the status code, not the JSON body) never saw a failure, so
+    # a real Postgres outage went undetected. Return the same body but with
+    # a real 503 when not ready — a Response instance returned directly
+    # bypasses response_model's forced-200 serialization for this case.
+    if overall_status != "healthy":
+        return JSONResponse(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            content=body.model_dump(mode="json"),
+        )
+
+    return body
 
 
 @router.get("/version")

--- a/apps/control-plane/tests/test_operational.py
+++ b/apps/control-plane/tests/test_operational.py
@@ -32,6 +32,39 @@ def test_readiness_probe(client: TestClient) -> None:
     assert "version" in data
 
 
+def test_readiness_probe_returns_503_when_db_down(client: TestClient) -> None:
+    """TR-17: a DB outage must fail the HTTP status code, not just the JSON body.
+
+    Before the fix, /health/ready computed status="unhealthy" in the response
+    body but always returned 200 — Docker's healthcheck (and any load balancer
+    or monitor that reads the status code, not the JSON) never saw a failure,
+    so a real Postgres outage went undetected.
+    """
+    from app.db.session import get_db
+
+    class _BrokenSession:
+        def execute(self, *args: object, **kwargs: object) -> None:
+            raise RuntimeError("simulated DB outage")
+
+    def _broken_get_db():
+        yield _BrokenSession()
+
+    original = client.app.dependency_overrides.get(get_db)
+    client.app.dependency_overrides[get_db] = _broken_get_db
+    try:
+        response = client.get("/health/ready")
+    finally:
+        if original is not None:
+            client.app.dependency_overrides[get_db] = original
+        else:
+            client.app.dependency_overrides.pop(get_db, None)
+
+    assert response.status_code == 503, response.text
+    data = response.json()
+    assert data["status"] == "unhealthy"
+    assert data["database"] == "unhealthy"
+
+
 def test_version_endpoint(client: TestClient) -> None:
     """Test version endpoint."""
     response = client.get("/version")

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -121,12 +121,17 @@ services:
       minio-init:
         condition: service_completed_successfully
     healthcheck:
+      # TR-17: watch readiness (DB-connectivity-checked), not the static /health
+      # endpoint (always {"ok": true}, no DB check at all — a Postgres outage
+      # never made this healthcheck fail). urlopen() raises HTTPError on a
+      # non-2xx response rather than returning it — explicitly catch it and
+      # exit 1 on any non-200 code, including /health/ready's 503.
       test:
         [
           "CMD",
           "python",
           "-c",
-          "import sys,urllib.request;sys.exit(0) if urllib.request.urlopen('http://127.0.0.1:8000/health').status == 200 else sys.exit(1)",
+          "import sys,urllib.error,urllib.request\ntry:\n    sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:8000/health/ready').status == 200 else 1)\nexcept urllib.error.HTTPError:\n    sys.exit(1)",
         ]
       interval: 15s
       timeout: 5s


### PR DESCRIPTION
## Summary
- `/health/ready` already computed `status="unhealthy"` in its JSON body when the DB was unreachable, but always returned HTTP **200** regardless — a load balancer, Docker healthcheck, or any monitor reading the status code (not parsing the JSON) never saw a failure.
- Meanwhile the actual Docker healthcheck in `infra/docker-compose.yml` hit the static `/health` endpoint, which does no DB check at all (`{"ok": true}` unconditionally).
- Combined: a real Postgres outage would go completely undetected — no container restart, no LB failover, no alert. This is the exact monitoring blind spot @daedalus flagged.

## Fix
- `health.py`: `readiness_probe` returns a `JSONResponse` with `status_code=503` (same body) when `overall_status != "healthy"`, 200 otherwise. Returning a `Response` instance directly bypasses `response_model`'s forced-200 serialization for just this case.
- `infra/docker-compose.yml`: control-plane healthcheck now targets `/health/ready` instead of `/health`. `urlopen()` raises `HTTPError` on a non-2xx response rather than returning it — added an explicit `except` clause so a 503 correctly maps to a failed healthcheck.

## Test plan
- [x] **Real Docker smoke test** (not just unit tests): built the image, ran it against a real `postgres:16` container, `alembic upgrade head`, confirmed `/health/ready`=200 and `docker inspect` container health=`healthy`. Then `docker stop` on postgres — confirmed `/health/ready`=503 and the container's own Docker healthcheck flipped to `unhealthy` within one interval. This matches the task's literal acceptance criterion ("остановить PG → /health/ready = 503, контейнер unhealthy") on an actual container, not a mock.
- [x] New unit test (`test_readiness_probe_returns_503_when_db_down`): overrides the `get_db` dependency to raise, asserts 503 + `database=unhealthy` in the body. Verified meaningful — reverted the fix locally, test failed (200 instead of 503) as expected; restored, green.
- [x] Full suite: `pytest` → 519 passed, 1 pre-existing skip (was 518 before this PR).
- [x] `ruff check`/`ruff format --check` clean.
- [x] Validated the exact healthcheck Python one-liner standalone against a mock HTTP server returning 200 and 503 — exit 0 / exit 1 respectively, confirming the `urllib.error.HTTPError` handling is correct.

Mesh task #bf670f8e (TR-17·P2), from audit #96d804dd.

Note: this PR fixes `infra/docker-compose.yml` (the repo's dev/local compose template). The **production** `docker-compose.yml` lives server-side on `tr-relay-vm` (not synced by the deploy pipeline, per `docs/DEPLOY.md`) and needs the identical healthcheck-target edit applied there at actual deploy time — flagged in the Mesh task alongside the current TR-03/TR-22/TR-39/TR-16 deploy-blocker discussion.