### PR TITLE
fix(lifecycle): commit queue+mark-sent atomically to stop duplicate nudges

### DIFF
--- a/apps/control-plane/app/services/email_service.py
+++ b/apps/control-plane/app/services/email_service.py
@@ -255,6 +255,8 @@ class EmailService:
         text_body: str,
         html_body: str,
         email_type: str,
+        *,
+        commit: bool = True,
     ) -> EmailQueue:
         """Queue email for async delivery.
 
@@ -265,9 +267,16 @@ class EmailService:
             text_body: Plain text body
             html_body: HTML body
             email_type: Email type for tracking
+            commit: Commit (and refresh) immediately. Set False to fold this
+                insert into a caller-managed transaction — e.g. lifecycle_service
+                (TR-18) commits the queued email and its idempotency-key row
+                together, so a crash lands on neither side of that gap instead
+                of leaving an email queued with no record that it was sent.
 
         Returns:
-            Created EmailQueue instance
+            Created EmailQueue instance. `id` is populated either way (a
+            client-side default), but server-generated fields like
+            `created_at` stay unset until whoever commits refreshes it.
         """
         email = EmailQueue(
             to_email=to_email,
@@ -280,8 +289,9 @@ class EmailService:
         )
 
         db.add(email)
-        db.commit()
-        db.refresh(email)
+        if commit:
+            db.commit()
+            db.refresh(email)
 
         logger.info(
             "Email queued",
@@ -289,6 +299,7 @@ class EmailService:
                 "email_id": str(email.id),
                 "to": to_email,
                 "type": email_type,
+                "committed": commit,
             },
         )
 

--- a/apps/control-plane/app/services/lifecycle_service.py
+++ b/apps/control-plane/app/services/lifecycle_service.py
@@ -23,6 +23,7 @@ from pathlib import Path
 
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 from sqlalchemy import exists, func, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.core.config import get_settings
@@ -39,6 +40,7 @@ from app.services import argus_service
 from app.services.email_service import (
     EMAIL_TYPE_LIFECYCLE_INACTIVE_AFTER_SHARE,
     EMAIL_TYPE_LIFECYCLE_NO_SHARE_24H,
+    EmailService,
     get_email_service,
 )
 
@@ -105,28 +107,54 @@ def _already_handled(db: Session, user_id: uuid.UUID, trigger_key: str) -> bool:
     return row is not None and row.state in ("sent", "suppressed")
 
 
-def _mark_sent(db: Session, user_id: uuid.UUID, trigger_key: str) -> None:
-    """Upsert lifecycle_state to sent (idempotent via unique constraint)."""
-    now = datetime.now(timezone.utc)
-    existing = db.execute(
-        select(LifecycleState).where(
-            LifecycleState.user_id == user_id,
-            LifecycleState.trigger_key == trigger_key,
+def _queue_and_mark_sent(
+    db: Session,
+    email_svc: EmailService,
+    user_id: uuid.UUID,
+    trigger_key: str,
+    to_email: str,
+    subject: str,
+    text_body: str,
+    html_body: str,
+    email_type: str,
+) -> bool:
+    """Queue the nudge email and claim the trigger in ONE transaction (TR-18).
+
+    queue_email() and marking the trigger sent used to be two independent
+    commits. A crash between them left the email queued but the trigger
+    unclaimed — the next cycle's _already_handled() found nothing and fired
+    the same trigger again, queuing a duplicate nudge. Committing both writes
+    together closes that window: a crash now lands on neither side of it, so
+    the next cycle retries from a clean state instead of double-sending.
+
+    The lifecycle_state unique constraint (user_id, trigger_key) is a second,
+    independent guard — it catches a genuine race (e.g. overlapping worker
+    cycles) that _already_handled()'s own read can't, since that read and
+    this write aren't atomic with each other. Caught here, not left to
+    propagate, so one conflicting user doesn't abort the rest of the batch.
+
+    Returns False (email rolled back, nothing sent) if the trigger was
+    already claimed by someone else; True on success.
+    """
+    email_svc.queue_email(db, to_email, subject, text_body, html_body, email_type, commit=False)
+    db.add(
+        LifecycleState(
+            user_id=user_id,
+            trigger_key=trigger_key,
+            state="sent",
+            sent_at=datetime.now(timezone.utc),
         )
-    ).scalar_one_or_none()
-    if existing is None:
-        db.add(
-            LifecycleState(
-                user_id=user_id,
-                trigger_key=trigger_key,
-                state="sent",
-                sent_at=now,
-            )
+    )
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        logger.warning(
+            "Lifecycle trigger already claimed, skipping duplicate send",
+            extra={"user_id": str(user_id), "trigger_key": trigger_key},
         )
-    else:
-        existing.state = "sent"
-        existing.sent_at = now
-    db.commit()
+        return False
+    return True
 
 
 # ------------------------------------------------------------------
@@ -208,11 +236,18 @@ def process_t1_no_share_24h(db: Session, launch_cutoff: datetime) -> int:
         html, text = _render_template("lifecycle-no-share-24h", ctx)
         subject = "Шара в Team Relay — нужна помощь с подключением?"
 
-        email_svc.queue_email(
-            db, user.email, subject, text, html, EMAIL_TYPE_LIFECYCLE_NO_SHARE_24H
-        )
-        _mark_sent(db, user.id, trigger_key)
-        sent += 1
+        if _queue_and_mark_sent(
+            db,
+            email_svc,
+            user.id,
+            trigger_key,
+            user.email,
+            subject,
+            text,
+            html,
+            EMAIL_TYPE_LIFECYCLE_NO_SHARE_24H,
+        ):
+            sent += 1
 
     return sent
 
@@ -278,11 +313,18 @@ def process_t2_inactive_after_share(db: Session, launch_cutoff: datetime) -> int
         html, text = _render_template("lifecycle-inactive-after-share", ctx)
         subject = "Как дела с шарой в Team Relay?"
 
-        email_svc.queue_email(
-            db, user.email, subject, text, html, EMAIL_TYPE_LIFECYCLE_INACTIVE_AFTER_SHARE
-        )
-        _mark_sent(db, user.id, trigger_key)
+        if _queue_and_mark_sent(
+            db,
+            email_svc,
+            user.id,
+            trigger_key,
+            user.email,
+            subject,
+            text,
+            html,
+            EMAIL_TYPE_LIFECYCLE_INACTIVE_AFTER_SHARE,
+        ):
+            sent += 1
         seen_users.add(user.id)
-        sent += 1
 
     return sent

--- a/apps/control-plane/tests/test_argus_integration.py
+++ b/apps/control-plane/tests/test_argus_integration.py
@@ -274,7 +274,6 @@ class TestLifecycleArgusSuppressionT1:
                 return_value=("<html>", "text"),
             ),
             patch("app.services.lifecycle_service._template_context", return_value={}),
-            patch("app.services.lifecycle_service._mark_sent"),
             patch("app.services.lifecycle_service.get_email_service") as mock_email,
         ):
             db.execute.return_value.scalars.return_value.all.return_value = [user]

