### PR TITLE
fix(listmonk-sync): idle instead of sys.exit(1) on missing config

### DIFF
--- a/apps/control-plane/app/workers/listmonk_sync_worker.py
+++ b/apps/control-plane/app/workers/listmonk_sync_worker.py
@@ -128,10 +128,18 @@ async def main() -> None:
     settings = get_settings()
 
     if not settings.listmonk_enabled:
+        # A missing/misconfigured LISTMONK_URL or LISTMONK_API_PASSWORD is a
+        # config defect, not a transient fault — sys.exit(1) here just hands
+        # `restart: unless-stopped` an infinite crash-restart loop (env vars
+        # are fixed at container start, so a restart can never fix it).
+        # Match the email/lifecycle worker convention instead: log clearly
+        # and idle the sync loop so the process stays up in a visibly
+        # misconfigured state until a human fixes the config (TR-50).
         logger.error(
-            "Listmonk sync disabled — set LISTMONK_URL and LISTMONK_API_PASSWORD. Exiting."
+            "Listmonk sync disabled — set LISTMONK_URL and LISTMONK_API_PASSWORD. "
+            "Worker will idle (not exit) until the config is fixed and the "
+            "container is recreated."
         )
-        sys.exit(1)
 
     svc = get_listmonk_service()
     await svc.start()
@@ -142,19 +150,26 @@ async def main() -> None:
             "listmonk_url": settings.listmonk_url,
             "list_id": settings.listmonk_list_id,
             "sync_interval": settings.listmonk_sync_interval,
+            "enabled": settings.listmonk_enabled,
         },
     )
 
     try:
         while not shutdown_flag:
-            db = get_sessionmaker()()
-            try:
-                await _run_backfill_if_due(svc, db)
-                await _run_incremental(svc, db, settings)
-            except Exception:
-                logger.exception("Error in Listmonk sync cycle")
-            finally:
-                db.close()
+            if settings.listmonk_enabled:
+                db = get_sessionmaker()()
+                try:
+                    await _run_backfill_if_due(svc, db)
+                    await _run_incremental(svc, db, settings)
+                except Exception:
+                    logger.exception("Error in Listmonk sync cycle")
+                finally:
+                    db.close()
+            else:
+                logger.error(
+                    "Listmonk sync still disabled — set LISTMONK_URL and "
+                    "LISTMONK_API_PASSWORD and recreate the container."
+                )
 
             for _ in range(settings.listmonk_sync_interval):
                 if shutdown_flag:

