### PR TITLE
fix(retention): purge old email_queue/webhook_deliveries rows (TR-48)

### DIFF
--- a/apps/control-plane/app/core/config.py
+++ b/apps/control-plane/app/core/config.py
@@ -185,6 +185,14 @@ class Settings(BaseSettings):
         default=10, description="Max agent key creations per user per hour"
     )
 
+    # Data retention (TR-48): email_queue/webhook_deliveries accumulate PII
+    # (recipient addresses, full HTML bodies, webhook payloads) with no purge —
+    # rows older than this are hard-deleted by the background retention worker.
+    data_retention_days: int = Field(
+        default=90,
+        description="Age (days) past which email_queue/webhook_deliveries rows are purged",
+    )
+
     # Argus CRM integration (S7: contact dedup + cross-product suppression-read)
     argus_enabled: bool = Field(default=False, description="Enable Argus CRM integration")
     argus_api_url: str = Field(default="http://argus-api:8000", description="Argus API base URL")

--- a/apps/control-plane/app/main.py
+++ b/apps/control-plane/app/main.py
@@ -40,7 +40,7 @@ from app.db.session import get_sessionmaker
 from app.middleware import errors, logging
 from app.middleware.metrics import PrometheusMiddleware
 from app.services import auth_service
-from app.workers import metrics_worker
+from app.workers import metrics_worker, retention_worker
 
 # Rate limiter configuration
 limiter = Limiter(key_func=get_remote_address)
@@ -282,6 +282,18 @@ Get a token by calling `POST /auth/login` with valid credentials.
     async def _stop_metrics_collector() -> None:
         """Cancel background metrics collection loop on shutdown."""
         task = getattr(app.state, "metrics_task", None)
+        if task is not None:
+            task.cancel()
+
+    @app.on_event("startup")
+    async def _start_retention_cleanup() -> None:
+        """Launch background data-retention cleanup loop (24h interval, TR-48)."""
+        app.state.retention_task = asyncio.create_task(retention_worker.run_retention_cleanup())
+
+    @app.on_event("shutdown")
+    async def _stop_retention_cleanup() -> None:
+        """Cancel background retention cleanup loop on shutdown."""
+        task = getattr(app.state, "retention_task", None)
         if task is not None:
             task.cancel()
 