--- a/apps/control-plane/tests/test_lifecycle_service.py
+++ b/apps/control-plane/tests/test_lifecycle_service.py
@@ -1,0 +1,180 @@
+"""Tests for lifecycle_service — TR-18 atomic queue+mark-sent.
+
+TR-18: queue_email() and marking a lifecycle trigger "sent" used to be two
+independent commits (lifecycle_service.py:211-214). A crash between them
+left the email queued but the trigger unclaimed, so the next detection
+cycle's _already_handled() found nothing and fired the same trigger again —
+a duplicate nudge. _queue_and_mark_sent() now commits both writes together
+in one transaction, with the lifecycle_state unique constraint as a second
+independent guard against a genuine race.
+
+No SMTP call happens on this path (queue_email() only inserts a DB row —
+actual sending is a separate later step in process_queued_email()), so
+these tests use the real EmailService + a real SQLite session rather than
+mocking the DB layer (per repo convention: mock only true external
+boundaries).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from app.db.models import EmailQueue, LifecycleState, User
+from app.services.email_service import get_email_service
+from app.services.lifecycle_service import (
+    _queue_and_mark_sent,
+    process_t1_no_share_24h,
+)
+
+
+def _make_user(db_session, email="nudge-target@example.com", created_at=None):
+    user = User(
+        email=email,
+        password_hash="x",
+        is_admin=False,
+        is_active=True,
+        created_at=created_at or (datetime.now(timezone.utc) - timedelta(hours=48)),
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+class TestQueueAndMarkSent:
+    def test_first_call_queues_email_and_claims_trigger(self, db_session):
+        user = _make_user(db_session)
+        email_svc = get_email_service()
+
+        result = _queue_and_mark_sent(
+            db_session,
+            email_svc,
+            user.id,
+            "trig-1",
+            user.email,
+            "subject",
+            "text",
+            "<html/>",
+            "lifecycle_no_share_24h",
+        )
+
+        assert result is True
+        assert db_session.query(EmailQueue).count() == 1
+        state = (
+            db_session.query(LifecycleState).filter_by(user_id=user.id, trigger_key="trig-1").one()
+        )
+        assert state.state == "sent"
+
+    def test_second_call_for_same_trigger_is_rejected_and_does_not_double_queue(self, db_session):
+        """The actual regression: a second claim attempt for the same
+        (user, trigger) — the observable shape of "the process crashed and
+        the cycle re-ran" — must not leave a second EmailQueue row behind.
+        Pre-fix, queue_email()'s own commit had already landed by the time
+        _mark_sent() ran, so there was nothing to roll back."""
+        user = _make_user(db_session)
+        email_svc = get_email_service()
+
+        first = _queue_and_mark_sent(
+            db_session,
+            email_svc,
+            user.id,
+            "trig-1",
+            user.email,
+            "s1",
+            "t1",
+            "<h1/>",
+            "lifecycle_no_share_24h",
+        )
+        second = _queue_and_mark_sent(
+            db_session,
+            email_svc,
+            user.id,
+            "trig-1",
+            user.email,
+            "s2",
+            "t2",
+            "<h2/>",
+            "lifecycle_no_share_24h",
+        )
+
+        assert first is True
+        assert second is False
+        assert db_session.query(EmailQueue).count() == 1
+        assert (
+            db_session.query(LifecycleState)
+            .filter_by(user_id=user.id, trigger_key="trig-1")
+            .count()
+            == 1
+        )
+
+    def test_session_remains_usable_after_a_rejected_claim(self, db_session):
+        """A rejected claim must roll back cleanly, not poison the session
+        for whoever processes the next user in the same batch loop."""
+        user = _make_user(db_session)
+        other_user = _make_user(db_session, email="other@example.com")
+        email_svc = get_email_service()
+
+        _queue_and_mark_sent(
+            db_session,
+            email_svc,
+            user.id,
+            "trig-1",
+            user.email,
+            "s",
+            "t",
+            "<h/>",
+            "lifecycle_no_share_24h",
+        )
+        _queue_and_mark_sent(
+            db_session,
+            email_svc,
+            user.id,
+            "trig-1",
+            user.email,
+            "s",
+            "t",
+            "<h/>",
+            "lifecycle_no_share_24h",
+        )  # rejected — would leave the session unusable if rollback were missing
+
+        third = _queue_and_mark_sent(
+            db_session,
+            email_svc,
+            other_user.id,
+            "trig-1",
+            other_user.email,
+            "s",
+            "t",
+            "<h/>",
+            "lifecycle_no_share_24h",
+        )
+
+        assert third is True
+        assert db_session.query(EmailQueue).count() == 2
+
+
+class TestProcessT1DuplicatePrevention:
+    def test_rerunning_the_cycle_does_not_double_send_the_same_due_user(
+        self, db_session, monkeypatch
+    ):
+        """The task's own verify method: re-running the detection cycle over
+        a user who's still due (the observable effect of a crash-and-restart
+        landing between the old code's two commits) must send once, not
+        twice."""
+        monkeypatch.setenv("ARGUS_ENABLED", "false")
+        from app.core.config import get_settings
+
+        get_settings.cache_clear()
+
+        user = _make_user(db_session, created_at=datetime.now(timezone.utc) - timedelta(hours=48))
+        launch_cutoff = datetime.now(timezone.utc) - timedelta(days=365)
+
+        sent1 = process_t1_no_share_24h(db_session, launch_cutoff)
+        sent2 = process_t1_no_share_24h(db_session, launch_cutoff)
+
+        assert sent1 == 1
+        assert sent2 == 0
+        assert db_session.query(EmailQueue).count() == 1
+        assert db_session.query(EmailQueue).filter_by(to_email=user.email).count() == 1
+
+        get_settings.cache_clear()


### PR DESCRIPTION
## Summary
- `queue_email()` and marking a lifecycle trigger "sent" (`_mark_sent()`) were two independent commits. A crash between them left the email queued but the trigger unclaimed — the next detection cycle's `_already_handled()` found nothing and fired the same trigger again, queuing a duplicate nudge.
- `queue_email()` now accepts `commit=False` so a caller can fold it into its own transaction (only caller is `lifecycle_service.py`, so this is a safe, non-breaking addition).
- New `_queue_and_mark_sent()` adds both the `EmailQueue` row and the `LifecycleState` row to the session and commits **once** — a crash now lands on neither side of the old gap.
- The `lifecycle_state` unique constraint `(user_id, trigger_key)` backstops a genuine race (caught as `IntegrityError`, rolled back) — one conflicting user doesn't abort the rest of the batch loop.

## Test plan
- [x] 4 new tests in `test_lifecycle_service.py` (real SQLite session, no DB-layer mocking — `queue_email()` doesn't touch SMTP): first claim succeeds; a second claim for the same trigger is rejected *and does not leave an orphaned duplicate email row*; a rejected claim doesn't poison the session for the next user in the loop; and the task's own verify method — re-running the detection cycle over a still-due user sends once, not twice.
- [x] Verified regression: reverted the fix locally — the new test file fails to even import (`_queue_and_mark_sent` doesn't exist pre-fix), confirming it targets the new code path, not a vacuous check.
- [x] Updated `test_argus_integration.py`'s mock of the now-removed `_mark_sent()`.
- [x] Full suite: `pytest` → 523 passed, 1 skipped (pre-existing, unrelated).
- [x] `ruff check`/`ruff format` clean on all changed files.

TR-18, flagged in audit #96d804dd. Same duplicate-delivery class as TR-11 (#8a509876, still in review) but a different bug: TR-11 guards concurrent claim of an already-queued row; this guards the trigger-detection step that decides whether to queue one in the first place.