### PR TITLE
fix(control-plane): default expires_at when invite creation omits/nulls it

### DIFF
--- a/apps/control-plane/app/core/config.py
+++ b/apps/control-plane/app/core/config.py
@@ -199,6 +199,16 @@ class Settings(BaseSettings):
             "(TR-45) — matches the prod-DB-password rotation cadence used elsewhere."
         ),
     )
+    invite_default_ttl_days: int = Field(
+        default=30,
+        description=(
+            "Default expiry applied when a caller omits/nulls expires_in_days at "
+            "invite creation (TR security-tail follow-up to TR-45) — the schema's "
+            "own default of 7 only fires when the field is absent from the request "
+            "body; a caller that sends an explicit null bypasses it and the invite "
+            "was left with no expiry at all."
+        ),
+    )
 
     # Data retention (TR-48): email_queue/webhook_deliveries accumulate PII
     # (recipient addresses, full HTML bodies, webhook payloads) with no purge —

--- a/apps/control-plane/app/services/invite_service.py
+++ b/apps/control-plane/app/services/invite_service.py
@@ -9,6 +9,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session, joinedload
 
 from app.core import security
+from app.core.config import get_settings
 from app.db import models
 from app.schemas import invite as invite_schema
 from app.schemas import user as user_schema
@@ -43,10 +44,17 @@ def create_invite(
     # Verify share exists (raises 404 if not found)
     share_service.get_share(db, share_id)
 
-    # Calculate expiration
-    expires_at = None
+    # Calculate expiration. The schema's own default (7) only applies when the
+    # field is absent from the request body — a caller that sends an explicit
+    # null (or 0) bypasses it, which is how invites ended up with no expiry at
+    # all. Apply a config-driven default in that case too (mirrors TR-45's
+    # agent-key fix in app/api/routers/agent_keys.py).
     if payload.expires_in_days:
         expires_at = security.utcnow() + timedelta(days=payload.expires_in_days)
+    else:
+        expires_at = security.utcnow() + timedelta(
+            days=get_settings().invite_default_ttl_days
+        )
 
     # Generate unique token
     token = generate_secure_token()

--- a/apps/control-plane/app/services/invite_service.py
+++ b/apps/control-plane/app/services/invite_service.py
@@ -52,9 +52,7 @@ def create_invite(
     if payload.expires_in_days:
         expires_at = security.utcnow() + timedelta(days=payload.expires_in_days)
     else:
-        expires_at = security.utcnow() + timedelta(
-            days=get_settings().invite_default_ttl_days
-        )
+        expires_at = security.utcnow() + timedelta(days=get_settings().invite_default_ttl_days)
 
     # Generate unique token
     token = generate_secure_token()

--- a/apps/control-plane/tests/test_invites.py
+++ b/apps/control-plane/tests/test_invites.py
@@ -107,6 +107,30 @@ class TestInviteCreation:
         assert invite["role"] == "viewer"
         assert invite["max_uses"] is None  # Unlimited uses
 
+    def test_create_invite_explicit_null_expires_in_days_gets_default(
+        self, client: TestClient
+    ):
+        """A caller sending expires_in_days: null bypasses the schema's own
+        default of 7 (only applied when the field is absent) — this must
+        still land on the config default, not on no expiry at all."""
+        admin_token = login(client, "bootstrap@example.com", "super-secret")
+
+        share_resp = client.post(
+            "/shares",
+            json={"kind": "doc", "path": "vault/test.md", "visibility": "private"},
+            headers=auth_headers(admin_token),
+        )
+        share_id = share_resp.json()["id"]
+
+        invite_resp = client.post(
+            f"/shares/{share_id}/invites",
+            json={"expires_in_days": None},
+            headers=auth_headers(admin_token),
+        )
+        assert invite_resp.status_code == 201
+        invite = invite_resp.json()
+        assert invite["expires_at"] is not None
+
 
 class TestInviteListing:
     """Tests for listing invite links."""

--- a/apps/control-plane/tests/test_invites.py
+++ b/apps/control-plane/tests/test_invites.py
@@ -107,9 +107,7 @@ class TestInviteCreation:
         assert invite["role"] == "viewer"
         assert invite["max_uses"] is None  # Unlimited uses
 
-    def test_create_invite_explicit_null_expires_in_days_gets_default(
-        self, client: TestClient
-    ):
+    def test_create_invite_explicit_null_expires_in_days_gets_default(self, client: TestClient):
         """A caller sending expires_in_days: null bypasses the schema's own
         default of 7 (only applied when the field is absent) — this must
         still land on the config default, not on no expiry at all."""


### PR DESCRIPTION
## Summary
- `InviteCreate.expires_in_days` defaults to 7, but that Pydantic default only fires when the field is absent from the request body — a caller sending an explicit `null` bypasses it, leaving `expires_at = None` permanently.
- Confirmed live in prod: an invite created 2026-07-22 (after TR-45 shipped) has no expiry — the invite-creation path never applies a fallback default at all.
- Mirrors the TR-45 agent-key fix (`app/api/routers/agent_keys.py`): apply a config-driven default (`invite_default_ttl_days`, 30d) whenever `expires_in_days` is falsy, not just when the field is omitted.

## Test plan
- [x] New regression test `test_create_invite_explicit_null_expires_in_days_gets_default` reproduces the exact bug (explicit `expires_in_days: null`) and asserts `expires_at` is set.
- [x] `pytest tests/test_invites.py` — 26 passed.
- [x] Full suite: `pytest` — 633 passed, 1 pre-existing skip.

Part of the TR security-tail follow-up.