### PR TITLE
docs(deploy): document the Caddyfile manual-sync gap (TR-47)

### DIFF
--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -188,6 +188,26 @@ The same `service_completed_successfully` guard applies to `webhook-worker` and 
   control-plane and its workers only. Rebuild those manually if their source changes.
 - **Firewall.** See the network note under [Automated deploy](#required-repository-secrets) if
   GitHub-hosted runners can't reach `tr-relay-vm`.
+- **`infra/Caddyfile` is NOT deployed by CD or the manual steps above — sync it by hand, every
+  time.** Neither the automated pipeline nor the manual upgrade recipe touches
+  `/opt/relay/Caddyfile`; it's a `docker-compose.yml`-managed bind mount the deploy tooling
+  deliberately leaves alone (same reasoning as the server-managed compose file, above), but
+  unlike compose/`.env` there is no independent reason for it to diverge from git — it's meant to
+  track `infra/Caddyfile` exactly. This has silently regressed the public `/metrics` block twice
+  (task history: `c27b715a`, `77117bf7`) — most recently by surviving the 2026-07-09 Helsinki
+  host migration, since a host migration copies data/config that was already on the box, not
+  what's in git. **After editing `infra/Caddyfile`, or after any host migration, manually sync
+  it:**
+  ```bash
+  scp infra/Caddyfile tr-relay-vm:/opt/relay/Caddyfile   # back up the old one on the host first
+  ssh tr-relay-vm "docker exec relay-caddy-1 caddy validate --config /etc/caddy/Caddyfile"
+  ssh tr-relay-vm "docker exec relay-caddy-1 caddy reload --config /etc/caddy/Caddyfile"
+  ```
+  Then verify from **outside** the container — `caddy reload`'s own success message is not proof
+  the running config changed (e.g. a single-file bind mount can retain a stale inode after some
+  edit methods; confirm `stat -c %i` matches between host and `docker exec ... stat` before
+  trusting `reload`, and always curl the actual external behavior afterward, not just the exit
+  code).
 
 ---
 


### PR DESCRIPTION
## Summary

`/metrics` on `cp.tr.entire.vc` was publicly reachable (200, real Prometheus data, no auth) — a regression of a fix already shipped once (task `c27b715a`, 2026-06-07). Root cause both times: CD/the manual deploy recipe never touch `/opt/relay/Caddyfile` (deliberately, same reasoning as leaving `docker-compose.yml`/`.env` server-managed), but unlike those files Caddyfile has no independent reason to diverge from `infra/Caddyfile` in git. The June fix was applied as a manual, git-untracked host edit — which is exactly why it didn't survive the 2026-07-09 Helsinki host migration to `tr-relay-vm` (a migration copies what was already on the box, not what's in git).

`infra/Caddyfile` already has the correct `handle /metrics* { respond 404 }` block from the original fix — this was a deploy gap, not a code gap.

## Fix

- Live-applied the block to `tr-relay-vm`'s `/opt/relay/Caddyfile` directly (backed up first; edited via content-preserving write, confirmed same inode on host and in-container before/after — this file is a single-file bind mount, where some edit methods can silently orphan the container's view).
- This commit documents the gap and the manual sync procedure in `docs/DEPLOY.md`, so a future host migration doesn't lose it a third time.

## Test plan

- [x] External: `curl https://cp.tr.entire.vc/metrics` → 404 (was 200), including `/metrics/` and `/metrics/foo` sub-path variants, empty body (no data leak)
- [x] External sanity: `/server/info` still 200 (Caddy is serving the new config, not just validating it)
- [x] Internal: Prometheus `up{job="tr-control-plane"}` == 1 via the separate firewall-locked metrics-proxy (`:9300`) — confirmed unaffected, it's a different Caddy instance/Caddyfile entirely