### PR TITLE
fix(listmonk-sync): freeze cursor watermark at first per-row sync failure

### DIFF
--- a/apps/control-plane/app/services/listmonk_service.py
+++ b/apps/control-plane/app/services/listmonk_service.py
@@ -214,13 +214,23 @@ class ListmonkService:
     # ------------------------------------------------------------------
 
     async def sync_new_users(self, db: Session, since: datetime) -> tuple[int, datetime | None]:
-        """Sync users created after `since`. Returns (synced_count, max_created_at)."""
+        """Sync users created after `since`. Returns (synced_count, max_created_at).
+
+        `max_ts` only advances while every row so far has been attempted
+        without raising. Once a row raises, the watermark freezes at the
+        last known-good `registered_at` — later rows in the same batch are
+        still attempted (a persistently-broken row shouldn't block newer
+        registrations forever), but the cursor never jumps past a row that
+        hasn't successfully synced, so the failed row gets retried on the
+        next cycle instead of silently skipped for up to 24h (TR-49).
+        """
         rows = db.execute(_NEW_USERS_SINCE_QUERY, {"since": since}).fetchall()
         if not rows:
             return 0, None
 
         synced = 0
         max_ts: datetime | None = None
+        failed = False
 
         for row in rows:
             try:
@@ -234,11 +244,12 @@ class ListmonkService:
                 )
                 if ok:
                     synced += 1
-                # Advance max_ts regardless (so cursor moves past opt-out users too)
-                if max_ts is None or row.registered_at > max_ts:
+                # Advance past opt-out users too, but never past a failure.
+                if not failed and (max_ts is None or row.registered_at > max_ts):
                     max_ts = row.registered_at
             except Exception:
                 logger.exception("Failed to upsert subscriber %s", row.email)
+                failed = True
 
         return synced, max_ts
 

--- a/apps/control-plane/tests/test_listmonk_service.py
+++ b/apps/control-plane/tests/test_listmonk_service.py
@@ -19,8 +19,9 @@ mocked; the escaping/normalization logic under test runs for real.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from unittest.mock import AsyncMock
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -135,3 +136,75 @@ class TestUpdateExistingLookupEscaping:
         # out of the string literal mid-fragment.
         assert lookup_query == "subscribers.email = 'o''brien@x.com'"
         assert "= 'o'brien" not in lookup_query
+
+
+def _make_row(email: str, registered_at: datetime):
+    return SimpleNamespace(
+        id=f"id-{email}",
+        email=email,
+        registered_at=registered_at,
+        casdoor=True,
+        has_share=False,
+        name=email.split("@")[0],
+        lifecycle_emails=True,
+    )
+
+
+class TestSyncNewUsersCursorOnPartialFailure:
+    """TR-49 regression: a per-row exception must not let the cursor jump past it.
+
+    Pre-fix, `max_ts` advanced on every row that didn't itself raise — so a
+    later, successfully-synced row would drag the watermark past an earlier
+    row that failed, and the failed row's `registered_at` would never again
+    satisfy `created_at > :since` on the next cycle. That user silently
+    stopped receiving lifecycle syncs for up to 24h (until the nightly
+    backfill caught it via full reconcile).
+    """
+
+    @pytest.mark.asyncio
+    async def test_cursor_freezes_at_first_failed_row_not_at_last_row(self):
+        base = datetime(2026, 7, 20, tzinfo=timezone.utc)
+        rows = [
+            _make_row("a@example.com", base),
+            _make_row("b@example.com", base + timedelta(minutes=1)),  # fails
+            _make_row("c@example.com", base + timedelta(minutes=2)),  # synced after the failure
+        ]
+
+        db = MagicMock()
+        db.execute.return_value.fetchall.return_value = rows
+
+        service = ListmonkService()
+
+        async def fake_upsert(*, email, **kwargs):
+            if email == "b@example.com":
+                raise RuntimeError("boom")
+            return True
+
+        with patch.object(service, "upsert_subscriber", new=AsyncMock(side_effect=fake_upsert)):
+            synced, max_ts = await service.sync_new_users(db, since=base - timedelta(days=1))
+
+        # a@ (before the failure) + c@ (attempted after, still succeeds) = 2 synced.
+        assert synced == 2
+        # The cursor must stay at a@'s timestamp — the last row that synced
+        # successfully BEFORE the failure — so b@'s created_at is still
+        # > the persisted cursor and gets re-fetched + retried next cycle.
+        assert max_ts == base
+        assert max_ts < rows[1].registered_at
+        assert max_ts < rows[2].registered_at
+
+    @pytest.mark.asyncio
+    async def test_no_failures_advances_cursor_to_last_row(self):
+        base = datetime(2026, 7, 20, tzinfo=timezone.utc)
+        rows = [
+            _make_row("a@example.com", base),
+            _make_row("b@example.com", base + timedelta(minutes=1)),
+        ]
+        db = MagicMock()
+        db.execute.return_value.fetchall.return_value = rows
+
+        service = ListmonkService()
+        with patch.object(service, "upsert_subscriber", new=AsyncMock(return_value=True)):
+            synced, max_ts = await service.sync_new_users(db, since=base - timedelta(days=1))
+
+        assert synced == 2
+        assert max_ts == rows[-1].registered_at


### PR DESCRIPTION
## Summary
- TR-49 (P3, wave-4 audit #96d804dd) — `sync_new_users()` advanced its `max_ts` cursor even when a row's upsert raised, so a later successfully-synced row could drag the watermark past an earlier failed row. That user's `registered_at` then permanently failed the `created_at > :since` filter on subsequent incremental syncs — silently dropped from lifecycle-email sync for up to 24h, until the nightly full backfill caught it.
- Fix: freeze `max_ts` once any row raises in the batch. Later rows are still attempted (a persistently-broken row doesn't block newer registrations forever), but the persisted cursor never advances past a row that hasn't synced successfully — the failed row is retried on the next incremental cycle.

## Test plan
- [x] New regression test `test_cursor_freezes_at_first_failed_row_not_at_last_row`: 3 rows, middle one raises, cursor stays at the row *before* the failure (not the last row that happened to succeed after it) — proves the exact TR-49 scenario.
- [x] New test `test_no_failures_advances_cursor_to_last_row`: confirms unchanged happy-path behavior.
- [x] `pytest tests/test_listmonk_service.py -v` → 8 passed
- [x] Full suite: `pytest tests/ -q` → 549 passed, 1 skipped (unrelated), no regressions
- [x] `ruff check` clean on changed files