### PR TITLE
fix(notifications): suppress duplicate new-session emails (TR-36)

### DIFF
--- a/apps/control-plane/app/core/config.py
+++ b/apps/control-plane/app/core/config.py
@@ -41,6 +41,14 @@ class Settings(BaseSettings):
     # value directly shrinks the write-after-removal window.
     relay_token_ttl_minutes: int = Field(default=5)
 
+    # TR-36: session.created fires (and notify_session_created queues a
+    # "New login to your account" email) on every login, including a
+    # reconnect-loop client hammering /auth/login — observed 10 emails to one
+    # user in 2 minutes. This bounds how often that email fires per
+    # (user, device) pair; the underlying UserSession row is still created
+    # every time, only the notification is suppressed.
+    security_new_session_email_suppression_hours: int = Field(default=24)
+
     # CORS settings
     cors_allowed_origins: str = Field(
         default="https://cp.tr.entire.vc",

--- a/apps/control-plane/app/services/notification_service.py
+++ b/apps/control-plane/app/services/notification_service.py
@@ -8,13 +8,15 @@ are notified appropriately.
 from __future__ import annotations
 
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING
 
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from app.core.config import get_settings
 from app.core.logging import get_logger
-from app.db.models import Share, ShareInvite, ShareMember, User
+from app.db.models import Share, ShareInvite, ShareMember, User, UserSession
 from app.services import webhook_service
 from app.services.email_service import EmailService, get_email_service
 
@@ -591,6 +593,64 @@ class NotificationService:
 
     # Auth events
 
+    def _should_send_new_session_email(
+        self,
+        db: Session,
+        user_id: uuid.UUID,
+        device_name: str | None,
+        ip_address: str | None,
+        user_agent: str | None,
+    ) -> bool:
+        """TR-36: suppress the "New login" email if an identical-looking
+        session already got one within the suppression window.
+
+        Keys on the FULL (device_name, ip_address, user_agent) tuple, not
+        device_name alone — device_name is frequently uninformative: the
+        OAuth login path (oauth.py) always passes the fixed literal
+        f"OAuth ({provider})" for every session regardless of the real
+        device, and the password path only sets it from an optional
+        X-Device-Name header most clients don't send (None otherwise). Either
+        one alone would collapse a user's genuinely different devices into
+        one suppression bucket — a real second device logging in via the
+        same OAuth provider within the window would go silently unnotified,
+        which is the opposite of what a security alert is for. ip_address +
+        user_agent narrow the match back down to "actually looks like the
+        same client", which is what a reconnect loop actually reproduces.
+
+        The UserSession row for the CURRENT login is already committed by
+        the time this runs (auth_service.login()/the OAuth callback create
+        it, then db.commit(), before notify_session_created is called) — so
+        "any matching session in the window besides the newest one" is the
+        signal, not "any session at all" (which would always be true for
+        the very login triggering this check).
+
+        Known residual gap (accepted, not fixed here — a plain
+        select-then-decide has no locking): two logins from an identical
+        client landing in the same instant on different worker processes
+        could both pass this check and both send. Failure direction is
+        "occasional duplicate email", not "a genuinely new device stays
+        silent" — the correct side to fail on for a security notification.
+        """
+        settings = get_settings()
+        cutoff = datetime.now(timezone.utc) - timedelta(
+            hours=settings.security_new_session_email_suppression_hours
+        )
+        stmt = (
+            select(UserSession.id)
+            .where(
+                UserSession.user_id == user_id,
+                UserSession.device_name == device_name,
+                UserSession.ip_address == ip_address,
+                UserSession.user_agent == user_agent,
+                UserSession.created_at >= cutoff,
+            )
+            .order_by(UserSession.created_at.desc())
+            .limit(2)
+        )
+        recent_session_ids = db.execute(stmt).scalars().all()
+        # 0 or 1 (just the current session) => nothing sent yet in this window.
+        return len(recent_session_ids) <= 1
+
     async def notify_session_created(
         self,
         db: Session,
@@ -625,16 +685,25 @@ class NotificationService:
 
         self._queue_webhooks(db, event_type, payload, user.id)
 
-        # Send security email
+        # Send security email — suppressed if an identical-looking session
+        # already got one within the suppression window (TR-36).
         if user.email:
-            await self.email_service.send_security_new_session(
-                db,
-                user.email,
-                user.id,
-                device_name,
-                ip_address,
-                user_agent,
-            )
+            if self._should_send_new_session_email(
+                db, user.id, device_name, ip_address, user_agent
+            ):
+                await self.email_service.send_security_new_session(
+                    db,
+                    user.email,
+                    user.id,
+                    device_name,
+                    ip_address,
+                    user_agent,
+                )
+            else:
+                logger.info(
+                    "Suppressed duplicate new-session email",
+                    extra={"user_id": str(user.id), "device_name": device_name},
+                )
 
         logger.info(
             "Session created notification sent",

--- a/apps/control-plane/tests/test_notification_service.py
+++ b/apps/control-plane/tests/test_notification_service.py
@@ -1,0 +1,168 @@
+"""Tests for TR-36 (#ea334842): security_new_session email spam.
+
+notify_session_created() used to queue a "New login to your account" email
+on every session, unconditionally — a reconnect-loop client hitting
+/auth/login repeatedly sent 10 emails to one user in 2 minutes (observed
+prod repro, 2026-07-07 13:10-13:12). The underlying UserSession row is
+still created every time (unaffected by this fix); only the notification
+email is suppressed within a per-(user, device) window.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.core import security
+from app.db.models import EmailQueue, User
+from app.services import session_service
+from app.services.email_service import EMAIL_TYPE_SECURITY_NEW_SESSION
+from app.services.notification_service import NotificationService
+
+
+def make_user(db: Session, email: str = "spam-target@example.com") -> User:
+    user = User(
+        id=uuid.uuid4(),
+        email=email,
+        password_hash=security.get_password_hash("test123456"),
+        is_admin=False,
+        is_active=True,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def count_session_emails(db: Session, to_email: str) -> int:
+    stmt = select(EmailQueue).where(
+        EmailQueue.to_email == to_email,
+        EmailQueue.email_type == EMAIL_TYPE_SECURITY_NEW_SESSION,
+    )
+    return len(db.execute(stmt).scalars().all())
+
+
+@pytest.mark.asyncio
+class TestSecuritySessionEmailSuppression:
+    async def test_second_session_same_device_is_suppressed(self, db_session: Session):
+        user = make_user(db_session)
+        service = NotificationService()
+
+        session_service.create_session(db_session, user.id, device_name="MacBook Pro")
+        await service.notify_session_created(db_session, user, device_name="MacBook Pro")
+
+        session_service.create_session(db_session, user.id, device_name="MacBook Pro")
+        await service.notify_session_created(db_session, user, device_name="MacBook Pro")
+
+        assert count_session_emails(db_session, user.email) == 1
+
+    async def test_10_sessions_in_a_row_send_at_most_1_email(self, db_session: Session):
+        """The task's own repro, almost literally: a reconnect-loop hammering
+        /auth/login from the same device must not spam the inbox."""
+        user = make_user(db_session)
+        service = NotificationService()
+
+        for _ in range(10):
+            session_service.create_session(db_session, user.id, device_name="Loop Device")
+            await service.notify_session_created(db_session, user, device_name="Loop Device")
+
+        assert count_session_emails(db_session, user.email) == 1
+
+    async def test_different_device_still_gets_its_own_email(self, db_session: Session):
+        """Suppression is per-device, not per-user — a genuinely new device
+        must still notify even if another device notified recently."""
+        user = make_user(db_session)
+        service = NotificationService()
+
+        session_service.create_session(db_session, user.id, device_name="MacBook Pro")
+        await service.notify_session_created(db_session, user, device_name="MacBook Pro")
+
+        session_service.create_session(db_session, user.id, device_name="iPhone")
+        await service.notify_session_created(db_session, user, device_name="iPhone")
+
+        assert count_session_emails(db_session, user.email) == 2
+
+    async def test_oauth_fixed_device_name_does_not_collapse_different_devices(
+        self, db_session: Session
+    ):
+        """OAuth logins (oauth.py) always pass the fixed literal
+        f"OAuth ({provider})" as device_name for EVERY session regardless of
+        the real device — device_name alone would wrongly suppress a
+        genuinely different device's login. ip_address/user_agent must
+        distinguish them."""
+        user = make_user(db_session)
+        service = NotificationService()
+
+        session_service.create_session(
+            db_session,
+            user.id,
+            device_name="OAuth (github)",
+            ip_address="203.0.113.10",
+            user_agent="Mozilla/5.0 (Macintosh)",
+        )
+        await service.notify_session_created(
+            db_session,
+            user,
+            device_name="OAuth (github)",
+            ip_address="203.0.113.10",
+            user_agent="Mozilla/5.0 (Macintosh)",
+        )
+
+        # Different real machine, same OAuth provider => same device_name
+        # string, but a different IP/user-agent.
+        session_service.create_session(
+            db_session,
+            user.id,
+            device_name="OAuth (github)",
+            ip_address="198.51.100.20",
+            user_agent="Mozilla/5.0 (iPhone)",
+        )
+        await service.notify_session_created(
+            db_session,
+            user,
+            device_name="OAuth (github)",
+            ip_address="198.51.100.20",
+            user_agent="Mozilla/5.0 (iPhone)",
+        )
+
+        assert count_session_emails(db_session, user.email) == 2
+
+    async def test_none_device_name_suppresses_against_itself_not_crash(self, db_session: Session):
+        """device_name is optional (Authorization header may not send one) —
+        the suppression query must handle NULL without raising, and treat
+        repeated no-device logins as the same 'device' bucket."""
+        user = make_user(db_session)
+        service = NotificationService()
+
+        session_service.create_session(db_session, user.id, device_name=None)
+        await service.notify_session_created(db_session, user, device_name=None)
+
+        session_service.create_session(db_session, user.id, device_name=None)
+        await service.notify_session_created(db_session, user, device_name=None)
+
+        assert count_session_emails(db_session, user.email) == 1
+
+    async def test_suppression_window_expiring_allows_a_new_email(
+        self, db_session: Session, monkeypatch
+    ):
+        from app.core.config import get_settings
+
+        monkeypatch.setenv("SECURITY_NEW_SESSION_EMAIL_SUPPRESSION_HOURS", "0")
+        get_settings.cache_clear()
+        try:
+            user = make_user(db_session)
+            service = NotificationService()
+
+            session_service.create_session(db_session, user.id, device_name="MacBook Pro")
+            await service.notify_session_created(db_session, user, device_name="MacBook Pro")
+
+            session_service.create_session(db_session, user.id, device_name="MacBook Pro")
+            await service.notify_session_created(db_session, user, device_name="MacBook Pro")
+
+            assert count_session_emails(db_session, user.email) == 2
+        finally:
+            monkeypatch.delenv("SECURITY_NEW_SESSION_EMAIL_SUPPRESSION_HOURS", raising=False)
+            get_settings.cache_clear()


### PR DESCRIPTION
## Summary

- TR-36 (P2, 2026-07-21 audit, mesh task #ea334842): `notify_session_created()` queued a "New login to your account" security email on every login unconditionally. A reconnect-loop client hammering `/auth/login` sent 10 emails to one user in ~2 minutes in prod (2026-07-07 13:10-13:12). Currently masked by the separately-dead email pipeline (TR-04) — Daedalus's routing note flagged this must land before/with that fix, otherwise re-enabling email will blast users.
- New `_should_send_new_session_email()` suppresses the email if an identical-looking session already triggered one within a configurable window (`security_new_session_email_suppression_hours`, default 24h). The underlying `UserSession` row is still created every time — only the notification is gated. The webhook (`session.created`) is intentionally left unsuppressed: a legitimate integration may want every session event, unlike a user's inbox.
- Keys on the full `(device_name, ip_address, user_agent)` tuple, not `device_name` alone — `device_name` alone would have been wrong: the OAuth login path always passes a fixed `f"OAuth ({provider})"` literal for every session regardless of the real device, and the password path only sets it from an optional client header most clients don't send. Either alone would collapse a user's genuinely different devices into one suppression bucket. Caught by independent `code-reviewer` pass; verified by temporarily reverting to a device_name-only key and confirming the new OAuth-collision test fails against it, passes with the full tuple.

## Test plan

- [x] 6 new tests in `test_notification_service.py`, including the literal prod repro (10 sessions in a row → exactly 1 email).
- [x] Verified 3 of 6 fail against pre-fix source via `git stash` (the other 3 exercise behavior unaffected by the suppression logic itself: cross-device non-interference, the OAuth-collision fix, and window expiry).
- [x] Full control-plane suite: 535 passed, 1 skipped (pre-existing, unrelated).
- [x] `ruff check` / `ruff format --check` clean against the CI-pinned ruff version (0.6.9).
- [x] Independent `code-reviewer` pass — found the device_name-only key gap (fixed above) plus a noted-but-accepted multi-worker race (fails toward duplicate email, not toward silence — the correct side for a security notification).
- [ ] Live repro (task's own AC: 10 sessions in 2 min → ≤1 email) not run against a live deployed instance this session — same deploy gate as the rest of this audit series.

**Sequencing note (per Daedalus):** this must merge before or together with TR-04's email-pipeline fix/re-enable, not standalone-and-forgotten.