### PR TITLE
fix(agent-keys): apply default 90-day TTL when expires_at is omitted (TR-45)

### DIFF
--- a/apps/control-plane/app/api/routers/agent_keys.py
+++ b/apps/control-plane/app/api/routers/agent_keys.py
@@ -137,10 +137,14 @@ def create_agent_key(
     """Create an agent key for a share. Raw key is shown once and never retrievable again."""
     share, user_id = _require_share_owner_or_admin(share_id, request, db)
     settings = get_settings()
+    now = security.utcnow()
 
-    # Validate expires_at
+    # Validate expires_at, or apply a default TTL when the caller omits it (TR-45):
+    # an unbounded key that survives a member's removal/offboarding forever is
+    # exactly the "stale access made permanent" risk the audit flagged (37 prod
+    # keys had no expiry at all). Non-breaking: existing callers that already
+    # pass expires_at keep their exact value; only the omitted case changes.
     if payload.expires_at is not None:
-        now = security.utcnow()
         exp = payload.expires_at
         if exp.tzinfo is None:
             exp = exp.replace(tzinfo=timezone.utc)
@@ -154,6 +158,8 @@ def create_agent_key(
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
                 detail="expires_at must be within 2 years from now",
             )
+    else:
+        exp = now + timedelta(days=settings.agent_key_default_ttl_days)
 
     # Enforce per-share active key cap
     active_count_stmt = select(func.count()).where(
@@ -179,7 +185,7 @@ def create_agent_key(
         label=payload.label,
         scopes=",".join(payload.scopes),
         created_by=user_id,
-        expires_at=exp if payload.expires_at is not None else None,
+        expires_at=exp,
     )
     db.add(agent_key)
     db.commit()
@@ -193,7 +199,8 @@ def create_agent_key(
             "share_id": str(share.id),
             "created_by": str(user_id),
             "label": payload.label,
-            "expires_at": payload.expires_at.isoformat() if payload.expires_at else None,
+            "expires_at": agent_key.expires_at.isoformat(),
+            "default_ttl_applied": payload.expires_at is None,
             "scopes": agent_key.scopes,
             "ip": request.client.host if request.client else None,
         },

--- a/apps/control-plane/app/core/config.py
+++ b/apps/control-plane/app/core/config.py
@@ -184,6 +184,13 @@ class Settings(BaseSettings):
     agent_key_creation_rate_per_hour: int = Field(
         default=10, description="Max agent key creations per user per hour"
     )
+    agent_key_default_ttl_days: int = Field(
+        default=90,
+        description=(
+            "Default expiry applied when a caller omits expires_at at key creation "
+            "(TR-45) — matches the prod-DB-password rotation cadence used elsewhere."
+        ),
+    )
 
     # Argus CRM integration (S7: contact dedup + cross-product suppression-read)
     argus_enabled: bool = Field(default=False, description="Enable Argus CRM integration")

--- a/apps/control-plane/tests/test_agent_keys.py
+++ b/apps/control-plane/tests/test_agent_keys.py
@@ -47,6 +47,16 @@ def test_settings_has_agent_key_creation_rate_per_hour() -> None:
     assert settings.agent_key_creation_rate_per_hour > 0
 
 
+def test_settings_has_agent_key_default_ttl_days() -> None:
+    """Settings must expose agent_key_default_ttl_days (TR-45 default-expiry fix)."""
+    from app.core.config import get_settings
+
+    settings = get_settings()
+    assert hasattr(settings, "agent_key_default_ttl_days")
+    assert isinstance(settings.agent_key_default_ttl_days, int)
+    assert settings.agent_key_default_ttl_days > 0
+
+
 # ---------------------------------------------------------------------------
 # POST /v1/web/shares/{share_id}/agent-keys  — the regressed 500 endpoint
 # ---------------------------------------------------------------------------
@@ -97,6 +107,63 @@ def test_create_agent_key_with_expiry(client: TestClient) -> None:
     )
     assert resp.status_code == 201, resp.text
     assert resp.json()["expires_at"] is not None
+
+
+def test_create_agent_key_omitted_expiry_gets_default_ttl(client: TestClient) -> None:
+    """TR-45: omitting expires_at must apply the default TTL, not create an
+    unbounded key. Before the fix this asserted `expires_at is None` (a stale
+    access grant that never expires); the audit found 37 such keys in prod.
+    """
+    from app.core.config import get_settings
+
+    token = login(client, "bootstrap@example.com", "super-secret")
+    share_id = create_share(client, token, path="vault/default-ttl.md")
+
+    before = datetime.now(timezone.utc)
+    resp = client.post(
+        f"/v1/web/shares/{share_id}/agent-keys",
+        json={"label": "no-expiry-specified"},
+        headers=auth_headers(token),
+    )
+    after = datetime.now(timezone.utc)
+    assert resp.status_code == 201, resp.text
+
+    expires_at = datetime.fromisoformat(resp.json()["expires_at"])
+    if expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=timezone.utc)
+
+    ttl_days = get_settings().agent_key_default_ttl_days
+    assert before + timedelta(days=ttl_days) <= expires_at <= after + timedelta(days=ttl_days)
+
+    # Must show up as active in the list, same as an explicit-future-expiry key.
+    list_resp = client.get(
+        f"/v1/web/shares/{share_id}/agent-keys",
+        headers=auth_headers(token),
+    )
+    key_in_list = next(k for k in list_resp.json() if k["label"] == "no-expiry-specified")
+    assert key_in_list["is_active"]
+
+
+def test_create_agent_key_explicit_expiry_not_overridden_by_default(client: TestClient) -> None:
+    """An explicitly-supplied expires_at must be used exactly as given, not
+    silently replaced by the default TTL (non-breaking for existing callers).
+    """
+    token = login(client, "bootstrap@example.com", "super-secret")
+    share_id = create_share(client, token, path="vault/explicit-not-overridden.md")
+
+    # Deliberately shorter than the default TTL so the two are distinguishable.
+    explicit = datetime.now(timezone.utc) + timedelta(days=1)
+    resp = client.post(
+        f"/v1/web/shares/{share_id}/agent-keys",
+        json={"label": "explicit-short-lived", "expires_at": explicit.isoformat()},
+        headers=auth_headers(token),
+    )
+    assert resp.status_code == 201, resp.text
+
+    expires_at = datetime.fromisoformat(resp.json()["expires_at"])
+    if expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=timezone.utc)
+    assert abs((expires_at - explicit).total_seconds()) < 5
 
 
 def test_create_agent_key_empty_label_rejected(client: TestClient) -> None:


