### PR TITLE
fix(migrations): merge TR-06 + branding-logo alembic heads (deploy blocker)

### DIFF
--- a/apps/control-plane/app/db/migrations/versions/202607240001_merge_tr06_and_branding_heads.py
+++ b/apps/control-plane/app/db/migrations/versions/202607240001_merge_tr06_and_branding_heads.py
@@ -1,0 +1,34 @@
+"""Merge the TR-06 admin_login_pending_tokens head with the branding-logo head.
+
+Two revisions both descend from 202607210001, creating two alembic heads:
+
+  * 202607210002 (TR-06, #113) — add admin_login_pending_tokens
+  * 202607220002 (branding-logo absolute-URL, #141) — currently the deployed
+    DB head
+
+TR-06's migration was authored off a base that predated the branding-logo
+migrations, so when #113 merged it branched the graph. `alembic upgrade head`
+(singular, as the control-plane-migrate service runs) fails on multiple heads.
+This no-op merge unifies them back to a single head so the standard deploy
+applies 202607210002 cleanly on top of the current 202607220002 DB state.
+
+Revision ID: 202607240001
+Revises: 202607210002, 202607220002
+Create Date: 2026-07-24 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+revision: str = "202607240001"
+down_revision: Union[str, Sequence[str], None] = ("202607210002", "202607220002")
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## Summary
Deploy-blocker fix, prerequisite for shipping the TR-06/13/14 security wave (#113, #116, #119).

After #113 (TR-06) merged, the alembic graph has **two heads**:
- `202607210002` — TR-06 admin_login_pending_tokens (new)
- `202607220002` — branding-logo absolute-URL (current deployed DB head)

Both descend from `202607210001`. The `control-plane-migrate` service runs `alembic upgrade head` (singular), which **fails on multiple heads** → migrate service fails → control-plane won't start. TR-06 was authored off a base predating the branding migrations, so it branched the graph on merge.

This adds a standard no-op merge migration (`202607240001`, `down_revision = (202607210002, 202607220002)`) unifying the heads to one. Verified locally: heads go from 2 → 1. No schema change.

## Test plan
- `alembic heads` returns a single head (`202607240001`)
- `alembic upgrade head` on the current `202607220002` DB applies `202607210002` (creates admin_login_pending_tokens) + the no-op merge, cleanly
- CI green (test-python runs migrations)