### PR TITLE
fix(listmonk): normalize email case and escape it in the lookup query

### DIFF
--- a/apps/control-plane/app/services/listmonk_service.py
+++ b/apps/control-plane/app/services/listmonk_service.py
@@ -23,6 +23,24 @@ from app.core.logging import get_logger
 
 logger = get_logger(__name__)
 
+
+def _sql_string_literal(value: str) -> str:
+    """Escape `value` for safe embedding in a single-quoted Postgres string literal.
+
+    Listmonk's GET /api/subscribers `query` param is a raw Postgres SQL
+    WHERE-clause fragment executed server-side against Listmonk's own DB —
+    not a parameterized filter. As of this writing there is no `email=`
+    param or dedicated get-by-email endpoint (confirmed against listmonk's
+    own API docs and an open, unresolved upstream issue asking for exactly
+    that: knadh/listmonk#2311), so a raw SQL fragment is the only way to
+    look up a subscriber by email through this API. A bare `'` is valid in
+    an RFC 5321 local-part (`o'brien@x.com` is a legal email) and breaks
+    out of the string literal, so every value interpolated into `query`
+    MUST go through this escape (U1, #baa47cc5).
+    """
+    return value.replace("'", "''")
+
+
 _USERS_QUERY = text(
     """
     SELECT DISTINCT ON (u.id)
@@ -111,6 +129,15 @@ class ListmonkService:
             logger.debug("Skipping %s — lifecycle_emails=false", email)
             return False
 
+        # Listmonk stores/matches emails lowercase internally. A mixed-case
+        # registration email (e.g. Jimenezisaac021@gmail.com) POSTs fine the
+        # first time, but every subsequent sync gets a 409 (already exists)
+        # whose exact-case lookup in _update_existing() never matches the
+        # lowercased row — attribs/list membership silently stop updating,
+        # forever (TR-34, #38a5bdfd). Normalize once, here, so the same
+        # value flows through the POST, the 409 lookup, and the PUT.
+        email = email.strip().lower()
+
         client = self._client_or_raise()
         settings = self._settings
 
@@ -151,7 +178,7 @@ class ListmonkService:
         # Lookup subscriber by email
         search = await client.get(
             "/api/subscribers",
-            params={"query": f"subscribers.email = '{email}'", "per_page": 1},
+            params={"query": f"subscribers.email = '{_sql_string_literal(email)}'", "per_page": 1},
         )
         search.raise_for_status()
         results = search.json().get("data", {}).get("results", [])

--- a/apps/control-plane/tests/test_listmonk_service.py
+++ b/apps/control-plane/tests/test_listmonk_service.py
@@ -87,9 +87,7 @@ class TestUpsertSubscriberCaseNormalization:
                 200,
                 {
                     "data": {
-                        "results": [
-                            {"id": 42, "lists": [], "attribs": {}, "status": "enabled"}
-                        ]
+                        "results": [{"id": 42, "lists": [], "attribs": {}, "status": "enabled"}]
                     }
                 },
             )
@@ -119,9 +117,7 @@ class TestUpdateExistingLookupEscaping:
     async def test_email_with_single_quote_is_escaped_in_lookup_query(self):
         client = AsyncMock()
         client.post = AsyncMock(return_value=_make_response(409))
-        client.get = AsyncMock(
-            return_value=_make_response(200, {"data": {"results": []}})
-        )
+        client.get = AsyncMock(return_value=_make_response(200, {"data": {"results": []}}))
         service = _make_service(client)
 
         await service.upsert_subscriber(

--- a/apps/control-plane/tests/test_listmonk_service.py
+++ b/apps/control-plane/tests/test_listmonk_service.py
@@ -1,0 +1,141 @@
+"""Tests for listmonk_service.py — TR-34 (case-sensitivity) + U1 (SQL injection).
+
+TR-34: Listmonk stores/matches subscriber emails lowercase internally. A
+mixed-case registration email POSTs fine the first time, but the 409-conflict
+lookup in _update_existing() compared against the ORIGINAL mixed-case email —
+which never matches Listmonk's lowercased row — so attribs/list membership
+silently stopped updating on every subsequent sync, forever.
+
+U1: the same lookup builds its `query` param via an f-string:
+`f"subscribers.email = '{email}'"`. Listmonk's GET /api/subscribers `query`
+param is a raw Postgres SQL WHERE-clause fragment executed against Listmonk's
+own DB. A bare `'` is valid in an RFC 5321 local-part (o'brien@x.com is a
+legal email) and breaks out of the string literal — a genuine SQL injection
+surface on Listmonk's backend.
+
+Only httpx (the real external boundary — network calls to Listmonk) is
+mocked; the escaping/normalization logic under test runs for real.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.services.listmonk_service import ListmonkService, _sql_string_literal
+
+
+def _make_response(status_code: int, json_data: dict | None = None) -> AsyncMock:
+    resp = AsyncMock()
+    resp.status_code = status_code
+    resp.json = lambda: json_data or {}
+    resp.raise_for_status = lambda: None
+    return resp
+
+
+def _make_service(client: AsyncMock) -> ListmonkService:
+    service = ListmonkService()
+    service._client = client
+    return service
+
+
+class TestSqlStringLiteralEscaping:
+    def test_no_special_characters_unchanged(self):
+        assert _sql_string_literal("plain@example.com") == "plain@example.com"
+
+    def test_single_quote_is_doubled(self):
+        # The actual regression: this is how you escape a value for safe
+        # embedding in a single-quoted Postgres string literal — a bare `'`
+        # would otherwise close the literal early.
+        assert _sql_string_literal("o'brien@x.com") == "o''brien@x.com"
+
+    def test_multiple_quotes_all_escaped(self):
+        assert _sql_string_literal("a'b'c") == "a''b''c"
+
+
+class TestUpsertSubscriberCaseNormalization:
+    @pytest.mark.asyncio
+    async def test_post_payload_uses_lowercased_email(self):
+        client = AsyncMock()
+        client.post = AsyncMock(return_value=_make_response(200))
+        service = _make_service(client)
+
+        await service.upsert_subscriber(
+            email="Jimenezisaac021@GMAIL.com",
+            name="Isaac",
+            casdoor=True,
+            registered_at=datetime.now(timezone.utc),
+            has_share=False,
+            lifecycle_emails_on=True,
+        )
+
+        posted_payload = client.post.call_args.kwargs["json"]
+        assert posted_payload["email"] == "jimenezisaac021@gmail.com"
+
+    @pytest.mark.asyncio
+    async def test_409_conflict_lookup_uses_lowercased_email_not_original_case(self):
+        """This is the actual regression: pre-fix, the lookup query embedded
+        the ORIGINAL mixed-case email, which never matches Listmonk's
+        lowercased row — the subscriber is "found via 409" but not via the
+        lookup, and the WARNING/no-op repeats on every future sync."""
+        client = AsyncMock()
+        client.post = AsyncMock(return_value=_make_response(409))
+        client.get = AsyncMock(
+            return_value=_make_response(
+                200,
+                {
+                    "data": {
+                        "results": [
+                            {"id": 42, "lists": [], "attribs": {}, "status": "enabled"}
+                        ]
+                    }
+                },
+            )
+        )
+        client.put = AsyncMock(return_value=_make_response(200))
+        service = _make_service(client)
+
+        result = await service.upsert_subscriber(
+            email="Jimenezisaac021@GMAIL.com",
+            name="Isaac",
+            casdoor=True,
+            registered_at=datetime.now(timezone.utc),
+            has_share=False,
+            lifecycle_emails_on=True,
+        )
+
+        assert result is True
+        lookup_query = client.get.call_args.kwargs["params"]["query"]
+        assert lookup_query == "subscribers.email = 'jimenezisaac021@gmail.com'"
+        # PUT also carries the normalized email through.
+        put_payload = client.put.call_args.kwargs["json"]
+        assert put_payload["email"] == "jimenezisaac021@gmail.com"
+
+
+class TestUpdateExistingLookupEscaping:
+    @pytest.mark.asyncio
+    async def test_email_with_single_quote_is_escaped_in_lookup_query(self):
+        client = AsyncMock()
+        client.post = AsyncMock(return_value=_make_response(409))
+        client.get = AsyncMock(
+            return_value=_make_response(200, {"data": {"results": []}})
+        )
+        service = _make_service(client)
+
+        await service.upsert_subscriber(
+            email="o'brien@x.com",
+            name="O'Brien",
+            casdoor=False,
+            registered_at=datetime.now(timezone.utc),
+            has_share=False,
+            lifecycle_emails_on=True,
+        )
+
+        lookup_query = client.get.call_args.kwargs["params"]["query"]
+        # Escaped: the literal stays syntactically closed. Pre-fix this was
+        # "subscribers.email = 'o'brien@x.com'" — an unescaped `'` breaking
+        # out of the string literal mid-fragment.
+        assert lookup_query == "subscribers.email = 'o''brien@x.com'"
+        assert "= 'o'brien" not in lookup_query


### PR DESCRIPTION
## Summary
- **TR-34**: Listmonk stores/matches subscriber emails lowercase internally. `upsert_subscriber()` POSTed the original mixed-case email; the first sync succeeded, but every subsequent one hit a 409 (already exists) whose lookup in `_update_existing()` compared against the still-mixed-case email — which never matches Listmonk's lowercased row — so attribs/list membership silently stopped updating, forever. Normalized email once, in `upsert_subscriber()`, so the same lowercased value flows through the POST, the 409 lookup, and the PUT.
- **U1**: the 409-conflict lookup built its `query` param via an f-string (`f"subscribers.email = '{email}'"`). Listmonk's `GET /api/subscribers` `query` param is a raw Postgres SQL WHERE-clause fragment executed against Listmonk's own DB, not a parameterized filter — confirmed against Listmonk's own API docs and an open, unresolved upstream issue ([knadh/listmonk#2311](https://github.com/knadh/listmonk/issues/2311)) asking for exactly a safer lookup path; none exists. A bare `'` is valid in an RFC 5321 local-part (`o'brien@x.com` is a legal email) and breaks out of the string literal — a genuine SQL injection surface. Added `_sql_string_literal()` (doubles embedded quotes, the standard Postgres string-literal escape) and used it for the one place we interpolate a value into this query.

Fixed together since parameterizing the query for U1 naturally covers the case fix's lookup path too — same line, same PR per the routing.

## Test plan
- [x] 6 new tests in `test_listmonk_service.py`: escaping helper unit tests; case normalization reaches the POST payload; the 409-lookup query uses the lowercased email (the actual TR-34 regression); the lookup query correctly escapes a `'` in the email (the actual U1 regression).
- [x] Verified regression: reverted locally — the test file fails to even import (`_sql_string_literal` doesn't exist pre-fix); restored.
- [x] Full suite: `pytest` → 529 passed, 1 skipped (pre-existing, unrelated).
- [x] `ruff check` clean.

TR-34 (#38a5bdfd) + U1 (#baa47cc5), both flagged in audit #96d804dd.