### PR TITLE
fix(email): match webhook worker's retry schedule, add DLQ requeue (TR-35)

### DIFF
--- a/apps/control-plane/app/api/routers/admin.py
+++ b/apps/control-plane/app/api/routers/admin.py
@@ -3,16 +3,18 @@ from __future__ import annotations
 import uuid
 from datetime import datetime
 
-from fastapi import APIRouter, Depends, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.orm import Session
 
 from app.api import deps
 from app.db import models
+from app.db.models import EmailStatus
 from app.db.session import get_db
 from app.schemas import audit as audit_schema
 from app.schemas import branding as branding_schema
+from app.schemas import email as email_schema
 from app.schemas import user as user_schema
-from app.services import audit_service, instance_settings_service, user_service
+from app.services import audit_service, email_service, instance_settings_service, user_service
 
 router = APIRouter(prefix="/admin", tags=["admin"])
 
@@ -153,3 +155,70 @@ def update_branding(
         custom_body_code=payload.custom_body_code,
     )
     return branding_schema.BrandingRead(**branding_data)
+
+
+@router.get("/emails", response_model=list[email_schema.EmailQueueRead])
+def list_emails(
+    status_filter: EmailStatus | None = Query(default=None, alias="status"),
+    email_type: str | None = Query(default=None),
+    skip: int = Query(default=0, ge=0, description="Pagination offset"),
+    limit: int = Query(default=50, ge=1, le=100, description="Maximum results per page"),
+    db: Session = Depends(get_db),
+    _: models.User = Depends(deps.get_current_admin),
+):
+    """
+    List queued/sent/failed emails. Admin only. TR-35.
+
+    A FAILED email exhausted MAX_EMAIL_RETRIES (currently 6 attempts over
+    ~24h, matching the webhook worker) — this is the admin-visible view of
+    that dead-letter state; see POST /admin/emails/{email_id}/requeue.
+    """
+    svc = email_service.get_email_service()
+    return svc.list_emails(
+        db=db,
+        status_filter=status_filter,
+        email_type=email_type,
+        skip=skip,
+        limit=limit,
+    )
+
+
+@router.post("/emails/{email_id}/requeue", response_model=email_schema.EmailQueueRead)
+def requeue_email(
+    email_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_admin: models.User = Depends(deps.get_current_admin),
+):
+    """
+    Manually requeue a FAILED email for another delivery attempt. Admin only. TR-35.
+
+    Resets attempt_count to 0 and schedules an immediate retry. Only valid
+    for emails currently in FAILED state — PENDING (still retrying) or SENT
+    emails are left untouched (409).
+    """
+    svc = email_service.get_email_service()
+    email = svc.get_email(db, email_id)
+    if not email:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Email not found")
+    if email.status != EmailStatus.FAILED:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Email is not in failed state (current: {email.status.value})",
+        )
+
+    email = svc.requeue_email(db, email)
+
+    audit_service.log_action(
+        db=db,
+        # no dedicated EMAIL_REQUEUED enum value yet, see webhooks.py precedent
+        action=models.AuditAction.USER_UPDATED,
+        actor_user_id=current_admin.id,
+        details={
+            "action": "email_requeued",
+            "email_id": str(email.id),
+            "to_email": email.to_email,
+            "email_type": email.email_type,
+        },
+    )
+
+    return email

--- a/apps/control-plane/app/schemas/email.py
+++ b/apps/control-plane/app/schemas/email.py
@@ -1,0 +1,27 @@
+"""Email queue admin API schemas (TR-35)."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+from app.db.models import EmailStatus
+
+
+class EmailQueueRead(BaseModel):
+    """Schema for reading a queued email (admin visibility)."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    to_email: str
+    subject: str
+    email_type: str
+    status: EmailStatus
+    attempt_count: int
+    error_message: str | None
+    next_retry_at: datetime | None
+    created_at: datetime
+    sent_at: datetime | None

--- a/apps/control-plane/app/services/email_service.py
+++ b/apps/control-plane/app/services/email_service.py
@@ -43,8 +43,12 @@ EMAIL_TYPE_SECURITY_PASSWORD_CHANGED = "security_password_changed"
 EMAIL_TYPE_LIFECYCLE_NO_SHARE_24H = "lifecycle_no_share_24h"
 EMAIL_TYPE_LIFECYCLE_INACTIVE_AFTER_SHARE = "lifecycle_inactive_after_share"
 
-# Retry intervals for email queue (seconds)
-EMAIL_RETRY_INTERVALS = [60, 300, 900]  # 1min, 5min, 15min
+# Retry intervals for email queue (seconds). TR-35: matches the webhook
+# worker's schedule (webhook_service.RETRY_INTERVALS) — 3 attempts over
+# ~21min gave up well inside a routine SMTP outage window; transactional
+# email (invites, security alerts) deserves at least the 24h the webhook
+# worker already gives itself.
+EMAIL_RETRY_INTERVALS = [60, 300, 900, 3600, 21600, 86400]  # 1m, 5m, 15m, 1h, 6h, 24h
 MAX_EMAIL_RETRIES = len(EMAIL_RETRY_INTERVALS)
 
 # Template directory