### PR DESCRIPTION
## Summary

`create_agent_key` left `expires_at` permanently `NULL` whenever the caller didn't supply one — an audit found 37 active prod keys with no expiry today. An unbounded key that survives a member's removal from a share forever is exactly the kind of stale-access risk that should have a bound by default.

## Fix

Apply a default 90-day TTL (new `agent_key_default_ttl_days` setting) when `expires_at` is omitted at key creation, rather than making the field mandatory — keeps existing callers (admin UI, scripts) working unchanged. Callers that already pass an explicit `expires_at` are unaffected; only the omitted case changes. `expires_at` stays nullable in the DB — this is an application-level default, no migration needed.

## Test plan

- [x] 2 new tests: omitted `expires_at` gets the default TTL (asserted against the actual configured window, not a magic number) and shows up as active; an explicit `expires_at` is used exactly as given, not silently overridden
- [x] 1 new settings unit test (mirrors the existing pattern for the sibling `agent_key_creation_rate_per_hour` field)
- [x] Full suite green (544 passed, 1 pre-existing skip), `ruff check`/`ruff format --check` clean

## Scope note

Not addressed here (flagged as a separate follow-up, real access-revocation risk, not a call to make unilaterally): whether the 37 existing no-expiry keys should be backfilled with an expiry or grandfathered.