--- a/apps/control-plane/app/workers/retention_worker.py
+++ b/apps/control-plane/app/workers/retention_worker.py
@@ -1,0 +1,96 @@
+"""Background data-retention cleanup — runs every 24h as an in-process asyncio task.
+
+email_queue and webhook_deliveries accumulate indefinitely with no purge (TR-48):
+email_queue holds recipient addresses and full HTML/text bodies, webhook_deliveries
+holds arbitrary event payloads — both are PII/GDPR-relevant and had rows going back
+to February with no retention policy. Started via app startup hook in app/main.py,
+mirroring the existing run_metrics_collector() pattern.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import delete
+from sqlalchemy.orm import Session
+
+from app.core.config import get_settings
+from app.core.logging import get_logger
+from app.db import models
+from app.db.session import get_sessionmaker
+
+logger = get_logger(__name__)
+
+RETENTION_CLEANUP_INTERVAL_SECONDS = 86400  # 24h — this is maintenance, not a hot path
+INITIAL_DELAY_SECONDS = 30  # let startup DB operations (bootstrap admin, etc.) settle first
+
+
+def cleanup_old_records(db: Session, retention_days: int) -> dict[str, int]:
+    """Hard-delete email_queue/webhook_deliveries rows older than retention_days.
+
+    Pure w.r.t. the caller's session (no commit/close here — the caller owns the
+    transaction boundary) so this is directly unit-testable against any Session.
+    Returns the deleted row count per table.
+    """
+    cutoff = datetime.now(timezone.utc) - timedelta(days=retention_days)
+
+    # synchronize_session=False: this worker owns no in-memory objects that need
+    # to stay in sync with the delete, and the default "evaluate" strategy chokes
+    # on tz-naive vs tz-aware datetime comparison under SQLite (this repo's test
+    # backend) — let the DB evaluate the WHERE clause directly instead.
+    email_result = db.execute(
+        delete(models.EmailQueue)
+        .where(models.EmailQueue.created_at < cutoff)
+        .execution_options(synchronize_session=False)
+    )
+    webhook_result = db.execute(
+        delete(models.WebhookDelivery)
+        .where(models.WebhookDelivery.created_at < cutoff)
+        .execution_options(synchronize_session=False)
+    )
+
+    return {
+        "email_queue_deleted": email_result.rowcount,
+        "webhook_deliveries_deleted": webhook_result.rowcount,
+    }
+
+
+def _run_cleanup() -> None:
+    """Open a fresh session, run the purge, commit, and log the result."""
+    settings = get_settings()
+    db = get_sessionmaker()()
+    try:
+        counts = cleanup_old_records(db, settings.data_retention_days)
+        db.commit()
+        logger.info(
+            "retention_worker: cleanup complete",
+            extra={"retention_days": settings.data_retention_days, **counts},
+        )
+    except Exception as exc:
+        db.rollback()
+        logger.error("retention_worker: cleanup failed", extra={"error": str(exc)})
+    finally:
+        db.close()
+
+
+async def run_retention_cleanup() -> None:
+    """Async loop started at app startup. Purges old PII-bearing rows every 24h.
+
+    Runs promptly after a short startup-settle delay (unlike the metrics collector,
+    which sleeps a full interval first — retention correctness doesn't benefit from
+    waiting, and there is no reason to leave known-stale rows sitting for up to a
+    full day before the first cleanup ever runs).
+    """
+    logger.info(
+        "retention_worker: background cleanup started",
+        extra={"interval": RETENTION_CLEANUP_INTERVAL_SECONDS},
+    )
+    await asyncio.sleep(INITIAL_DELAY_SECONDS)
+    while True:
+        try:
+            loop = asyncio.get_running_loop()
+            await loop.run_in_executor(None, _run_cleanup)
+        except Exception as exc:
+            logger.error("retention_worker: unexpected error", extra={"error": str(exc)})
+        await asyncio.sleep(RETENTION_CLEANUP_INTERVAL_SECONDS)

--- a/apps/control-plane/tests/test_retention_worker.py
+++ b/apps/control-plane/tests/test_retention_worker.py
@@ -1,0 +1,158 @@
+"""Tests for TR-48 (#68f7cd73): email_queue/webhook_deliveries retention cleanup.
+
+Neither table had a purge path — email_queue accumulates full HTML bodies and
+recipient addresses (PII), webhook_deliveries accumulates arbitrary event
+payloads, both with rows going back to February and no retention policy. Fixed
+with a background worker (mirroring the existing run_metrics_collector()
+pattern) that hard-deletes rows older than settings.data_retention_days.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.db import models
+from app.services import webhook_service
+from app.workers import retention_worker
+
+
+def make_email(
+    db: Session, created_at: datetime, to_email: str = "someone@example.com"
+) -> models.EmailQueue:
+    email = models.EmailQueue(
+        to_email=to_email,
+        subject="Test",
+        body_text="body",
+        body_html="<p>body</p>",
+        email_type="invite_notification",
+        status=models.EmailStatus.SENT,
+        created_at=created_at,
+    )
+    db.add(email)
+    db.commit()
+    db.refresh(email)
+    return email
+
+
+def make_webhook(db: Session) -> models.Webhook:
+    webhook = models.Webhook(
+        id=uuid.uuid4(),
+        user_id=None,
+        name="test-hook",
+        url="https://example.com/hook",
+        secret=webhook_service.generate_webhook_secret(),
+        events=["share.created"],
+        active=True,
+        failure_count=0,
+    )
+    db.add(webhook)
+    db.commit()
+    db.refresh(webhook)
+    return webhook
+
+
+def make_delivery(
+    db: Session, webhook: models.Webhook, created_at: datetime
+) -> models.WebhookDelivery:
+    delivery = models.WebhookDelivery(
+        webhook_id=webhook.id,
+        event_id=uuid.uuid4(),
+        event_type="share.created",
+        payload={"foo": "bar"},
+        status=models.WebhookDeliveryStatus.SUCCESS,
+        created_at=created_at,
+    )
+    db.add(delivery)
+    db.commit()
+    db.refresh(delivery)
+    return delivery
+
+
+def test_settings_has_data_retention_days() -> None:
+    """Settings must expose data_retention_days so the retention worker works."""
+    from app.core.config import get_settings
+
+    settings = get_settings()
+    assert hasattr(settings, "data_retention_days")
+    assert isinstance(settings.data_retention_days, int)
+    assert settings.data_retention_days > 0
+
+
+class TestCleanupOldRecords:
+    def test_deletes_email_queue_rows_older_than_retention(self, db_session: Session):
+        now = datetime.now(timezone.utc)
+        old_email_id = make_email(db_session, created_at=now - timedelta(days=100)).id
+        recent_email_id = make_email(db_session, created_at=now - timedelta(days=1)).id
+
+        counts = retention_worker.cleanup_old_records(db_session, retention_days=90)
+        db_session.commit()
+
+        assert counts["email_queue_deleted"] == 1
+        remaining_ids = set(db_session.execute(select(models.EmailQueue.id)).scalars().all())
+        assert old_email_id not in remaining_ids
+        assert recent_email_id in remaining_ids
+
+    def test_deletes_webhook_deliveries_older_than_retention(self, db_session: Session):
+        now = datetime.now(timezone.utc)
+        webhook = make_webhook(db_session)
+        old_delivery_id = make_delivery(
+            db_session, webhook, created_at=now - timedelta(days=100)
+        ).id
+        recent_delivery_id = make_delivery(
+            db_session, webhook, created_at=now - timedelta(days=1)
+        ).id
+
+        counts = retention_worker.cleanup_old_records(db_session, retention_days=90)
+        db_session.commit()
+
+        assert counts["webhook_deliveries_deleted"] == 1
+        remaining_ids = set(db_session.execute(select(models.WebhookDelivery.id)).scalars().all())
+        assert old_delivery_id not in remaining_ids
+        assert recent_delivery_id in remaining_ids
+
+    def test_returns_zero_counts_when_nothing_is_old_enough(self, db_session: Session):
+        now = datetime.now(timezone.utc)
+        make_email(db_session, created_at=now - timedelta(days=1))
+        webhook = make_webhook(db_session)
+        make_delivery(db_session, webhook, created_at=now - timedelta(days=1))
+
+        counts = retention_worker.cleanup_old_records(db_session, retention_days=90)
+
+        assert counts == {"email_queue_deleted": 0, "webhook_deliveries_deleted": 0}
+
+    def test_does_not_touch_the_parent_webhook_row(self, db_session: Session):
+        """Deleting old deliveries must not cascade up and remove the webhook
+        registration itself — only the delivery history rows are retention-bound."""
+        now = datetime.now(timezone.utc)
+        webhook = make_webhook(db_session)
+        make_delivery(db_session, webhook, created_at=now - timedelta(days=100))
+
+        retention_worker.cleanup_old_records(db_session, retention_days=90)
+        db_session.commit()
+
+        assert (
+            db_session.execute(
+                select(models.Webhook).where(models.Webhook.id == webhook.id)
+            ).scalar_one_or_none()
+            is not None
+        )
+
+    def test_boundary_row_just_inside_the_window_is_kept(self, db_session: Session):
+        now = datetime.now(timezone.utc)
+        # 89 days old with a 90-day retention window: must survive.
+        kept = make_email(db_session, created_at=now - timedelta(days=89))
+
+        counts = retention_worker.cleanup_old_records(db_session, retention_days=90)
+        db_session.commit()
+
+        assert counts["email_queue_deleted"] == 0
+        assert (
+            db_session.execute(
+                select(models.EmailQueue).where(models.EmailQueue.id == kept.id)
+            ).scalar_one_or_none()
+            is not None
+        )


### PR DESCRIPTION
## Summary

`email_queue` (full HTML/text bodies + recipient addresses) and `webhook_deliveries` (arbitrary event payloads) had no retention policy — prod has 1434 `email_queue` rows going back to February. Grepped for any existing DELETE/purge path on either model: zero.

## Fix

Background retention worker mirroring the existing `run_metrics_collector()` pattern (in-process asyncio task, started via the app startup hook in `main.py`) — hard-deletes rows in both tables older than `settings.data_retention_days` (new setting, default 90 days, matching the agent-keys default-TTL cadence from #131). Runs every 24h, with only a short startup-settle delay before the first pass.

Per this task's deploy-durability note: this is code that goes through the normal build+deploy pipeline, not a one-off DB patch — so a restart or future host migration can't silently lose it (the exact regression class that hit the Caddyfile fix in #133).

## Test plan

- [x] 6 new tests: deletes old rows in both tables, leaves recent rows alone, returns accurate counts, doesn't cascade-delete the parent `Webhook` row, a row just inside the retention window survives (boundary check), settings field exists
- [x] Verified discriminating: stubbed `cleanup_old_records` to a no-op — the two delete-assertion tests correctly fail; restored the real implementation, all green again
- [x] Full suite green (547 passed, 1 pre-existing skip), `ruff check`/`ruff format --check` clean
- [ ] Live trigger against the 1434-row prod backlog + confirm the background loop is actually wired at startup — will report back on the Mesh task once deployed