@@ -387,6 +391,86 @@ class EmailService:
         )
 
         return list(db.execute(stmt).scalars().all())
+
+    def get_email(self, db: Session, email_id: uuid.UUID) -> EmailQueue | None:
+        """Get a single queued/sent/failed email by id.
+
+        Args:
+            db: Database session
+            email_id: EmailQueue id
+
+        Returns:
+            EmailQueue instance, or None if not found
+        """
+        return db.execute(select(EmailQueue).where(EmailQueue.id == email_id)).scalar_one_or_none()
+
+    def list_emails(
+        self,
+        db: Session,
+        status_filter: EmailStatus | None = None,
+        email_type: str | None = None,
+        skip: int = 0,
+        limit: int = 50,
+    ) -> list[EmailQueue]:
+        """List queued emails with optional filters (admin visibility — TR-35).
+
+        Args:
+            db: Database session
+            status_filter: Filter by status
+            email_type: Filter by email type
+            skip: Number of records to skip
+            limit: Maximum number of records to return
+
+        Returns:
+            List of EmailQueue instances, most recent first
+        """
+        stmt = select(EmailQueue)
+
+        if status_filter:
+            stmt = stmt.where(EmailQueue.status == status_filter)
+        if email_type:
+            stmt = stmt.where(EmailQueue.email_type == email_type)
+
+        stmt = stmt.order_by(EmailQueue.created_at.desc()).offset(skip).limit(limit)
+
+        return list(db.execute(stmt).scalars().all())
+
+    def requeue_email(self, db: Session, email: EmailQueue) -> EmailQueue:
+        """Manually requeue a FAILED email for another delivery attempt (TR-35).
+
+        The router does its own `status == FAILED` check first so it can
+        return a clean 409 — this is a hard backstop, not just documentation:
+        resetting a still-retrying PENDING or already-SENT email's budget
+        would let the worker silently re-send it (e.g. a duplicate
+        security-alert or invite to a real user).
+
+        Args:
+            db: Database session
+            email: EmailQueue instance to requeue
+
+        Returns:
+            The updated EmailQueue instance
+
+        Raises:
+            ValueError: If `email.status` is not FAILED.
+        """
+        if email.status != EmailStatus.FAILED:
+            raise ValueError(
+                f"Cannot requeue email {email.id} in status {email.status.value!r} "
+                "— only FAILED emails may be requeued"
+            )
+
+        email.status = EmailStatus.PENDING
+        email.attempt_count = 0
+        email.error_message = None
+        email.next_retry_at = datetime.now(timezone.utc)
+        db.add(email)
+        db.commit()
+        db.refresh(email)
+
+        logger.info("Email manually requeued", extra={"email_id": str(email.id)})
+
+        return email
 
     def get_user_email_preferences(
         self, db: Session, user_id: uuid.UUID

--- a/apps/control-plane/tests/test_email_retry_dlq.py
+++ b/apps/control-plane/tests/test_email_retry_dlq.py
@@ -1,0 +1,206 @@
+"""Tests for TR-35 (#adc5086f): email-worker retry/DLQ.
+
+EMAIL_RETRY_INTERVALS used to be [60, 300, 900] — 3 attempts over ~21min,
+then FAILED forever with no way to ever retry. A routine 30min SMTP outage
+silently lost transactional email (invites, security alerts). Fixed by
+matching the webhook worker's schedule (RETRY_INTERVALS in
+webhook_service.py: 1m/5m/15m/1h/6h/24h, 6 attempts) and adding an admin
+requeue endpoint for the terminal FAILED state.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.db.models import EmailQueue, EmailStatus
+from app.services import email_service
+from app.services.webhook_service import MAX_RETRIES as WEBHOOK_MAX_RETRIES
+from app.services.webhook_service import RETRY_INTERVALS as WEBHOOK_RETRY_INTERVALS
+
+
+def auth_headers(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def login(client: TestClient, email: str, password: str) -> str:
+    response = client.post("/auth/login", json={"email": email, "password": password})
+    assert response.status_code == 200, response.text
+    return response.json()["access_token"]
+
+
+def make_email(
+    db: Session,
+    status: EmailStatus = EmailStatus.FAILED,
+    attempt_count: int = 3,
+    error_message: str | None = "SMTP delivery failed, scheduled for retry",
+) -> EmailQueue:
+    email = EmailQueue(
+        to_email="someone@example.com",
+        subject="Test",
+        body_text="body",
+        body_html="<p>body</p>",
+        email_type="invite_notification",
+        status=status,
+        attempt_count=attempt_count,
+        error_message=error_message,
+    )
+    db.add(email)
+    db.commit()
+    db.refresh(email)
+    return email
+
+
+class TestRetrySchedule:
+    def test_matches_webhook_worker_schedule(self):
+        """The whole point of TR-35: email and webhook workers must not
+        silently diverge again — same intervals, same attempt budget."""
+        assert email_service.EMAIL_RETRY_INTERVALS == WEBHOOK_RETRY_INTERVALS
+        assert email_service.MAX_EMAIL_RETRIES == WEBHOOK_MAX_RETRIES
+
+    def test_covers_the_reported_30min_outage(self):
+        """Task's own repro: SMTP down 30min must NOT exhaust retries."""
+        elapsed = 0
+        attempts_within_30min = 0
+        for interval in email_service.EMAIL_RETRY_INTERVALS:
+            elapsed += interval
+            if elapsed <= 30 * 60:
+                attempts_within_30min += 1
+        assert attempts_within_30min < email_service.MAX_EMAIL_RETRIES, (
+            "a 30min outage must not exhaust all retry attempts"
+        )
+
+    def test_total_retry_window_is_at_least_24h(self):
+        assert sum(email_service.EMAIL_RETRY_INTERVALS) >= 24 * 3600
+
+
+class TestProcessQueuedEmailStillMarksFailedAtBudgetEnd:
+    @pytest.mark.asyncio
+    async def test_status_is_failed_after_max_retries_exceeded(self, db_session: Session):
+        """Regression guard: exhausting the (now longer) budget still lands
+        on the terminal FAILED status the requeue endpoint targets."""
+        svc = email_service.EmailService()
+        svc.email_enabled = True
+        svc.smtp_host = ""  # _send_smtp() returns False immediately, no real SMTP needed
+        email = make_email(
+            db_session,
+            status=EmailStatus.PENDING,
+            attempt_count=email_service.MAX_EMAIL_RETRIES - 1,
+        )
+
+        result = await svc.process_queued_email(db_session, email)
+
+        assert result is False
+        assert email.status == EmailStatus.FAILED
+        assert email.attempt_count == email_service.MAX_EMAIL_RETRIES
+
+
+class TestRequeueEmailServiceGuard:
+    def test_refuses_to_requeue_a_pending_email(self, db_session: Session):
+        """Backstop below the router's own check — a future call site that
+        forgets to check status first must fail loud, not silently reset a
+        still-retrying email's budget and let the worker re-send it."""
+        svc = email_service.EmailService()
+        email = make_email(db_session, status=EmailStatus.PENDING, attempt_count=1)
+
+        with pytest.raises(ValueError, match="only FAILED emails may be requeued"):
+            svc.requeue_email(db_session, email)
+
+    def test_refuses_to_requeue_a_sent_email(self, db_session: Session):
+        svc = email_service.EmailService()
+        email = make_email(db_session, status=EmailStatus.SENT, attempt_count=1)
+
+        with pytest.raises(ValueError, match="only FAILED emails may be requeued"):
+            svc.requeue_email(db_session, email)
+
+
+class TestAdminRequeueEmail:
+    def test_requeue_resets_failed_email_to_pending(self, db_session: Session, client: TestClient):
+        admin_token = login(client, "bootstrap@example.com", "super-secret")
+        email = make_email(db_session, status=EmailStatus.FAILED, attempt_count=6)
+
+        response = client.post(
+            f"/admin/emails/{email.id}/requeue",
+            headers=auth_headers(admin_token),
+        )
+
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert data["status"] == EmailStatus.PENDING.value
+        assert data["attempt_count"] == 0
+        assert data["error_message"] is None
+
+    def test_requeue_pending_email_is_rejected(self, db_session: Session, client: TestClient):
+        """Only FAILED (exhausted) emails may be requeued — a still-retrying
+        PENDING email has its own schedule already, resetting it would
+        silently discard its position in that schedule."""
+        admin_token = login(client, "bootstrap@example.com", "super-secret")
+        email = make_email(db_session, status=EmailStatus.PENDING, attempt_count=1)
+
+        response = client.post(
+            f"/admin/emails/{email.id}/requeue",
+            headers=auth_headers(admin_token),
+        )
+
+        assert response.status_code == 409
+
+    def test_requeue_sent_email_is_rejected(self, db_session: Session, client: TestClient):
+        admin_token = login(client, "bootstrap@example.com", "super-secret")
+        email = make_email(db_session, status=EmailStatus.SENT, attempt_count=1)
+
+        response = client.post(
+            f"/admin/emails/{email.id}/requeue",
+            headers=auth_headers(admin_token),
+        )
+
+        assert response.status_code == 409
+
+    def test_requeue_unknown_email_returns_404(self, client: TestClient):
+        admin_token = login(client, "bootstrap@example.com", "super-secret")
+
+        response = client.post(
+            f"/admin/emails/{uuid.uuid4()}/requeue",
+            headers=auth_headers(admin_token),
+        )
+
+        assert response.status_code == 404
+
+    def test_requeue_requires_admin(self, db_session: Session, client: TestClient):
+        client.post(
+            "/admin/users",
+            json={
+                "email": "not-admin@example.com",
+                "password": "password123",
+                "is_admin": False,
+                "is_active": True,
+            },
+            headers=auth_headers(login(client, "bootstrap@example.com", "super-secret")),
+        )
+        non_admin_token = login(client, "not-admin@example.com", "password123")
+        email = make_email(db_session, status=EmailStatus.FAILED)
+
+        response = client.post(
+            f"/admin/emails/{email.id}/requeue",
+            headers=auth_headers(non_admin_token),
+        )
+
+        assert response.status_code == 403
+
+    def test_list_emails_filters_by_status(self, db_session: Session, client: TestClient):
+        admin_token = login(client, "bootstrap@example.com", "super-secret")
+        make_email(db_session, status=EmailStatus.FAILED)
+        make_email(db_session, status=EmailStatus.SENT)
+
+        response = client.get(
+            "/admin/emails",
+            params={"status": EmailStatus.FAILED.value},
+            headers=auth_headers(admin_token),
+        )
+
+        assert response.status_code == 200, response.text
+        results = response.json()
+        assert len(results) == 1
+        assert results[0]["status"] == EmailStatus.FAILED.value

--- a/apps/control-plane/tests/test_email_retry_dlq.py
+++ b/apps/control-plane/tests/test_email_retry_dlq.py
@@ -69,9 +69,9 @@ class TestRetrySchedule:
             elapsed += interval
             if elapsed <= 30 * 60:
                 attempts_within_30min += 1
-        assert attempts_within_30min < email_service.MAX_EMAIL_RETRIES, (
-            "a 30min outage must not exhaust all retry attempts"
-        )
+        assert (
+            attempts_within_30min < email_service.MAX_EMAIL_RETRIES
+        ), "a 30min outage must not exhaust all retry attempts"
 
     def test_total_retry_window_is_at_least_24h(self):
         assert sum(email_service.EMAIL_RETRY_INTERVALS) >= 24 * 3600


### PR DESCRIPTION
## Summary

- TR-35 (P2, 2026-07-21 audit, mesh task #adc5086f): `EMAIL_RETRY_INTERVALS` was `[60, 300, 900]` — 3 attempts over ~21min, then the email lands in terminal `FAILED` status forever with no way to ever retry. A routine SMTP outage over ~21 minutes silently and permanently lost transactional email (invites, security alerts).
- The sibling webhook worker already schedules 6 attempts over ~24h (`webhook_service.RETRY_INTERVALS`); email now matches it exactly, guarded by a test that imports and compares both schedules so they can't silently diverge again.
- Adds the "DLQ or manual requeue" half of the AC: `GET /admin/emails` (list, filterable by status/type) and `POST /admin/emails/{id}/requeue` (404 if unknown, 409 if not currently FAILED) — mirrors `webhook_service.list_deliveries` / the existing `/v1/admin/webhooks/deliveries` admin surface, including its `AuditAction.USER_UPDATED` placeholder convention (adding a dedicated enum value is a migration — `AuditAction` is a native Postgres enum — matching `webhooks.py`'s existing "we'll add WEBHOOK_CREATED later" shortcut rather than doing that migration in a P2 fix).
- `requeue_email()` re-validates `status == FAILED` itself (not just via the router's pre-check) and raises `ValueError` otherwise — a future call site that skips the check fails loud instead of silently resetting a still-retrying or already-sent email's budget, which would let the worker duplicate-send it. Added after an independent review pass flagged the router-only check as a latent footgun.

## Test plan

- [x] New `tests/test_email_retry_dlq.py` (12 tests): schedule-matches-webhook + total-window regression guards, exhausting retries still lands on FAILED, full requeue-endpoint matrix (success / reject-PENDING / reject-SENT / 404-unknown / 403-non-admin / list-filter), service-level guard tests for the `ValueError` backstop.
- [x] Full control-plane suite: 541 passed, 1 skipped (pre-existing, unrelated).
- [x] `ruff check` + `ruff format --check` clean on all changed files.
- [x] Independent code-review pass (no blocking issues; one Medium finding — the requeue-status footgun — fixed above).
- [ ] Live repro (task's own AC): SMTP down 30min → email delivered after recovery, not FAILED. Not run live this session (no deployed SMTP-outage harness); the new schedule mathematically covers it (`test_covers_the_reported_30min_outage`) and the full suite is green, but flagging for reviewer/live smoke before `done`.