### PR TITLE
fix(auth): password-login of an OAuth-only user returns 401, not 500 (TR-20)

### DIFF
--- a/apps/control-plane/app/core/security.py
+++ b/apps/control-plane/app/core/security.py
@@ -23,7 +23,34 @@ def utcnow() -> datetime:
 
 
 def verify_password(plain_password: str, hashed_password: str) -> bool:
-    return pwd_context.verify(plain_password, hashed_password)
+    """Verify a plaintext password against a stored hash.
+
+    OAuth-only accounts are created with password_hash="" (oauth_service.py)
+    since they have no password — passlib can't identify an empty string as a
+    hash and raises UnknownHashError rather than returning False (TR-20; that
+    used to surface as an unhandled 500 from /auth/login instead of a 401).
+
+    UnknownHashError is a ValueError subclass; passlib's bcrypt backend also
+    raises a *bare* ValueError (not UnknownHashError) for a hash that has a
+    recognizable scheme prefix but is otherwise malformed — e.g. a truncated
+    salt. Catch ValueError, not just UnknownHashError, to fail closed on both
+    shapes rather than just the empty-string one. hashed_password always
+    comes from the DB (never attacker-controlled), so failing closed here
+    only ever denies a login/share-password check, never allows one.
+    """
+    try:
+        return pwd_context.verify(plain_password, hashed_password)
+    except ValueError as e:
+        # The empty-string OAuth-only case is routine and expected; anything
+        # else reaching here (a real but malformed stored hash) is more
+        # likely a genuine data issue, so log it — the alternative is an
+        # ordinary-looking 401 with zero trace of the underlying corruption.
+        logger.warning(
+            "Password verification failed on an unverifiable hash (%s: %s)",
+            type(e).__name__,
+            e,
+        )
+        return False
 
 
 def get_password_hash(password: str) -> str:

--- a/apps/control-plane/tests/test_security.py
+++ b/apps/control-plane/tests/test_security.py
@@ -2,8 +2,13 @@
 
 from __future__ import annotations
 
+import uuid
+
 import pytest
 from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.db import models
 
 
 def auth_headers(token: str) -> dict[str, str]:
@@ -14,6 +19,63 @@ def login(client: TestClient, email: str, password: str) -> str:
     response = client.post("/auth/login", json={"email": email, "password": password})
     assert response.status_code == 200, response.text
     return response.json()["access_token"]
+
+
+# ── TR-20: password-login of an OAuth-only user must 401, not 500 ────────────
+#
+# OAuth-only accounts are created with password_hash="" (oauth_service.py:457
+# — "No password for OAuth-only accounts"). passlib can't identify an empty
+# string as a hash and raises UnknownHashError rather than returning False;
+# unhandled, that surfaced as a 500 from POST /auth/login instead of the
+# expected 401 (prod repro 2026-07-19T08:12:15).
+
+
+class TestTR20OAuthUserPasswordLogin:
+    def test_verify_password_returns_false_for_empty_hash(self):
+        """Direct unit test of the actual failure point (core/security.py)."""
+        from app.core import security
+
+        assert security.verify_password("anything", "") is False
+
+    def test_verify_password_returns_false_for_garbage_hash(self):
+        """Not just the empty-string case — any hash passlib can't identify
+        must fail closed, not raise."""
+        from app.core import security
+
+        assert security.verify_password("anything", "not-a-real-hash") is False
+
+    def test_verify_password_returns_false_for_malformed_bcrypt_hash(self):
+        """A scheme-prefixed but corrupted hash (e.g. a truncated bcrypt salt)
+        raises a *bare* ValueError from passlib's backend, not
+        UnknownHashError — a narrower `except UnknownHashError` would still
+        crash on this shape. Found by independent review, not the original
+        repro."""
+        from app.core import security
+
+        assert security.verify_password("anything", "$2b$04$shorttoolong") is False
+
+    def test_login_with_password_for_oauth_only_user_returns_401(
+        self, db_session: Session, client: TestClient
+    ):
+        """End-to-end repro: an OAuth-only user (password_hash="", exactly
+        as oauth_service.create/link produces it) attempts a password login —
+        must get 401, never an unhandled 500."""
+        user = models.User(
+            id=uuid.uuid4(),
+            email="oauth-only@example.com",
+            password_hash="",
+            is_admin=False,
+            is_active=True,
+        )
+        db_session.add(user)
+        db_session.commit()
+
+        response = client.post(
+            "/auth/login",
+            json={"email": "oauth-only@example.com", "password": "whatever-they-typed"},
+        )
+
+        assert response.status_code == 401, response.text
 
 
 def test_public_key_endpoint(client: TestClient) -> None:


### PR DESCRIPTION
## Summary

- TR-20 (P2, 2026-07-21 audit, mesh task #7c8320a7): OAuth-only accounts are created with `password_hash=""` (`oauth_service.py` — "No password for OAuth-only accounts"). passlib can't identify an empty string as a hash and raises `UnknownHashError` rather than returning `False`, which surfaced as an unhandled 500 from `POST /auth/login` instead of the expected 401 (prod repro 2026-07-19T08:12:15).
- `verify_password()` now catches `ValueError`, not just `UnknownHashError` — passlib's bcrypt backend also raises a bare `ValueError` (not `UnknownHashError`) for a hash with a recognizable scheme prefix that's otherwise malformed (e.g. a truncated salt), which a narrower catch would still crash on. Found by independent review, not the original repro.
- Logs a warning on the fallback path: the empty-string OAuth case is routine, but anything else reaching it is more likely real data corruption worth a trace, not a silent 401.
- `hashed_password` is always DB-sourced at all 3 call sites (`auth_service.authenticate_user`, plus two already-null-guarded share-password checks in `web.py`/`share_service.py`) — never attacker-controlled — so failing closed here only ever denies, never grants, an auth check.

## Test plan

- [x] 4 new tests in `tests/test_security.py` (`TestTR20OAuthUserPasswordLogin`): empty hash, garbage hash, malformed-but-scheme-prefixed bcrypt hash, and an end-to-end `POST /auth/login` repro against a real OAuth-only user row.
- [x] Verified all 4 FAIL against pre-fix code (`git stash` on just `security.py`) and PASS after — confirmed discriminating.
- [x] Full control-plane suite: 533 passed, 1 skipped (pre-existing, unrelated).
- [x] `ruff check` / `ruff format --check` clean against the CI-pinned ruff version (0.6.9).
- [x] Independent code-review pass — caught the `UnknownHashError`-too-narrow gap (fixed above); confirmed no auth-bypass surface (hash value is never attacker-controlled).
- [ ] Live repro (task's own AC): login with a password against a real OAuth-only user on the deployed instance → 401, not 500. Not run live this session; flagging for reviewer/live smoke before `done`.