### PR TITLE
fix(web-publish): stop hardcoding public Cache-Control on the assets proxy (TR-60)

### DIFF
--- a/apps/web-publish/src/routes/[slug]/_assets/[...path]/+server.ts
+++ b/apps/web-publish/src/routes/[slug]/_assets/[...path]/+server.ts
@@ -27,10 +27,18 @@ export const GET: RequestHandler = async ({ params, request, url }) => {
 	const body = await response.arrayBuffer();
 	const contentType = response.headers.get('content-type') || 'application/octet-stream';
 
-	return new Response(body, {
-		headers: {
-			'Content-Type': contentType,
-			'Cache-Control': 'public, max-age=86400'
-		}
-	});
+	// TR-60: don't hardcode a cache policy here — control-plane already sets
+	// Cache-Control based on the share's actual visibility (public shares get
+	// `public, max-age=...`; private/protected shares get none at all, see
+	// web.py's serve_web_asset). Forward whatever it decided instead of
+	// overriding it with a blanket `public`, which would let any downstream
+	// CDN/shared cache in front of this proxy serve a private asset to
+	// anyone who guesses its URL.
+	const responseHeaders: Record<string, string> = { 'Content-Type': contentType };
+	const upstreamCacheControl = response.headers.get('cache-control');
+	if (upstreamCacheControl) {
+		responseHeaders['Cache-Control'] = upstreamCacheControl;
+	}
+
+	return new Response(body, { headers: responseHeaders });
 };

--- a/apps/web-publish/src/tests/assetsProxy.test.ts
+++ b/apps/web-publish/src/tests/assetsProxy.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { GET } from '../routes/[slug]/_assets/[...path]/+server.js';
+
+// TR-60: the proxy used to hardcode `Cache-Control: public, max-age=86400`
+// on every asset response regardless of the share's actual visibility —
+// control-plane already decides the right policy (public shares get
+// `public, max-age=...`; private/protected shares get none at all). These
+// tests pin that the proxy now forwards whatever control-plane decided
+// instead of overriding it.
+
+function makeEvent(cacheControlFromCp: string | null, overrides: Record<string, string> = {}) {
+	const upstreamHeaders = new Headers({ 'content-type': 'image/png' });
+	if (cacheControlFromCp !== null) {
+		upstreamHeaders.set('cache-control', cacheControlFromCp);
+	}
+
+	vi.stubGlobal(
+		'fetch',
+		vi.fn(() =>
+			Promise.resolve(
+				new Response(new ArrayBuffer(4), {
+					status: 200,
+					headers: upstreamHeaders
+				})
+			)
+		)
+	);
+
+	return {
+		params: { slug: 'test-slug', path: 'image.png' },
+		request: new Request('http://localhost/test-slug/_assets/image.png', {
+			headers: overrides
+		}),
+		url: new URL('http://localhost/test-slug/_assets/image.png')
+	};
+}
+
+describe('GET /[slug]/_assets/[...path] — Cache-Control forwarding (TR-60)', () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("forwards control-plane's public Cache-Control unchanged (public share, no regression)", async () => {
+		const event = makeEvent('public, max-age=86400');
+		const response = await GET(event as never);
+
+		expect(response.headers.get('Cache-Control')).toBe('public, max-age=86400');
+	});
+
+	it('does NOT set Cache-Control at all when control-plane sets none (private/protected share)', async () => {
+		const event = makeEvent(null);
+		const response = await GET(event as never);
+
+		expect(response.headers.has('Cache-Control')).toBe(false);
+	});
+
+	it('never falls back to a hardcoded public directive when upstream omits one', async () => {
+		const event = makeEvent(null);
+		const response = await GET(event as never);
+
+		const cacheControl = response.headers.get('Cache-Control');
+		expect(cacheControl === null || !cacheControl.includes('public')).toBe(true);
+	});
+
+	it('forwards a private/no-store directive verbatim if control-plane ever sends one', async () => {
+		const event = makeEvent('private, no-store');
+		const response = await GET(event as never);
+
+		expect(response.headers.get('Cache-Control')).toBe('private, no-store');
+	});
+
+	it('still sets Content-Type from the upstream response', async () => {
+		const event = makeEvent('public, max-age=86400');
+		const response = await GET(event as never);
+
+		expect(response.headers.get('Content-Type')).toBe('image/png');
+	});
+});


### PR DESCRIPTION
## Summary

- `/[slug]/_assets/[...path]/+server.ts` unconditionally set `Cache-Control: public, max-age=86400` on every asset response, regardless of the share's actual visibility.
- Control-plane (`serve_web_asset`, `web.py`) already decides the right policy — public shares get `public, max-age=86400`; private/protected shares get **no** `Cache-Control` at all — but the proxy discarded that and substituted its own blanket `public` on top.
- Not currently exploited (edge Caddy in front of this proxy doesn't cache), but a defense-in-depth regression: any future CDN/shared cache placed in front of `tr.entire.vc`/`docs.entire.vc` would silently start caching private assets as if they were public — same risk class as the PRIVATE web-publish auth contract work (PRs #55/#56/#59).
- Fix: forward whatever `Cache-Control` control-plane's response actually carries (or omit the header entirely if it didn't set one) instead of overriding it. No behavior change for public shares; private/protected shares now correctly carry no public-caching directive.

## Test plan
- [x] 5 new tests in `src/tests/assetsProxy.test.ts`: public `Cache-Control` forwarded unchanged, no `Cache-Control` set when upstream sets none, never falls back to a hardcoded `public` directive, a `private, no-store` directive forwarded verbatim if control-plane ever sends one, `Content-Type` still set correctly
- [x] Full web-publish suite: 59/59 passing; `svelte-check`: 0 errors/warnings
- [ ] Live curl on a real private asset before/after — deferred to post-deploy, matching this repo's established pattern for prior TR-* fixes (TR-13/TR-22/TR-38) where live verification happens as part of Daedalus's batched deploy pass, not pre-merge

(TR-60, audit #96d804dd)