### PR TITLE
fix(branding): handle absolute-URL branding_logo_url in TR-62 migration

### DIFF
--- a/apps/control-plane/app/db/migrations/versions/202607220002_branding_logo_png_absolute_url.py
+++ b/apps/control-plane/app/db/migrations/versions/202607220002_branding_logo_png_absolute_url.py
@@ -1,0 +1,48 @@
+"""Fix branding_logo_url PNG switch for instances storing an absolute URL
+
+Follow-up to 202607220001, which only matched the relative-path default
+(`/static/img/evc-ava.svg`) and silently matched zero rows on prod — prod's
+stored value is `https://cp.tr.entire.vc/static/img/evc-ava.svg` (absolute,
+presumably set via an earlier admin-branding-settings write). Use a
+suffix-preserving REPLACE so it works whether the stored value is relative,
+absolute, or on any other domain — only rows still pointing at the default
+evc-ava.svg asset are touched, any genuinely custom logo is left alone.
+
+Revision ID: 202607220002
+Revises: 202607220001
+Create Date: 2026-07-22 00:00:01.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "202607220002"
+down_revision: Union[str, None] = "202607220001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+OLD_SUFFIX = "/static/img/evc-ava.svg"
+NEW_SUFFIX = "/static/img/evc-ava.png"
+
+
+def upgrade() -> None:
+    op.execute(
+        f"""
+        UPDATE instance_settings
+        SET value = REPLACE(value, '{OLD_SUFFIX}', '{NEW_SUFFIX}')
+        WHERE key = 'branding_logo_url' AND value LIKE '%{OLD_SUFFIX}'
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        f"""
+        UPDATE instance_settings
+        SET value = REPLACE(value, '{NEW_SUFFIX}', '{OLD_SUFFIX}')
+        WHERE key = 'branding_logo_url' AND value LIKE '%{NEW_SUFFIX}'
+        """
+    )


### PR DESCRIPTION
## Summary
Follow-up to #140 (TR-62), caught during live-verify. `202607220001` only matched the relative default path (`/static/img/evc-ava.svg`), and matched **zero rows on prod** — its actual stored `branding_logo_url` is the absolute form `https://cp.tr.entire.vc/static/img/evc-ava.svg` (presumably set at some earlier point via the admin branding settings UI). After deploying #140 and running the migration, `/server/info` still reported `.svg` — confirmed via `curl` + a direct read-only DB query.

New migration uses a suffix-preserving `REPLACE()` + `LIKE '%...'` match instead of an exact-match `WHERE`, so it works regardless of whether the stored value is relative, absolute, or on a different domain — only rows still pointing at the default `evc-ava.svg` asset are touched, any genuinely custom logo is left alone.

## Test plan
- [x] `alembic heads` confirms this chains cleanly after `202607220001`.
- [x] `ruff check` clean on the new file.
- [ ] Will live-verify post-deploy: `curl /server/info` shows `.png`, and the real share page's `og:image`/`twitter:image` resolve to the PNG.