### PR TITLE
fix(relay): don't strip query-string tokens on WebSocket-upgrade paths

### DIFF
--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -186,6 +186,13 @@ The same `service_completed_successfully` guard applies to `webhook-worker` and 
   the server's compose file and `.env` alone.
 - **web-publish / relay-server** are not (re)built by the deploy pipeline — it covers the
   control-plane and its workers only. Rebuild those manually if their source changes.
+- **`infra/Caddyfile` is host-managed and NOT synced by the deploy pipeline** (same gap as the
+  compose file above). A fix applied here must ALSO be applied live on `tr-relay-vm`
+  (`/opt/relay/Caddyfile`, content-preserving write + `caddy validate` + `caddy reload` inside
+  `relay-caddy-1` — it's a bind-mounted single file, don't `sed -i` it, write a fresh copy so the
+  inode is preserved) or it silently only exists in git. Confirmed drifted at least once already
+  (TR-47's `/metrics` block, TR-43's WS-token-stripping fix) — always diff live vs repo before
+  assuming they match.
 - **Firewall.** See the network note under [Automated deploy](#required-repository-secrets) if
   GitHub-hosted runners can't reach `tr-relay-vm`.
 

--- a/infra/Caddyfile
+++ b/infra/Caddyfile
@@ -14,12 +14,27 @@ cp.{$DOMAIN_BASE} {
 }
 
 {$DOMAIN_BASE} {
-  # Browser WebSocket API cannot set custom headers, so Obsidian plugin
-  # sends CWT token as ?token= query param. Extract it and set as
-  # Authorization header for relay-server, then strip ?token= from URL
-  # (relay-server also tries to parse ?token= in its own binary format,
-  # which fails on CWT tokens — so we must remove it).
-  @token_in_query query token=*
+  # Browser WebSocket API cannot set custom headers, so this rule extracts
+  # ?token= and sets it as an Authorization header instead, for plain HTTP
+  # endpoints that need it that way.
+  #
+  # TR-43 (#ec3199b7): this must NOT apply to the WebSocket-upgrade paths
+  # (/doc/ws/:doc_id, /d/:did/ws/:doc_id) — relay-server's WS handlers only
+  # ever read the token from the query string (verify_socket_token in
+  # crates/relay/src/server.rs takes Query(params).token only, never an
+  # Authorization header), and relay-server's own Authenticator already
+  # correctly verifies CWT tokens via the query param directly (confirmed:
+  # relay.toml has server.url set, enabling CWT audience validation —
+  # verify_token_with_channel auto-detects Custom vs Cwt token format).
+  # So for WS paths this rule was stripping a token that would otherwise
+  # have authenticated successfully, and replacing it with a header the
+  # handler never reads — turning a valid request into "missing_token".
+  # Live-confirmed 2026-07-22: relay_server_http_auth_errors_total{missing_token}
+  # incremented on a synthetic WS-upgrade request that DID carry ?token=.
+  @token_in_query {
+    query token=*
+    not path /doc/ws/* /d/*/ws/*
+  }
   handle @token_in_query {
     route {
       request_header Authorization "Bearer {query.token}"


### PR DESCRIPTION
## Summary
- TR-43 (P3, wave-4 audit #96d804dd) — investigation task, originally framed as "179 unauthenticated requests on a deprecated route." Found the real cause: a live, active auth bug, not a dead/legacy route.
- `infra/Caddyfile`'s `@token_in_query` rule converted `?token=` into an `Authorization` header for **every** path on the domain, including the two WebSocket-upgrade routes (`/doc/ws/:doc_id`, `/d/:did/ws/:doc_id`). Neither WS handler in `relay-server` (`crates/relay/src/server.rs`, `verify_socket_token`) ever reads an `Authorization` header — only the query string — so this rule was stripping a token that would otherwise have authenticated successfully and replacing it with a header the handler never checks, turning a legitimate connection attempt into a `missing_token` rejection.
- `relay-server`'s own `Authenticator` already correctly verifies CWT tokens via the query param directly (`relay.toml` has `server.url` set, enabling CWT audience validation; `verify_token_with_channel` auto-detects Custom vs CWT format) — the header-conversion workaround was unnecessary for these two paths (its own code comment claiming CWT tokens "fail" via query param appears to be stale/incorrect).
- Fix: excluded both WS-upgrade path patterns from the matcher (`not path /doc/ws/* /d/*/ws/*`) so their query token passes through unchanged; every other path keeps the existing Authorization-header conversion.

## Live verification (tr-relay-vm, 2026-07-22)
- **Pre-fix baseline:** a synthetic WS-upgrade request carrying `?token=faketesttoken123` → relay-server reported `missing_token` (proves the token was being stripped before reaching it, not just an invalid one).
- **Applied the fix live** (rollback anchor: `/opt/relay/Caddyfile.bak-tr43-ws-token-fix-20260722-120141`), `caddy validate` clean, `caddy reload` clean.
- **Post-fix, same test class:** the WS-upgrade request now reports `invalid_token` instead of `missing_token` — proving the (fake, deliberately invalid) token now genuinely reaches the verifier rather than being silently dropped. A real, validly-signed CWT token would now be accepted.
- **Regression check:** a non-WS path with `?token=` still correctly converts to an `invalid_doc_token` error via the Authorization-header path (unchanged behavior for everything else).
- `docs/DEPLOY.md` updated: `infra/Caddyfile` is host-managed and not synced by the deploy pipeline (same gap already known for `docker-compose.yml`) — this PR is git-side documentation of a fix that's *also* already live; noted explicitly so a future reader doesn't assume merging this PR alone ships it.

## Note on severity
This task was filed as a P3 "close a deprecated route" cleanup item. What I actually found is that the primary WebSocket real-time-collaboration path may have been silently broken for any client going through the public `tr.entire.vc` domain (not a bypass route) — low absolute event volume (181 failures over 13 days) is consistent with Team Relay's real-time-collab feature being lightly used rather than the bug being narrow. Flagging this in case it warrants a broader look (e.g. whether relay-onprem/relay-onprem-enterprise deployments have the identical Caddyfile pattern).