--- a/apps/control-plane/tests/test_listmonk_sync_worker.py
+++ b/apps/control-plane/tests/test_listmonk_sync_worker.py
@@ -1,0 +1,120 @@
+"""Tests for TR-50 (#ec96809c): sys.exit(1) on missing config + restart:unless-stopped crash-loop.
+
+listmonk_sync_worker.main() used to sys.exit(1) when LISTMONK_URL/LISTMONK_API_PASSWORD
+were unset. Under `restart: unless-stopped` (infra/docker-compose.yml) that turns a
+config gap into an infinite restart storm — a missing env var is a config defect, not
+a transient fault, and restarting the process can never fix it (env vars are fixed at
+container start). Fixed to log an error and idle the sync loop instead of exiting,
+matching the existing email_worker/lifecycle_worker convention (log once, no-op the
+cycle, keep looping).
+
+Only the DB session factory and the Listmonk service are mocked (the true external/
+infra boundaries for this worker's main loop); the disabled/enabled branching logic
+under test runs for real.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.workers import listmonk_sync_worker
+
+
+def _fake_settings(*, listmonk_enabled: bool) -> SimpleNamespace:
+    return SimpleNamespace(
+        listmonk_enabled=listmonk_enabled,
+        listmonk_url="https://lists.example.com",
+        listmonk_list_id=8,
+        listmonk_sync_interval=300,
+    )
+
+
+async def _stop_after_one_iteration(_seconds) -> None:
+    listmonk_sync_worker.shutdown_flag = True
+
+
+@pytest.fixture(autouse=True)
+def _reset_shutdown_flag():
+    listmonk_sync_worker.shutdown_flag = False
+    yield
+    listmonk_sync_worker.shutdown_flag = False
+
+
+class TestMainIdlesInsteadOfExitingOnMissingConfig:
+    @pytest.mark.asyncio
+    async def test_disabled_config_returns_normally_and_skips_the_sync_cycle(self):
+        """Pre-fix this called sys.exit(1), which raises SystemExit straight
+        through this await — a bare `await main()` completing normally is
+        itself proof the crash-exit path is gone. It must also never touch
+        the DB while disabled (no per-row upsert spam against a client that
+        was never started)."""
+        settings = _fake_settings(listmonk_enabled=False)
+        fake_svc = SimpleNamespace(start=AsyncMock(), stop=AsyncMock())
+        fake_sessionmaker = MagicMock()
+
+        with (
+            patch.object(listmonk_sync_worker, "get_settings", return_value=settings),
+            patch.object(listmonk_sync_worker, "get_listmonk_service", return_value=fake_svc),
+            patch.object(listmonk_sync_worker, "get_sessionmaker", return_value=fake_sessionmaker),
+            patch("asyncio.sleep", new=AsyncMock(side_effect=_stop_after_one_iteration)),
+        ):
+            await listmonk_sync_worker.main()
+
+        fake_sessionmaker.assert_not_called()
+        fake_svc.start.assert_awaited_once()
+        fake_svc.stop.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_disabled_config_keeps_looping_across_multiple_cycles(self):
+        """Not just 'doesn't exit once' — the idle loop must be durable
+        across repeated cycles, since a real container stays up indefinitely
+        under restart: unless-stopped until someone fixes the config."""
+        settings = _fake_settings(listmonk_enabled=False)
+        fake_svc = SimpleNamespace(start=AsyncMock(), stop=AsyncMock())
+        fake_sessionmaker = MagicMock()
+
+        calls = {"n": 0}
+
+        async def stop_after_three(_seconds):
+            calls["n"] += 1
+            if calls["n"] >= 3:
+                listmonk_sync_worker.shutdown_flag = True
+
+        with (
+            patch.object(listmonk_sync_worker, "get_settings", return_value=settings),
+            patch.object(listmonk_sync_worker, "get_listmonk_service", return_value=fake_svc),
+            patch.object(listmonk_sync_worker, "get_sessionmaker", return_value=fake_sessionmaker),
+            patch("asyncio.sleep", new=AsyncMock(side_effect=stop_after_three)),
+        ):
+            await listmonk_sync_worker.main()
+
+        assert calls["n"] == 3
+        fake_sessionmaker.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_enabled_config_still_runs_the_sync_cycle(self):
+        """Regression guard: the normal enabled path must be unchanged."""
+        settings = _fake_settings(listmonk_enabled=True)
+        fake_svc = SimpleNamespace(start=AsyncMock(), stop=AsyncMock())
+        fake_sessionmaker = MagicMock(return_value=MagicMock())
+
+        with (
+            patch.object(listmonk_sync_worker, "get_settings", return_value=settings),
+            patch.object(listmonk_sync_worker, "get_listmonk_service", return_value=fake_svc),
+            patch.object(listmonk_sync_worker, "get_sessionmaker", return_value=fake_sessionmaker),
+            patch.object(
+                listmonk_sync_worker, "_run_backfill_if_due", new=AsyncMock()
+            ) as backfill_mock,
+            patch.object(
+                listmonk_sync_worker, "_run_incremental", new=AsyncMock()
+            ) as incremental_mock,
+            patch("asyncio.sleep", new=AsyncMock(side_effect=_stop_after_one_iteration)),
+        ):
+            await listmonk_sync_worker.main()
+
+        backfill_mock.assert_awaited_once()
+        incremental_mock.assert_awaited_once()
+        fake_sessionmaker.assert_called_once()


### PR DESCRIPTION
## Summary
- TR-50 (P3, wave-4 audit #96d804dd) — `listmonk_sync_worker.main()` called `sys.exit(1)` when `LISTMONK_URL`/`LISTMONK_API_PASSWORD` were unset. Under `restart: unless-stopped` (`infra/docker-compose.yml`) that turns a config gap into an infinite restart storm: env vars are fixed at container start, so restarting the process achieves nothing except log/CPU churn until a human fixes the config.
- Fix: log the error clearly and idle the sync loop instead of exiting — matches the existing `email_worker`/`lifecycle_worker` convention already in this codebase (log once, no-op the disabled cycle, keep looping). Also re-logs the still-disabled state on every idle cycle so it stays visible in live logs instead of a single line that scrolls away.
- Same bug class as a prior Argus X1 crash-loop incident (missing config → non-zero exit → `restart:on-failure` looped it repeatedly) — fixed the same way there: don't treat a recoverable config gap as fatal.

## Test plan
- [x] New `tests/test_listmonk_sync_worker.py`: disabled config → `main()` returns normally (proves the `sys.exit(1)` path is gone — a `SystemExit` would propagate straight through the `await`) and never touches the DB session factory; idle loop is durable across multiple cycles, not just one; enabled path unchanged (regression guard).
- [x] `pytest tests/test_listmonk_sync_worker.py -v` → 3 passed
- [x] Full suite: `pytest tests/ -q` → 552 passed, 1 skipped (unrelated), no regressions
- [x] `ruff check` clean on changed files