### PR TITLE
fix(logging): don't log 404 at WARNING level (TR-63)

### DIFF
--- a/apps/control-plane/app/middleware/logging.py
+++ b/apps/control-plane/app/middleware/logging.py
@@ -74,9 +74,18 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
                 if user_id:
                     log_context["user_id"] = str(user_id)
 
-            # Log based on status code
+            # Log based on status code.
+            # 404 is routine, not an actionable signal: public slug-lookup routes
+            # (e.g. /v1/web/shares/{slug}) return it identically for an expired/
+            # deleted share and for a vulnerability scanner probing garbage paths
+            # (.env, .idea, ...) — the route matches either way, so there is no
+            # way to tell those apart from the response alone. Logging it at
+            # WARNING just buries real WARNINGs (401/403/409/422/429, etc.) under
+            # scanner noise (TR-63). Every other 4xx still warns.
             if response.status_code >= 500:
                 logger.error("Request failed", extra=log_context)
+            elif response.status_code == 404:
+                logger.info("Request not found", extra=log_context)
             elif response.status_code >= 400:
                 logger.warning("Request error", extra=log_context)
             elif request.url.path not in self.QUIET_PATHS:

--- a/apps/control-plane/tests/test_logging.py
+++ b/apps/control-plane/tests/test_logging.py
@@ -211,3 +211,37 @@ class TestRequestLogging:
             ids.add(response.headers["X-Request-ID"])
 
         assert len(ids) == 5  # All IDs should be unique
+
+    def test_404_logs_at_info_not_warning(self, client, caplog) -> None:
+        """TR-63: a 404 (e.g. a scanner probing a garbage slug like /.env, /.idea
+        under /v1/web/shares/{slug}) must not log at WARNING — it's routine, not
+        an actionable signal, and was drowning real WARNINGs in scanner noise."""
+        import logging as logging_module
+
+        with caplog.at_level(logging_module.INFO, logger="app.middleware.logging"):
+            response = client.get("/v1/web/shares/.env")
+
+        assert response.status_code == 404
+        request_records = [
+            r for r in caplog.records if r.message in ("Request error", "Request not found")
+        ]
+        assert len(request_records) == 1
+        assert request_records[0].levelname == "INFO"
+        assert request_records[0].message == "Request not found"
+
+    def test_real_4xx_still_logs_at_warning(self, client, caplog) -> None:
+        """TR-63 regression guard: only 404 is downgraded — a genuine client-error
+        4xx (e.g. an invalid refresh token, 401) must still warn, so this fix
+        doesn't silently swallow actionable signals along with the scanner noise."""
+        import logging as logging_module
+
+        with caplog.at_level(logging_module.INFO, logger="app.middleware.logging"):
+            response = client.post("/v1/auth/refresh", json={"refresh_token": "a" * 64})
+
+        assert response.status_code == 401
+        request_records = [
+            r for r in caplog.records if r.message in ("Request error", "Request not found")
+        ]
+        assert len(request_records) == 1
+        assert request_records[0].levelname == "WARNING"
+        assert request_records[0].message == "Request error"


### PR DESCRIPTION
## Summary

- `RequestLoggingMiddleware` logged every 4xx response at WARNING, including legitimate 404s from vulnerability scanners probing garbage slugs under `/v1/web/shares/{slug}` (`.env`, `.idea`, etc.) — burying real WARNINGs (401/403/409/422/429) under scanner noise.
- Considered using route-template matching (the same technique that fixed the earlier `/metrics` cardinality explosion) to distinguish "scanner probe" from "real request," but it doesn't apply here: a scanner probe and a real user's expired/deleted share both hit the exact same matched route (`/v1/web/shares/{slug}`) and both return the identical app-level 404 — there is no signal in the response to tell them apart.
- Fix is at the status code itself: 404 is inherently routine (a "resource doesn't exist" outcome, not a bug) and now logs at INFO. Every other 4xx is unchanged and still logs at WARNING.

## Test plan
- [x] New test: 404 on a garbage slug logs at INFO, not WARNING
- [x] New test: a genuine 4xx (invalid refresh token → 401) still logs at WARNING — confirms the fix doesn't silently swallow actionable signals
- [x] Full control-plane suite: 559 passed, 1 skipped (pre-existing, unrelated)
- [x] `ruff check` + `ruff format --check`: clean (pinned 0.6.9, matches CI)

(TR-63, audit #96d804dd)