### PR TITLE
feat(billing): port enterprise billing router+migrations onto OSS main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,10 +36,21 @@ concurrency:
 
 jobs:
   deploy:
-    # OSS deploy to prod is DISABLED — prod control-plane is built from relay-onprem-enterprise
-    # (enterprise edition with billing_enabled). The OSS source hardcodes edition=community which
-    # breaks the billing button in the plugin. Re-enable only when the OSS and enterprise
-    # migration trees are reconciled. See Mesh task e5b4a3d6 for context.
+    # OSS deploy to prod is DISABLED — not because of an edition mismatch (that's
+    # resolved as of TR·edition/billing #f75f04bb: this repo's main IS what's live
+    # on tr-relay-vm, edition=enterprise with billing_enabled, verified by byte-diffing
+    # /opt/relay/control-plane-src against this repo — the old "built from
+    # relay-onprem-enterprise" claim here was already stale/wrong before that fix, see
+    # episode-gandalf-2026-07-24-tr20-live-deploy-verify), but because this job cannot
+    # actually run: tr-relay-vm (10.10.10.40) is reachable only via ProxyJump through
+    # hel01 on the private Helsinki network, `ubuntu-latest` GitHub-hosted runners have
+    # no path to it, there are zero self-hosted runners on this repo, and zero of the
+    # TW_RELAY_* secrets this job needs are configured (`gh secret list` returns empty).
+    # Every recent fix (TR-03/20/22/39/45/55/60...) ships via the documented manual path
+    # instead: `docs/DEPLOY.md` / `scripts/deploy.sh` run by hand over SSH through the
+    # ProxyJump alias. Re-enabling this job for real needs a self-hosted runner (or a
+    # bastion) that can reach the private network, plus the TW_RELAY_* secrets — that's
+    # a standalone infra task, not something to flip live without a working target.
     if: ${{ false }}
     runs-on: ubuntu-latest
     environment: production

--- a/apps/control-plane/app/api/routers/billing.py
+++ b/apps/control-plane/app/api/routers/billing.py
@@ -1,0 +1,294 @@
+"""Billing API endpoints for plugin consumption."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+from sqlalchemy.orm import Session
+
+from app.api import deps
+from app.clients.billing_client import BillingServiceError
+from app.core.config import get_settings
+from app.core.logging import get_logger
+from app.db import models
+from app.db.session import get_db
+from app.services import billing_service
+from app.services.instance_settings_service import get_branding
+
+logger = get_logger(__name__)
+
+router = APIRouter(prefix="/billing", tags=["billing"])
+
+# Public router for billing callback (SSR page)
+callback_router = APIRouter(prefix="/billing", tags=["billing"])
+
+# Templates for SSR
+templates = Jinja2Templates(directory="app/templates")
+
+
+def _get_casdoor_id(db: Session, user: models.User) -> str:
+    """Get Casdoor UUID for a user (for billing API calls)."""
+    if user.casdoor_id:
+        return user.casdoor_id
+    # Fallback: look up in oauth_accounts
+    oauth = db.query(models.UserOAuthAccount).filter_by(user_id=user.id).first()
+    if oauth:
+        return oauth.provider_user_id
+    return str(user.id)
+
+
+@router.get("/plan")
+async def get_billing_plan(
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(deps.get_current_user),
+):
+    """Get current user's billing plan with usage info.
+
+    Returns plan details, entitlements, and current usage metrics.
+    """
+    settings = get_settings()
+    if not settings.billing_enabled:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Billing is not enabled",
+        )
+
+    casdoor_id = _get_casdoor_id(db, current_user)
+    return await billing_service.get_billing_plan(casdoor_id, db, current_user.id)
+
+
+@router.get("/plans")
+async def get_billing_plans():
+    """Get available billing plans.
+
+    Returns all plans with their entitlements for the upgrade UI.
+    No authentication required.
+    """
+    settings = get_settings()
+    if not settings.billing_enabled:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Billing is not enabled",
+        )
+
+    plans = await billing_service.get_available_plans()
+    return {"plans": plans}
+
+
+@router.post("/checkout")
+async def create_checkout(
+    payload: dict,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(deps.get_current_user),
+):
+    """Create a checkout session for upgrading to a paid plan.
+
+    Expects payload with:
+    - product_id: Product ID to purchase
+    - price_id: Price ID (optional)
+
+    Returns checkout URL and subscription ID.
+    """
+    settings = get_settings()
+    if not settings.billing_enabled:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Billing is not enabled",
+        )
+
+    casdoor_id = _get_casdoor_id(db, current_user)
+    try:
+        return await billing_service.create_checkout_session(casdoor_id, payload, db, current_user)
+    except BillingServiceError as e:
+        if 400 <= e.status < 500:
+            logger.warning("Billing client error in create_checkout: %s", e)
+            raise HTTPException(status_code=e.status, detail=e.message)
+        logger.exception("Billing service error in create_checkout")
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Billing service unavailable",
+        )
+
+
+@router.post("/change-plan")
+async def change_plan(
+    payload: dict,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(deps.get_current_user),
+):
+    """Change plan on an existing subscription.
+
+    Expects payload with:
+    - product_id: New product ID
+    - price_id: New price ID
+
+    Returns updated subscription info.
+    """
+    settings = get_settings()
+    if not settings.billing_enabled:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Billing is not enabled",
+        )
+
+    product_id = payload.get("product_id")
+    price_id = payload.get("price_id")
+    if not product_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="product_id is required",
+        )
+    if not price_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="price_id is required",
+        )
+
+    casdoor_id = _get_casdoor_id(db, current_user)
+    try:
+        return await billing_service.change_subscription_plan(
+            casdoor_id,
+            current_user.billing_subscription_id,
+            product_id,
+            price_id,
+        )
+    except BillingServiceError as e:
+        if 400 <= e.status < 500:
+            logger.warning("Billing client error in change_plan: %s", e)
+            raise HTTPException(status_code=e.status, detail=e.message)
+        logger.exception("Billing service error in change_plan")
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Billing service unavailable",
+        )
+
+
+@router.post("/cancel")
+async def cancel_subscription(
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(deps.get_current_user),
+):
+    """Cancel current subscription.
+
+    User will retain access until end of billing period (grace period).
+    """
+    settings = get_settings()
+    if not settings.billing_enabled:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Billing is not enabled",
+        )
+
+    casdoor_id = _get_casdoor_id(db, current_user)
+    try:
+        return await billing_service.cancel_user_subscription(
+            casdoor_id, current_user.billing_subscription_id
+        )
+    except BillingServiceError as e:
+        if 400 <= e.status < 500:
+            logger.warning("Billing client error in cancel_subscription: %s", e)
+            raise HTTPException(status_code=e.status, detail=e.message)
+        logger.exception("Billing service error in cancel_subscription")
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Billing service unavailable",
+        )
+
+
+@router.post("/portal")
+async def create_portal_session(
+    payload: dict = {},
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(deps.get_current_user),
+):
+    """Create a Stripe Customer Portal session for subscription management.
+
+    Allows users to manage payment methods, view invoices, change plans.
+    Returns a portal_url to open in browser.
+
+    Optional payload:
+    - return_url: URL to redirect to after portal session
+    """
+    settings = get_settings()
+    if not settings.billing_enabled:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Billing is not enabled",
+        )
+
+    casdoor_id = _get_casdoor_id(db, current_user)
+    return_url = payload.get("return_url") or settings.billing_return_url or ""
+
+    try:
+        return await billing_service.create_portal_session(casdoor_id, return_url)
+    except BillingServiceError as e:
+        if 400 <= e.status < 500:
+            logger.warning("Billing client error in create_portal_session: %s", e)
+            raise HTTPException(status_code=e.status, detail=e.message)
+        logger.exception("Billing service error in create_portal_session")
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Billing service unavailable",
+        )
+    except Exception:
+        logger.exception("Unexpected error in create_portal_session")
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Billing service unavailable",
+        )
+
+
+# Billing callback page (SSR) - no auth required, user comes from Stripe
+@callback_router.get("/callback", response_class=HTMLResponse)
+async def billing_callback(
+    request: Request,
+    db: Session = Depends(get_db),
+    status: Optional[str] = Query(None, description="Payment status (legacy parameter)"),
+    payment_status: Optional[str] = Query(None, description="Payment status from Stripe"),
+    session_id: Optional[str] = Query(None, description="Stripe checkout session ID (legacy)"),
+    subscription_id: Optional[str] = Query(None, description="Stripe subscription ID"),
+):
+    """Billing callback page shown after Stripe checkout completes.
+
+    This is an SSR page that redirects the user back to the Obsidian plugin
+    via deep link (obsidian://evc-team-relay/billing-ok).
+
+    Query params from Stripe redirect (v4.1):
+    - payment_status: success | cancelled | (other) [NEW]
+    - subscription_id: Stripe subscription ID [NEW]
+
+    Legacy params (backward compat):
+    - status: success | canceled | (other)
+    - session_id: Stripe checkout session ID
+
+    No authentication required - user just came from Stripe.
+    """
+    branding = get_branding(db)
+
+    # Use payment_status if provided, otherwise fall back to status
+    final_status = payment_status or status
+
+    # Map Stripe's "cancelled" (double-l) to "canceled" (single-l) for template consistency
+    if final_status == "cancelled":
+        final_status = "canceled"
+
+    # Default to 'unknown' if no status provided
+    if not final_status:
+        final_status = "unknown"
+
+    # Prefer subscription_id (new) over session_id (legacy)
+    final_id = subscription_id or session_id
+
+    return templates.TemplateResponse(
+        request=request,
+        name="billing_callback.html",
+        context={
+            "branding": branding,
+            "status": final_status,
+            "session_id": final_id,  # Template still uses session_id for display
+            "subscription_id": final_id,
+        },
+    )

--- a/apps/control-plane/app/api/routers/billing_webhooks.py
+++ b/apps/control-plane/app/api/routers/billing_webhooks.py
@@ -1,0 +1,162 @@
+"""Billing Service webhook receiver."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import time
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.core.config import get_settings
+from app.core.logging import get_logger
+from app.db import models
+from app.db.session import get_db
+from app.services import audit_service, billing_service
+
+logger = get_logger(__name__)
+
+router = APIRouter(prefix="/v1/billing", tags=["billing"])
+
+
+def _verify_webhook_signature(body: bytes, signature: str, timestamp: str) -> bool:
+    """Verify HMAC-SHA256 webhook signature."""
+    settings = get_settings()
+    secret = settings.billing_webhook_secret
+    if not secret:
+        logger.warning("Billing webhook secret not configured, rejecting webhook")
+        return False
+
+    # Check timestamp freshness (reject if older than 5 minutes)
+    try:
+        ts = int(timestamp)
+        if abs(time.time() - ts) > 300:
+            return False
+    except (ValueError, TypeError):
+        return False
+
+    # Compute expected signature
+    message = f"{timestamp}.{body.decode('utf-8')}"
+    expected = hmac.new(
+        secret.encode("utf-8"),
+        message.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+
+    return hmac.compare_digest(expected, signature)
+
+
+_EVENT_TO_AUDIT: dict[str, models.AuditAction | None] = {
+    "subscription.created": models.AuditAction.BILLING_SUBSCRIPTION_CREATED,
+    "subscription.updated": models.AuditAction.BILLING_SUBSCRIPTION_UPDATED,
+    "subscription.renewed": models.AuditAction.BILLING_SUBSCRIPTION_UPDATED,
+    "subscription.cancelled": models.AuditAction.BILLING_SUBSCRIPTION_CANCELLED,
+    "subscription.expired": models.AuditAction.BILLING_SUBSCRIPTION_CANCELLED,
+    "subscription.activated": models.AuditAction.BILLING_SUBSCRIPTION_ACTIVATED,
+    "subscription.payment_failed": models.AuditAction.BILLING_PAYMENT_FAILED,
+    "payment.succeeded": None,  # Acknowledge without audit log
+}
+
+
+@router.post("/webhooks", status_code=status.HTTP_200_OK)
+async def billing_webhook(
+    request: Request,
+    db: Session = Depends(get_db),
+):
+    """Receive billing webhooks from Billing Service.
+
+    Verifies HMAC signature, deduplicates events, invalidates entitlements cache,
+    and creates audit log entries.
+    """
+    settings = get_settings()
+    if not settings.billing_enabled:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Billing is not enabled",
+        )
+
+    # Get headers
+    signature = request.headers.get("X-Webhook-Signature", "")
+    timestamp = request.headers.get("X-Webhook-Timestamp", "")
+    event_id = request.headers.get("X-Webhook-Id", "")
+
+    if not event_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Missing X-Webhook-Id header",
+        )
+
+    # Read body
+    body = await request.body()
+
+    # Verify signature
+    if not _verify_webhook_signature(body, signature, timestamp):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid webhook signature",
+        )
+
+    # Dedup check
+    existing = db.execute(
+        select(models.BillingWebhookEvent).where(models.BillingWebhookEvent.event_id == event_id)
+    ).scalar_one_or_none()
+
+    if existing:
+        logger.info("Duplicate webhook event, skipping", extra={"event_id": event_id})
+        return {"status": "ok", "duplicate": True}
+
+    # Parse payload
+    import json
+
+    payload = json.loads(body)
+    event_type = payload.get("event", "")
+    data = payload.get("data", {})
+    user_id = data.get("user_id", "")
+    subscription_id = data.get("subscription_id", "")
+
+    # C-08: Use canonical event_id from header only (body ID ignored for dedup)
+    # If body has a different ID, log warning but use header ID consistently
+
+    # Invalidate entitlements cache
+    if user_id:
+        billing_service.invalidate_cache(user_id)
+
+    # Store subscription_id on user if provided
+    if user_id and subscription_id:
+        user = db.execute(
+            select(models.User).where(models.User.casdoor_id == user_id)
+        ).scalar_one_or_none()
+        if user:
+            user.billing_subscription_id = subscription_id
+            db.commit()
+
+    # Create audit log entry
+    audit_action = _EVENT_TO_AUDIT.get(event_type)
+    if audit_action:
+        audit_service.log_action(
+            db=db,
+            action=audit_action,
+            details={
+                "event_id": event_id,
+                "event_type": event_type,
+                "user_id": user_id,
+                "subscription_id": subscription_id,
+            },
+        )
+
+    # Record processed event (dedup) — always use canonical header event_id
+    webhook_event = models.BillingWebhookEvent(
+        event_id=event_id,
+        event_type=event_type,
+    )
+    db.add(webhook_event)
+    db.commit()
+
+    logger.info(
+        "Processed billing webhook",
+        extra={"event_id": event_id, "event_type": event_type, "user_id": user_id},
+    )
+
+    return {"status": "ok"}

--- a/apps/control-plane/app/api/routers/server.py
+++ b/apps/control-plane/app/api/routers/server.py
@@ -20,6 +20,7 @@ class ServerFeatures(BaseModel):
     admin_ui: bool = True
     oauth_enabled: bool = False
     oauth_provider: str | None = None
+    billing_enabled: bool = False
     web_publish_enabled: bool = False
     web_publish_domain: str | None = None
 
@@ -67,11 +68,12 @@ def get_server_info(db: Session = Depends(get_db)) -> ServerInfo:
         id=server_id,
         name=settings.server_name,
         version=settings.api_version,
-        edition="community",  # OSS edition; Enterprise will override this
+        edition="enterprise",
         relay_url=str(settings.relay_public_url).rstrip("/"),
         features=ServerFeatures(
             oauth_enabled=settings.oauth_enabled,
             oauth_provider=settings.oauth_provider_name if settings.oauth_enabled else None,
+            billing_enabled=settings.billing_enabled,
             web_publish_enabled=settings.web_publish_enabled,
             web_publish_domain=settings.web_publish_domain,
         ),

--- a/apps/control-plane/app/clients/billing_client.py
+++ b/apps/control-plane/app/clients/billing_client.py
@@ -1,0 +1,196 @@
+"""Async httpx client for Billing Service API."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from app.core.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class BillingServiceError(Exception):
+    """Error from Billing Service API."""
+
+    # Human-readable fallback messages for common HTTP status codes
+    _STATUS_MESSAGES: dict[int, str] = {
+        400: "Invalid request",
+        401: "Billing authentication failed",
+        403: "Billing access denied",
+        404: "Billing resource not found",
+        409: "Active subscription already exists",
+        422: "Invalid billing data",
+        429: "Too many billing requests, try again later",
+    }
+
+    def __init__(self, code: str, message: str, status: int, details: dict | None = None):
+        self.code = code
+        self.message = message
+        self.status = status
+        self.details = details or {}
+        super().__init__(f"[{code}] {message}")
+
+
+def _parse_billing_error(e: httpx.HTTPStatusError) -> BillingServiceError:
+    """Parse httpx error into BillingServiceError with clean messages."""
+    try:
+        body = e.response.json() if e.response.content else {}
+    except Exception:
+        body = {}
+
+    # Log raw response for debugging
+    logger.debug("Billing API error response (status=%s): %s", e.response.status_code, body)
+
+    # Support both {"error": {"code": ..., "message": ...}} and FastAPI {"detail": ...} formats
+    err = body.get("error", {})
+    code = err.get("code", "UNKNOWN")
+
+    # Try multiple message sources: error.message, detail string, detail[0].msg
+    message = err.get("message")
+    if not message:
+        detail = body.get("detail")
+        if isinstance(detail, str):
+            message = detail
+        elif isinstance(detail, list) and detail:
+            # FastAPI validation error format: [{"msg": "...", "loc": [...]}]
+            message = detail[0].get("msg", "")
+
+    message = message or BillingServiceError._STATUS_MESSAGES.get(
+        e.response.status_code, f"Billing error ({e.response.status_code})"
+    )
+    return BillingServiceError(
+        code=code,
+        message=message,
+        status=e.response.status_code,
+        details=err.get("details"),
+    )
+
+
+class BillingClient:
+    """Async client for Billing Service API."""
+
+    def __init__(self, base_url: str, service_token: str):
+        self._client = httpx.AsyncClient(
+            base_url=base_url,
+            headers={
+                "Authorization": f"Bearer {service_token}",
+                "X-Service-Id": "relay",
+                "Content-Type": "application/json",
+            },
+            timeout=httpx.Timeout(connect=5.0, read=30.0, write=10.0, pool=5.0),
+            limits=httpx.Limits(max_keepalive_connections=0),
+        )
+
+    async def get_entitlements(self, user_id: str) -> dict[str, Any]:
+        """Get user entitlements from Billing Service."""
+        try:
+            resp = await self._client.get(f"/entitlements/{user_id}/relay")
+            resp.raise_for_status()
+            return resp.json()
+        except httpx.HTTPStatusError as e:
+            raise _parse_billing_error(e) from e
+
+    async def get_products(self) -> dict[str, Any]:
+        """Get available products/plans from Billing Service."""
+        try:
+            resp = await self._client.get(
+                "/products",
+                params={"service_id": "relay"},
+            )
+            resp.raise_for_status()
+            return resp.json()
+        except httpx.HTTPStatusError as e:
+            raise _parse_billing_error(e) from e
+
+    async def create_subscription(self, payload: dict[str, Any]) -> dict[str, Any]:
+        """Create a subscription/checkout session for a user.
+
+        Args:
+            payload: Dict with service_id, product_id, price_id, return_url,
+                    idempotency_key, metadata (optional)
+
+        Returns:
+            Dict with checkout_url and subscription_id
+        """
+        try:
+            resp = await self._client.post("/subscriptions", json=payload)
+            resp.raise_for_status()
+            return resp.json()
+        except httpx.HTTPStatusError as e:
+            raise _parse_billing_error(e) from e
+
+    async def change_plan(
+        self,
+        subscription_id: str,
+        product_id: str,
+        price_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Change plan on an existing subscription.
+
+        Args:
+            subscription_id: Current subscription ID
+            product_id: New product to switch to
+            price_id: New price ID (optional, Billing Service picks default)
+
+        Returns:
+            Dict with updated subscription info
+        """
+        payload: dict[str, Any] = {
+            "new_product_id": product_id,
+            "new_price_id": price_id or "",
+        }
+        try:
+            resp = await self._client.post(
+                f"/subscriptions/{subscription_id}/change-plan",
+                json=payload,
+            )
+            resp.raise_for_status()
+            return resp.json()
+        except httpx.HTTPStatusError as e:
+            raise _parse_billing_error(e) from e
+
+    async def cancel_subscription(self, subscription_id: str) -> dict[str, Any]:
+        """Cancel active subscription.
+
+        Args:
+            subscription_id: Subscription ID to cancel
+
+        Returns:
+            Dict with status and message
+        """
+        try:
+            resp = await self._client.post(f"/subscriptions/{subscription_id}/cancel")
+            resp.raise_for_status()
+            return resp.json()
+        except httpx.HTTPStatusError as e:
+            raise _parse_billing_error(e) from e
+
+    async def create_portal_session(self, user_id: str, return_url: str) -> dict[str, Any]:
+        """Create a Stripe Customer Portal session for a user.
+
+        Args:
+            user_id: Casdoor user ID
+            return_url: URL to return to after portal session
+
+        Returns:
+            Dict with portal_url
+        """
+        try:
+            resp = await self._client.post(
+                "/portal-sessions",
+                json={
+                    "user_id": user_id,
+                    "service_id": "relay",
+                    "return_url": return_url,
+                },
+            )
+            resp.raise_for_status()
+            return resp.json()
+        except httpx.HTTPStatusError as e:
+            raise _parse_billing_error(e) from e
+
+    async def close(self) -> None:
+        """Close the underlying HTTP client."""
+        await self._client.aclose()

--- a/apps/control-plane/app/clients/storage_client.py
+++ b/apps/control-plane/app/clients/storage_client.py
@@ -1,0 +1,50 @@
+"""MinIO storage client for calculating per-user storage usage."""
+
+from __future__ import annotations
+
+from minio import Minio
+
+from app.core.config import get_settings
+from app.core.logging import get_logger
+
+logger = get_logger(__name__)
+
+# Singleton client
+_client: Minio | None = None
+
+
+def _get_client() -> Minio:
+    """Get or create singleton MinIO client."""
+    global _client
+    if _client is None:
+        settings = get_settings()
+        _client = Minio(
+            settings.minio_endpoint,
+            access_key=settings.minio_access_key,
+            secret_key=settings.minio_secret_key,
+            secure=settings.minio_secure,
+        )
+    return _client
+
+
+def get_objects_size(prefix: str) -> int:
+    """List objects under prefix and return total size in bytes.
+
+    Args:
+        prefix: Prefix to filter objects (e.g. "share_id/")
+
+    Returns:
+        Total size of all objects under prefix in bytes
+    """
+    settings = get_settings()
+    client = _get_client()
+    total = 0
+
+    try:
+        for obj in client.list_objects(settings.minio_bucket, prefix=prefix, recursive=True):
+            total += obj.size or 0
+    except Exception:
+        logger.exception(f"Failed to list objects under prefix {prefix}")
+        raise
+
+    return total

--- a/apps/control-plane/app/core/config.py
+++ b/apps/control-plane/app/core/config.py
@@ -131,6 +131,17 @@ class Settings(BaseSettings):
         description="Block relay token issuance for users with unverified email",
     )
 
+    # Billing integration (enterprise edition)
+    billing_enabled: bool = Field(default=False, description="Enable billing integration")
+    billing_stub_mode: bool = Field(
+        default=True, description="Use local stub instead of Billing Service"
+    )
+    billing_base_url: str = Field(default="https://billing.entire.vc/api/v1")
+    billing_service_token: str = Field(default="")
+    billing_webhook_secret: str = Field(default="")
+    billing_grace_period_days: int = Field(default=7)
+    billing_return_url: str = Field(default="", description="Return URL after checkout")
+
     # Web publishing settings
     web_publish_domain: str | None = Field(
         default=None,

--- a/apps/control-plane/app/db/migrations/versions/202607250001_reconcile_billing_pilot_schema.py
+++ b/apps/control-plane/app/db/migrations/versions/202607250001_reconcile_billing_pilot_schema.py
@@ -1,0 +1,84 @@
+"""Reconcile the 2026-02 billing-pilot schema into the OSS migration graph.
+
+TR·edition/billing (#f75f04bb): a short enterprise-only billing pilot ran
+2026-02-09/11 against this same prod database, applying schema changes from
+migration files that lived only in relay-onprem-enterprise and were never
+merged into this repo's history — the same class of gap already reconciled
+once by 202602190001_stub_prod_head. Verified live against prod (read-only,
+2026-07-24) before writing this: `users.casdoor_id`, `users.
+billing_subscription_id`, the `billing_webhook_events` table, and all 5
+`billing_*` auditaction enum labels already exist on prod exactly as defined
+below. This migration is written to be safe on BOTH prod (everything already
+present, guards make every statement a no-op) and a fresh dev/CI database
+(nothing present, guards let every statement actually create it) — a blind
+`pass` stub would leave fresh databases missing this schema entirely, which
+the OSS-only `casdoor_id` raw-SQL consumers (listmonk_service.py) and the new
+billing router both need.
+
+`casdoor_id` predates the billing pilot (down_revision 202602030003 in the
+original enterprise chain, i.e. applied first) but was never billing-specific
+in itself — it is folded in here rather than as a separate migration because
+both come from the same undocumented out-of-band deploy and both are needed
+for a consistent revision graph.
+
+Revision ID: 202607250001
+Revises: 202607210003
+Create Date: 2026-07-24 19:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "202607250001"
+down_revision: str | None = "202607210003"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # users.casdoor_id — Casdoor OAuth subject ID. Already relied upon via
+    # raw SQL by oauth_service.py/listmonk_service.py without an ORM column
+    # or migration ever existing for it in this repo.
+    op.execute("ALTER TABLE users ADD COLUMN IF NOT EXISTS casdoor_id VARCHAR(64)")
+    op.execute("CREATE UNIQUE INDEX IF NOT EXISTS ix_users_casdoor_id ON users (casdoor_id)")
+
+    # users.billing_subscription_id — Billing Service subscription ID.
+    op.execute("ALTER TABLE users ADD COLUMN IF NOT EXISTS billing_subscription_id VARCHAR(255)")
+
+    # billing_webhook_events — dedup record for processed Billing Service webhooks.
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS billing_webhook_events (
+            id UUID PRIMARY KEY,
+            event_id VARCHAR(255) NOT NULL,
+            event_type VARCHAR(100) NOT NULL,
+            processed_at TIMESTAMPTZ NOT NULL DEFAULT now()
+        )
+        """
+    )
+    op.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS ix_billing_webhook_events_event_id "
+        "ON billing_webhook_events (event_id)"
+    )
+
+    # auditaction enum — billing event labels. Must not be referenced by any
+    # row/default in this same transaction (Postgres forbids using a
+    # freshly-added enum value before the adding transaction commits) —
+    # this migration only adds the labels, nothing consumes them here.
+    op.execute("ALTER TYPE auditaction ADD VALUE IF NOT EXISTS 'billing_subscription_created'")
+    op.execute("ALTER TYPE auditaction ADD VALUE IF NOT EXISTS 'billing_subscription_updated'")
+    op.execute("ALTER TYPE auditaction ADD VALUE IF NOT EXISTS 'billing_subscription_cancelled'")
+    op.execute("ALTER TYPE auditaction ADD VALUE IF NOT EXISTS 'billing_subscription_activated'")
+    op.execute("ALTER TYPE auditaction ADD VALUE IF NOT EXISTS 'billing_payment_failed'")
+
+
+def downgrade() -> None:
+    # Postgres has no ALTER TYPE ... DROP VALUE — removing enum labels
+    # requires recreating the type. Not attempted: harmless to leave unused
+    # labels behind (same reasoning as 202607210003's downgrade).
+    op.execute("DROP TABLE IF EXISTS billing_webhook_events")
+    op.execute("ALTER TABLE users DROP COLUMN IF EXISTS billing_subscription_id")
+    op.execute("ALTER TABLE users DROP COLUMN IF EXISTS casdoor_id")

--- a/apps/control-plane/app/db/models.py
+++ b/apps/control-plane/app/db/models.py
@@ -59,6 +59,14 @@ class AuditAction(str, Enum):
     TOTP_ENABLED = "totp_enabled"
     TOTP_DISABLED = "totp_disabled"
     TOTP_BACKUP_USED = "totp_backup_used"
+    # Billing (enterprise edition) — values match the auditaction Postgres enum
+    # labels already live on prod from the 2026-02 billing pilot; see the
+    # 202607250001 reconciliation migration.
+    BILLING_SUBSCRIPTION_CREATED = "billing_subscription_created"
+    BILLING_SUBSCRIPTION_UPDATED = "billing_subscription_updated"
+    BILLING_SUBSCRIPTION_CANCELLED = "billing_subscription_cancelled"
+    BILLING_SUBSCRIPTION_ACTIVATED = "billing_subscription_activated"
+    BILLING_PAYMENT_FAILED = "billing_payment_failed"
 
 
 class OAuthProviderType(str, Enum):
@@ -111,6 +119,13 @@ class User(Base, TimestampMixin):
     totp_secret_encrypted: Mapped[str | None] = mapped_column(String(255), nullable=True)
     totp_enabled: Mapped[bool] = mapped_column(default=False, nullable=False)
     backup_codes_encrypted: Mapped[str | None] = mapped_column(String(2000), nullable=True)
+    # Casdoor subject ID — already live on prod (2026-02 pilot, raw-SQL-only
+    # consumers in oauth_service.py/listmonk_service.py predate this ORM field).
+    casdoor_id: Mapped[str | None] = mapped_column(
+        String(64), unique=True, nullable=True, index=True
+    )
+    # Billing (enterprise edition) — Billing Service subscription ID.
+    billing_subscription_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
 
     shares_owned: Mapped[list["Share"]] = relationship(
         back_populates="owner",
@@ -700,3 +715,18 @@ class ShareAgentKey(Base, TimestampMixin):
     revoked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
     share: Mapped["Share"] = relationship(back_populates="agent_keys")
+
+
+class BillingWebhookEvent(Base):
+    """Dedup record for processed Billing Service webhook events (enterprise edition)."""
+
+    __tablename__ = "billing_webhook_events"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    event_id: Mapped[str] = mapped_column(String(255), unique=True, nullable=False, index=True)
+    event_type: Mapped[str] = mapped_column(String(100), nullable=False)
+    processed_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+    )

--- a/apps/control-plane/app/main.py
+++ b/apps/control-plane/app/main.py
@@ -18,6 +18,8 @@ from app.api.routers import (
     admin_ui,
     agent_keys,
     auth,
+    billing,
+    billing_webhooks,
     dashboard,
     health,
     invites,
@@ -40,6 +42,7 @@ from app.db.session import get_sessionmaker
 from app.middleware import errors, logging
 from app.middleware.metrics import PrometheusMiddleware
 from app.services import auth_service
+from app.services.billing_service import LimitExceededError, VisibilityNotAllowedError
 from app.workers import metrics_worker, retention_worker
 
 # Rate limiter configuration
@@ -144,12 +147,17 @@ Get a token by calling `POST /auth/login` with valid credentials.
     app.add_exception_handler(SQLAlchemyError, errors.database_exception_handler)
     app.add_exception_handler(Exception, errors.general_exception_handler)
     app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+    app.add_exception_handler(LimitExceededError, errors.limit_exceeded_handler)
+    app.add_exception_handler(VisibilityNotAllowedError, errors.visibility_not_allowed_handler)
 
     # Mount static files for admin UI
     app.mount("/static", StaticFiles(directory="app/static"), name="static")
 
     # Prometheus metrics endpoint (no auth, no versioning)
     app.include_router(metrics.router)
+
+    # Billing callback page (SSR, public — no /v1 prefix, matches plugin deep-link)
+    app.include_router(billing.callback_router)
 
     # Register v1 API routers
     app.include_router(health.router, prefix="/v1")
@@ -165,10 +173,12 @@ Get a token by calling `POST /auth/login` with valid credentials.
     app.include_router(invites.public_router, prefix="/v1")  # Public invite redemption
     app.include_router(tokens.router, prefix="/v1")
     app.include_router(keys.router, prefix="/v1")
+    app.include_router(billing.router, prefix="/v1")  # Billing API (enterprise edition)
     app.include_router(web.router)  # Web publishing public API (prefix included)
     app.include_router(agent_keys.router)  # Agent key management (prefix included)
     app.include_router(webhooks.router)  # Webhooks API (prefix included)
     app.include_router(webhooks.admin_router)  # Admin webhooks API (prefix included)
+    app.include_router(billing_webhooks.router)  # Billing Service webhooks (prefix included)
     app.include_router(unsubscribe.router)  # Lifecycle email one-click unsubscribe (public)
 
     # Legacy routes (backward compatibility) - proxy to /v1 with deprecation warning
@@ -261,6 +271,17 @@ Get a token by calling `POST /auth/login` with valid credentials.
                 raise RuntimeError(
                     "MINIO_ACCESS_KEY is set to the insecure default 'minioadmin'. "
                     "Change it before running in production."
+                )
+
+    @app.on_event("startup")
+    def _validate_billing_config() -> None:
+        """M-16: require a Billing Service token once billing leaves stub mode."""
+        settings = get_settings()
+        if settings.billing_enabled and not settings.billing_stub_mode:
+            if not settings.billing_service_token:
+                raise ValueError(
+                    "BILLING_SERVICE_TOKEN is required when billing is enabled "
+                    "and stub mode is disabled."
                 )
 
     @app.on_event("startup")

--- a/apps/control-plane/app/middleware/errors.py
+++ b/apps/control-plane/app/middleware/errors.py
@@ -8,6 +8,7 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from app.core.config import get_settings
 from app.core.logging import get_logger
+from app.services.billing_service import LimitExceededError, VisibilityNotAllowedError
 
 logger = get_logger(__name__)
 
@@ -202,6 +203,48 @@ async def database_exception_handler(request: Request, exc: SQLAlchemyError) -> 
         content["error"]["details"] = str(exc)
 
     return JSONResponse(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, content=content)
+
+
+async def limit_exceeded_handler(request: Request, exc: LimitExceededError) -> JSONResponse:
+    """Handle billing limit exceeded errors."""
+    limit_messages = {
+        "max_shares": "You have reached the maximum number of shares for your plan",
+        "max_members_per_share": "You have reached the maximum number of members for this share",
+        "max_web_published": (
+            "You have reached the maximum number of web-published shares for your plan"
+        ),
+        "max_storage_bytes": "You have reached the storage limit for your plan",
+    }
+    return JSONResponse(
+        status_code=status.HTTP_403_FORBIDDEN,
+        content={
+            "error": "limit_exceeded",
+            "detail": limit_messages.get(exc.limit, f"Plan limit exceeded: {exc.limit}"),
+            "limit": exc.limit,
+            "current": exc.current,
+            "max": exc.max_value,
+            "plan": exc.plan,
+        },
+    )
+
+
+async def visibility_not_allowed_handler(
+    request: Request, exc: VisibilityNotAllowedError
+) -> JSONResponse:
+    """Handle visibility tier not allowed by plan."""
+    return JSONResponse(
+        status_code=status.HTTP_403_FORBIDDEN,
+        content={
+            "error": "visibility_not_allowed",
+            "detail": (
+                f"Visibility '{exc.visibility}' requires a higher plan. "
+                f"Your plan allows: {', '.join(exc.allowed)}"
+            ),
+            "visibility": exc.visibility,
+            "allowed": exc.allowed,
+            "plan": exc.plan,
+        },
+    )
 
 
 async def general_exception_handler(request: Request, exc: Exception) -> JSONResponse:

--- a/apps/control-plane/app/services/billing_service.py
+++ b/apps/control-plane/app/services/billing_service.py
@@ -1,0 +1,568 @@
+"""Billing service — entitlement cache, limit enforcement, plan info."""
+
+from __future__ import annotations
+
+import time
+import uuid
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from app.clients.billing_client import BillingClient, BillingServiceError
+from app.core.config import get_settings
+from app.core.logging import get_logger
+from app.services.billing_stub import (
+    _format_entitlement_value,
+    cancel_stub_subscription,
+    create_stub_checkout,
+    create_stub_portal_session,
+    get_stub_entitlements,
+    get_stub_plans,
+)
+
+logger = get_logger(__name__)
+
+# In-memory entitlements cache: {casdoor_id: (data, timestamp)}
+_entitlements_cache: dict[str, tuple[dict[str, Any], float]] = {}
+_CACHE_TTL_SECONDS = 300  # 5 minutes
+
+# Singleton billing client (lazy init)
+_billing_client: BillingClient | None = None
+
+
+def _get_limit(entitlements: dict[str, Any], key: str) -> int | None:
+    """Extract limit value from entitlements.
+
+    Supports both structured format {"limit": N} and plain int (backwards compat).
+
+    Args:
+        entitlements: Entitlements dict
+        key: Entitlement key (e.g. 'max_shares')
+
+    Returns:
+        Limit value (int) or None (unlimited)
+    """
+    value = entitlements.get(key)
+    if value is None:
+        return None
+    if isinstance(value, dict) and "limit" in value:
+        return value["limit"]
+    if isinstance(value, int):
+        return value
+    return None
+
+
+def _get_allowed_list(entitlements: dict[str, Any], key: str) -> list[str]:
+    """Extract allowed-values list from entitlements.
+
+    Supports:
+        - {"allowed": ["public", "protected"]}  (Billing Service format)
+        - ["public", "protected"]                (plain list, stub/backwards compat)
+
+    Args:
+        entitlements: Entitlements dict
+        key: Entitlement key (e.g. 'allowed_web_visibility')
+
+    Returns:
+        List of allowed values, defaults to ["public"] if missing/invalid.
+    """
+    value = entitlements.get(key)
+    if value is None:
+        return ["public"]
+    if isinstance(value, dict) and "allowed" in value:
+        return value["allowed"]
+    if isinstance(value, list):
+        return value
+    return ["public"]
+
+
+class LimitExceededError(Exception):
+    """Raised when a user exceeds their plan limit."""
+
+    def __init__(self, limit: str, current: int, max_value: int, plan: str):
+        self.limit = limit
+        self.current = current
+        self.max_value = max_value
+        self.plan = plan
+        super().__init__(f"Limit exceeded: {limit} ({current}/{max_value}) on plan {plan}")
+
+
+class VisibilityNotAllowedError(Exception):
+    """Raised when a user tries to use a visibility tier not in their plan."""
+
+    def __init__(self, visibility: str, allowed: list[str], plan: str):
+        self.visibility = visibility
+        self.allowed = allowed
+        self.plan = plan
+        super().__init__(
+            f"Visibility '{visibility}' not allowed on plan {plan}. "
+            f"Allowed: {', '.join(allowed)}"
+        )
+
+
+def _get_billing_client() -> BillingClient:
+    """Get or create singleton billing client."""
+    global _billing_client
+    if _billing_client is None:
+        settings = get_settings()
+        _billing_client = BillingClient(
+            base_url=settings.billing_base_url,
+            service_token=settings.billing_service_token,
+        )
+    return _billing_client
+
+
+async def get_entitlements_cached(casdoor_id: str) -> dict[str, Any]:
+    """Get user entitlements with 5-minute TTL cache.
+
+    Returns:
+        Dict with 'plan' and 'entitlements' keys.
+    """
+    now = time.monotonic()
+
+    # Check cache
+    cached = _entitlements_cache.get(casdoor_id)
+    if cached:
+        data, ts = cached
+        if now - ts < _CACHE_TTL_SECONDS:
+            return data
+
+    # Fetch fresh
+    settings = get_settings()
+    if settings.billing_stub_mode:
+        data = await get_stub_entitlements(casdoor_id)
+    else:
+        try:
+            client = _get_billing_client()
+            data = await client.get_entitlements(casdoor_id)
+        except BillingServiceError:
+            logger.exception("Failed to fetch entitlements from Billing Service")
+            # Fallback to cache if available, even if expired
+            if cached:
+                return cached[0]
+            # Last resort: return stub entitlements
+            data = await get_stub_entitlements(casdoor_id)
+
+    # Free tier fallback: billing returns empty entitlements for users without subscription.
+    # Apply local free-tier defaults so limits are enforced.
+    if not data.get("entitlements") and data.get("plan") in ("free", "Free", None):
+        from app.services.billing_stub import STUB_PLANS
+
+        free_ent = STUB_PLANS["free"]["entitlements"]
+        data["entitlements"] = {k: _format_entitlement_value(v) for k, v in free_ent.items()}
+
+    # Update cache
+    _entitlements_cache[casdoor_id] = (data, now)
+    return data
+
+
+def invalidate_cache(casdoor_id: str) -> None:
+    """Invalidate cached entitlements for a user (called by webhook handler)."""
+    _entitlements_cache.pop(casdoor_id, None)
+
+
+def is_in_grace_period(subscription: dict[str, Any] | None) -> bool:
+    """Check if user is in grace period after subscription expiry.
+
+    Grace period applies when:
+    - Subscription status is "cancelled"
+    - current_period_end is set
+    - Current time < current_period_end + grace_period_days
+
+    Args:
+        subscription: Subscription object with status and current_period_end
+
+    Returns:
+        True if in grace period, False otherwise
+    """
+    import datetime
+
+    if not subscription:
+        return False
+
+    status = subscription.get("status")
+    period_end_str = subscription.get("current_period_end")
+
+    if status != "cancelled" or not period_end_str:
+        return False
+
+    settings = get_settings()
+    try:
+        period_end = datetime.datetime.fromisoformat(period_end_str.replace("Z", "+00:00"))
+        grace_end = period_end + datetime.timedelta(days=settings.billing_grace_period_days)
+        return datetime.datetime.now(datetime.timezone.utc) < grace_end
+    except (ValueError, AttributeError):
+        return False
+
+
+async def check_limit(casdoor_id: str, entitlement_key: str, current_count: int) -> None:
+    """Check if current usage is within plan limits.
+
+    Accounts for grace period: if subscription is cancelled but within grace period,
+    continue using the cancelled plan's entitlements. After grace period expires,
+    fall back to Free plan limits.
+
+    Args:
+        casdoor_id: User's Casdoor UUID
+        entitlement_key: Entitlement key (e.g. 'max_shares')
+        current_count: Current usage count
+
+    Raises:
+        LimitExceededError: If the user has reached or exceeded the limit
+    """
+    data = await get_entitlements_cached(casdoor_id)
+    plan_name = data.get("plan", "Unknown")
+    subscription = data.get("subscription")
+    entitlements = data.get("entitlements", {})
+
+    # Check if in grace period
+    if (
+        subscription
+        and subscription.get("status") in ("cancelled", "expired")
+        and not is_in_grace_period(subscription)
+    ):
+        # Grace period expired, use Free plan limits
+        settings = get_settings()
+        if not settings.billing_stub_mode:
+            from app.services.billing_stub import STUB_PLANS
+
+            free_entitlements = STUB_PLANS["free"]["entitlements"]
+            entitlements = free_entitlements
+            plan_name = "Free (expired)"
+
+    max_value = _get_limit(entitlements, entitlement_key)
+
+    # None means unlimited
+    if max_value is None:
+        return
+
+    if current_count >= max_value:
+        raise LimitExceededError(
+            limit=entitlement_key,
+            current=current_count,
+            max_value=max_value,
+            plan=plan_name,
+        )
+
+
+async def check_visibility(casdoor_id: str, visibility: str) -> None:
+    """Check if a visibility tier is allowed by the user's plan.
+
+    Accounts for grace period: after grace period expires, falls back to Free plan
+    which only allows 'public'.
+
+    Args:
+        casdoor_id: User's Casdoor UUID
+        visibility: Target visibility value (e.g. 'public', 'protected', 'private')
+
+    Raises:
+        VisibilityNotAllowedError: If the visibility is not in the user's allowed list
+    """
+    data = await get_entitlements_cached(casdoor_id)
+    plan_name = data.get("plan", "Unknown")
+    subscription = data.get("subscription")
+    entitlements = data.get("entitlements", {})
+
+    # Check if grace period expired → fallback to Free plan
+    if (
+        subscription
+        and subscription.get("status") in ("cancelled", "expired")
+        and not is_in_grace_period(subscription)
+    ):
+        settings = get_settings()
+        if not settings.billing_stub_mode:
+            from app.services.billing_stub import STUB_PLANS
+
+            entitlements = STUB_PLANS["free"]["entitlements"]
+            plan_name = "Free (expired)"
+
+    allowed = _get_allowed_list(entitlements, "allowed_web_visibility")
+
+    if visibility not in allowed:
+        raise VisibilityNotAllowedError(
+            visibility=visibility,
+            allowed=allowed,
+            plan=plan_name,
+        )
+
+
+async def get_billing_plan(
+    casdoor_id: str,
+    db: Session,
+    user_id: Any,
+) -> dict[str, Any]:
+    """Get full billing plan info with usage data for /v1/billing/plan endpoint.
+
+    Args:
+        casdoor_id: User's Casdoor UUID
+        db: Database session
+        user_id: Internal user UUID
+
+    Returns:
+        Dict with plan, entitlements, and usage.
+    """
+    from app.services import usage_service
+
+    data = await get_entitlements_cached(casdoor_id)
+    entitlements = data.get("entitlements", {})
+
+    # Get current usage
+    shares_count = usage_service.count_user_shares(db, user_id)
+    web_published_count = usage_service.count_web_published(db, user_id)
+    storage_bytes = await usage_service.get_user_storage_bytes(db, user_id)
+
+    max_shares = _get_limit(entitlements, "max_shares")
+    max_web = _get_limit(entitlements, "max_web_published")
+    max_storage = _get_limit(entitlements, "max_storage_bytes")
+    allowed_visibility = _get_allowed_list(entitlements, "allowed_web_visibility")
+
+    return {
+        "plan": data.get("plan", "Unknown"),
+        "subscription": data.get("subscription"),
+        "entitlements": entitlements,
+        "allowed_web_visibility": allowed_visibility,
+        "usage": {
+            "shares": {
+                "current": shares_count,
+                "max": max_shares,
+                "percentage": (round(shares_count / max_shares * 100) if max_shares else None),
+            },
+            "web_published": {
+                "current": web_published_count,
+                "max": max_web,
+                "percentage": (round(web_published_count / max_web * 100) if max_web else None),
+            },
+            "storage": {
+                "current_bytes": storage_bytes,
+                "max_bytes": max_storage,
+                "percentage": (
+                    round(storage_bytes / max_storage * 100)
+                    if storage_bytes is not None and max_storage
+                    else None
+                ),
+            },
+        },
+    }
+
+
+async def get_available_plans() -> list[dict[str, Any]]:
+    """Get available plans for upgrade UI."""
+    settings = get_settings()
+    if settings.billing_stub_mode:
+        return await get_stub_plans()
+
+    try:
+        client = _get_billing_client()
+        result = await client.get_products()
+        return result.get("products", [])
+    except BillingServiceError:
+        logger.exception("Failed to fetch plans from Billing Service")
+        return await get_stub_plans()
+
+
+async def create_checkout_session(
+    casdoor_id: str,
+    payload: dict[str, Any],
+    db: Any,
+    user: Any,
+) -> dict[str, Any]:
+    """Create a checkout session for plan upgrade.
+
+    Args:
+        casdoor_id: User's Casdoor UUID
+        payload: Dict with product_id and optional price_id
+        db: Database session
+        user: User model instance
+
+    Returns:
+        Dict with checkout_url and subscription_id
+    """
+    settings = get_settings()
+    if settings.billing_stub_mode:
+        return await create_stub_checkout(casdoor_id, payload)
+
+    # Prepare payload with required fields
+    full_payload = {
+        "service_id": "relay",
+        "user_id": casdoor_id,
+        "product_id": payload.get("product_id"),
+        "price_id": payload.get("price_id"),
+        "return_url": settings.billing_return_url or payload.get("return_url", ""),
+        "idempotency_key": payload.get("idempotency_key") or str(uuid.uuid4()),
+        "metadata": payload.get("metadata", {}),
+    }
+
+    try:
+        client = _get_billing_client()
+        result = await client.create_subscription(full_payload)
+
+        # Store subscription_id on user
+        if result.get("id"):
+            user.billing_subscription_id = result["id"]
+            db.commit()
+
+        return result
+    except BillingServiceError:
+        logger.exception("Failed to create checkout session")
+        raise
+
+
+async def cancel_user_subscription(casdoor_id: str, subscription_id: str | None) -> dict[str, Any]:
+    """Cancel user's active subscription.
+
+    Args:
+        casdoor_id: User's Casdoor UUID
+        subscription_id: Subscription ID to cancel
+
+    Returns:
+        Dict with status and message
+    """
+    settings = get_settings()
+    if settings.billing_stub_mode:
+        return await cancel_stub_subscription(casdoor_id)
+
+    # Prefer subscription_id from Billing Service (authoritative)
+    try:
+        ent_data = await get_entitlements_cached(casdoor_id)
+        billing_sub = ent_data.get("subscription") or {}
+        fresh_sub_id = billing_sub.get("id") or ent_data.get("subscription_id")
+        if fresh_sub_id:
+            subscription_id = fresh_sub_id
+    except Exception:
+        logger.debug("Could not fetch entitlements for subscription_id lookup")
+
+    if not subscription_id:
+        raise BillingServiceError(
+            code="NO_SUBSCRIPTION",
+            message="No active subscription found",
+            status=400,
+        )
+
+    try:
+        client = _get_billing_client()
+        result = await client.cancel_subscription(subscription_id)
+        # Invalidate cache so next entitlement check fetches fresh data
+        invalidate_cache(casdoor_id)
+        return result
+    except BillingServiceError:
+        logger.exception("Failed to cancel subscription")
+        raise
+
+
+async def change_subscription_plan(
+    casdoor_id: str,
+    subscription_id: str | None,
+    product_id: str,
+    price_id: str | None = None,
+) -> dict[str, Any]:
+    """Change plan on an existing subscription.
+
+    Args:
+        casdoor_id: User's Casdoor UUID
+        subscription_id: Current subscription ID
+        product_id: New product to switch to
+        price_id: New price ID (optional)
+
+    Returns:
+        Dict with updated subscription info from Billing Service
+    """
+    settings = get_settings()
+    if settings.billing_stub_mode:
+        return {
+            "status": "changed",
+            "message": "Plan changed (stub mode)",
+            "product_id": product_id,
+        }
+
+    # Prefer subscription_id from Billing Service entitlements (authoritative source)
+    # over the potentially stale value stored in our DB.
+    try:
+        ent_data = await get_entitlements_cached(casdoor_id)
+        billing_sub = ent_data.get("subscription") or {}
+        fresh_sub_id = billing_sub.get("id") or ent_data.get("subscription_id")
+        if fresh_sub_id:
+            subscription_id = fresh_sub_id
+    except Exception:
+        logger.debug("Could not fetch entitlements for subscription_id lookup")
+
+    if not subscription_id:
+        raise BillingServiceError(
+            code="NO_SUBSCRIPTION",
+            message="No active subscription to change",
+            status=400,
+        )
+
+    try:
+        client = _get_billing_client()
+        result = await client.change_plan(subscription_id, product_id, price_id)
+        invalidate_cache(casdoor_id)
+        return result
+    except BillingServiceError:
+        logger.exception("Failed to change subscription plan")
+        raise
+
+
+async def get_usage_warnings(casdoor_id: str, db: Any, user_id: Any) -> list[str]:
+    """Get usage warnings for entitlements at >= 80% of limit.
+
+    Args:
+        casdoor_id: User's Casdoor UUID
+        db: Database session
+        user_id: Internal user UUID
+
+    Returns:
+        List of warning strings like ['shares:approaching_limit', ...]
+    """
+    from app.services import usage_service
+
+    warnings = []
+    data = await get_entitlements_cached(casdoor_id)
+    entitlements = data.get("entitlements", {})
+
+    # Check shares
+    max_shares = _get_limit(entitlements, "max_shares")
+    if max_shares:
+        shares_count = usage_service.count_user_shares(db, user_id)
+        if shares_count >= max_shares * 0.8:
+            warnings.append("shares:approaching_limit")
+
+    # Check web published
+    max_web = _get_limit(entitlements, "max_web_published")
+    if max_web:
+        web_count = usage_service.count_web_published(db, user_id)
+        if web_count >= max_web * 0.8:
+            warnings.append("web_published:approaching_limit")
+
+    # Check storage
+    max_storage = _get_limit(entitlements, "max_storage_bytes")
+    if max_storage:
+        storage_bytes = await usage_service.get_user_storage_bytes(db, user_id)
+        if storage_bytes is not None and storage_bytes >= max_storage * 0.8:
+            warnings.append("storage:approaching_limit")
+
+    # Note: members check would need share_id context, skip for now
+
+    return warnings
+
+
+async def create_portal_session(casdoor_id: str, return_url: str) -> dict[str, Any]:
+    """Create a Stripe Customer Portal session for subscription management.
+
+    Args:
+        casdoor_id: User's Casdoor UUID
+        return_url: URL to redirect to after portal session
+
+    Returns:
+        Dict with portal_url
+    """
+    settings = get_settings()
+    if settings.billing_stub_mode:
+        return await create_stub_portal_session(casdoor_id)
+
+    try:
+        client = _get_billing_client()
+        result = await client.create_portal_session(casdoor_id, return_url)
+        return result
+    except BillingServiceError:
+        logger.exception("Failed to create portal session")
+        raise

--- a/apps/control-plane/app/services/billing_stub.py
+++ b/apps/control-plane/app/services/billing_stub.py
@@ -1,0 +1,96 @@
+"""Local billing stub for development when Billing Service is not available."""
+
+from __future__ import annotations
+
+from typing import Any
+
+STUB_PLANS: dict[str, dict[str, Any]] = {
+    "free": {
+        "product_id": "prod_relay_free",
+        "name": "Relay Free",
+        "description": "For personal use",
+        "price": None,
+        "entitlements": {
+            "max_shares": 3,
+            "max_members_per_share": 3,
+            "max_web_published": 1,
+            "max_storage_bytes": 524288000,  # 500 MB
+            "allowed_web_visibility": ["public"],
+        },
+    },
+    "builder": {
+        "product_id": "prod_relay_builder",
+        "name": "Relay Builder",
+        "description": "For creators and teams",
+        "price": {"amount": 900, "currency": "USD", "period": "month"},
+        "entitlements": {
+            "max_shares": 10,
+            "max_members_per_share": 10,
+            "max_web_published": 5,
+            "max_storage_bytes": 3221225472,  # 3 GB
+            "allowed_web_visibility": ["public", "private"],
+        },
+    },
+}
+
+
+def _format_entitlement_value(value: Any) -> dict[str, Any]:
+    """Format a raw entitlement value into the API response format.
+
+    - list values → {"allowed": [...]}
+    - numeric/None values → {"limit": N}
+    """
+    if isinstance(value, list):
+        return {"allowed": value}
+    return {"limit": value}
+
+
+async def get_stub_entitlements(casdoor_id: str) -> dict[str, Any]:
+    """Return Free plan entitlements for all users in stub mode."""
+    free_plan = STUB_PLANS["free"]
+    return {
+        "plan": free_plan["name"],
+        "subscription": None,
+        "entitlements": {
+            k: _format_entitlement_value(v) for k, v in free_plan["entitlements"].items()
+        },
+    }
+
+
+async def get_stub_plans() -> list[dict[str, Any]]:
+    """Return all available plans in stub mode."""
+    return [
+        {
+            "product_id": plan["product_id"],
+            "name": plan["name"],
+            "description": plan["description"],
+            "price": plan["price"],
+            "entitlements": plan["entitlements"],
+        }
+        for plan in STUB_PLANS.values()
+    ]
+
+
+async def create_stub_checkout(casdoor_id: str, payload: dict[str, Any]) -> dict[str, Any]:
+    """Return stub checkout response (upgrade not available in stub mode)."""
+    return {
+        "checkout_url": "#stub-checkout-not-available",
+        "subscription_id": None,
+        "message": "Billing is in stub mode. Upgrade not available.",
+    }
+
+
+async def cancel_stub_subscription(casdoor_id: str) -> dict[str, Any]:
+    """Return stub cancel response (cancellation not available in stub mode)."""
+    return {
+        "status": "not_available",
+        "message": "Billing is in stub mode. Cancellation not available.",
+    }
+
+
+async def create_stub_portal_session(casdoor_id: str) -> dict[str, Any]:
+    """Return stub portal session response."""
+    return {
+        "url": None,
+        "message": "Billing is in stub mode. Portal not available.",
+    }

--- a/apps/control-plane/app/services/usage_service.py
+++ b/apps/control-plane/app/services/usage_service.py
@@ -1,0 +1,91 @@
+"""Usage counting helpers for billing limit enforcement."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+import uuid
+
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from app.clients import storage_client
+from app.core.config import get_settings
+from app.db import models
+
+
+def count_user_shares(db: Session, user_id: uuid.UUID) -> int:
+    """Count total shares owned by user."""
+    result = db.execute(select(func.count()).where(models.Share.owner_user_id == user_id))
+    return result.scalar() or 0
+
+
+def count_share_members(db: Session, share_id: uuid.UUID) -> int:
+    """Count members of a share (excluding owner)."""
+    result = db.execute(select(func.count()).where(models.ShareMember.share_id == share_id))
+    return result.scalar() or 0
+
+
+def count_web_published(db: Session, user_id: uuid.UUID) -> int:
+    """Count web-published shares owned by user."""
+    result = db.execute(
+        select(func.count()).where(
+            models.Share.owner_user_id == user_id,
+            models.Share.web_published.is_(True),
+        )
+    )
+    return result.scalar() or 0
+
+
+# In-memory storage cache: {user_id_str: (bytes, timestamp)}
+_storage_cache: dict[str, tuple[int, float]] = {}
+_STORAGE_CACHE_TTL = 900  # 15 minutes
+
+
+async def get_user_storage_bytes(db: Session, user_id: uuid.UUID) -> int | None:
+    """Calculate total storage bytes for a user from MinIO.
+
+    Args:
+        db: Database session
+        user_id: User UUID
+
+    Returns:
+        Total storage in bytes or None if MinIO not configured/unavailable
+    """
+    settings = get_settings()
+    if not settings.minio_access_key:
+        return None  # MinIO not configured
+
+    user_key = str(user_id)
+    now = time.monotonic()
+
+    # Check cache
+    cached = _storage_cache.get(user_key)
+    if cached:
+        bytes_val, ts = cached
+        if now - ts < _STORAGE_CACHE_TTL:
+            return bytes_val
+
+    # Get all shares owned by user
+    shares = (
+        db.execute(select(models.Share.id).where(models.Share.owner_user_id == user_id))
+        .scalars()
+        .all()
+    )
+
+    # Calculate storage from MinIO in background thread
+    total_bytes = 0
+    try:
+        for share_id in shares:
+            prefix = f"{share_id}/"
+            size = await asyncio.to_thread(storage_client.get_objects_size, prefix)
+            total_bytes += size
+    except Exception:
+        # MinIO unavailable — return cached value or None
+        if cached:
+            return cached[0]
+        return None
+
+    # Update cache
+    _storage_cache[user_key] = (total_bytes, now)
+    return total_bytes

--- a/apps/control-plane/app/templates/billing_callback.html
+++ b/apps/control-plane/app/templates/billing_callback.html
@@ -1,0 +1,224 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Entire VC Team Relay - Payment Complete</title>
+    <link rel="icon" type="image/svg+xml" href="/static/img/evc-ava.svg">
+    <link rel="stylesheet" href="/static/css/admin.css">
+    <style>
+        .callback-container {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            min-height: 100vh;
+            background: var(--bg-secondary);
+        }
+
+        .callback-card {
+            background: var(--bg);
+            padding: 2rem;
+            border-radius: 8px;
+            box-shadow: 0 4px 6px var(--shadow);
+            width: 100%;
+            max-width: 500px;
+            text-align: center;
+        }
+
+        .callback-brand {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 0.75rem;
+            margin-bottom: 1.5rem;
+            padding-bottom: 1rem;
+            border-bottom: 1px solid var(--border);
+        }
+
+        .callback-brand a {
+            display: flex;
+            transition: opacity 0.2s;
+        }
+
+        .callback-brand a:hover {
+            opacity: 0.8;
+        }
+
+        .callback-brand img {
+            border-radius: 8px;
+        }
+
+        .callback-brand span {
+            font-size: 1.25rem;
+            font-weight: 600;
+            color: var(--text);
+        }
+
+        .status-icon {
+            font-size: 4rem;
+            margin: 1rem 0;
+        }
+
+        .status-icon.success {
+            color: var(--success);
+        }
+
+        .status-icon.error {
+            color: var(--danger);
+        }
+
+        .status-icon.pending {
+            color: var(--warning);
+        }
+
+        .callback-card h1 {
+            margin: 0.5rem 0;
+            font-size: 1.75rem;
+        }
+
+        .callback-card p {
+            color: var(--text-muted);
+            margin: 1rem 0;
+        }
+
+        .redirect-info {
+            background: var(--bg-secondary);
+            border: 1px solid var(--border);
+            border-radius: 4px;
+            padding: 1rem;
+            margin: 1.5rem 0;
+        }
+
+        .redirect-info p {
+            margin: 0.5rem 0;
+            font-size: 0.875rem;
+        }
+
+        .loader {
+            display: inline-block;
+            width: 20px;
+            height: 20px;
+            border: 3px solid var(--border);
+            border-top-color: var(--primary);
+            border-radius: 50%;
+            animation: spin 1s linear infinite;
+            margin-left: 0.5rem;
+            vertical-align: middle;
+        }
+
+        @keyframes spin {
+            to { transform: rotate(360deg); }
+        }
+
+        .btn-full {
+            width: 100%;
+            margin-top: 1rem;
+        }
+
+        .session-id {
+            font-family: monospace;
+            font-size: 0.75rem;
+            color: var(--text-muted);
+            word-break: break-all;
+            margin-top: 1rem;
+            padding: 0.5rem;
+            background: var(--bg-secondary);
+            border-radius: 4px;
+        }
+    </style>
+</head>
+<body>
+    <div class="callback-container">
+        <div class="callback-card">
+            <div class="callback-brand">
+                <a href="/">
+                    <img src="{{ branding.logo_url if branding else '/static/img/evc-ava.svg' }}" alt="{{ branding.name if branding else 'EVC Team Relay' }}" width="40" height="40">
+                </a>
+                <span>{{ branding.name if branding else 'Team Relay' }}</span>
+            </div>
+
+            {% if status == 'success' %}
+                <div class="status-icon success">✓</div>
+                <h1>Payment Successful!</h1>
+                <p>Your subscription has been activated. Redirecting you back to Obsidian...</p>
+
+                <div class="redirect-info">
+                    <p><strong>Redirecting automatically</strong> <span class="loader"></span></p>
+                    <p style="margin-top: 0.5rem;">If the redirect doesn't work, click the button below.</p>
+                </div>
+
+                <a href="obsidian://evc-team-relay/billing-ok?status=success{% if subscription_id %}&subscription_id={{ subscription_id }}{% endif %}"
+                   class="btn btn-primary btn-full">
+                    Return to Obsidian
+                </a>
+
+                {% if subscription_id %}
+                <div class="session-id">
+                    {% if subscription_id.startswith('sub_') %}
+                    Subscription ID: {{ subscription_id }}
+                    {% else %}
+                    Session ID: {{ subscription_id }}
+                    {% endif %}
+                </div>
+                {% endif %}
+
+            {% elif status == 'canceled' %}
+                <div class="status-icon pending">⚠</div>
+                <h1>Payment Canceled</h1>
+                <p>Your payment was canceled. No charges have been made.</p>
+
+                <div class="redirect-info">
+                    <p>You can close this page and return to Obsidian to try again.</p>
+                </div>
+
+                <a href="obsidian://evc-team-relay/billing-canceled?status=canceled"
+                   class="btn btn-secondary btn-full">
+                    Return to Obsidian
+                </a>
+
+            {% elif status == 'unknown' %}
+                <div class="status-icon success">✓</div>
+                <h1>You're All Set</h1>
+                <p>You can safely close this page and return to Obsidian.</p>
+
+                <div class="redirect-info">
+                    <p>Your subscription settings are managed in the Obsidian plugin.</p>
+                </div>
+
+                <a href="obsidian://evc-team-relay/billing-ok?status=portal_return"
+                   class="btn btn-primary btn-full">
+                    Return to Obsidian
+                </a>
+
+            {% else %}
+                <div class="status-icon error">✕</div>
+                <h1>Payment Issue</h1>
+                <p>Something went wrong with your payment ({{ status }}). Please check your billing settings in Obsidian.</p>
+
+                <div class="redirect-info">
+                    <p>If you were charged but don't see your subscription, please contact support.</p>
+                </div>
+
+                <a href="obsidian://evc-team-relay/billing-error?status={{ status }}"
+                   class="btn btn-secondary btn-full">
+                    Return to Obsidian
+                </a>
+            {% endif %}
+
+            <p style="margin-top: 2rem; font-size: 0.875rem;">
+                Having trouble? <a href="mailto:support@entire.vc" style="color: var(--primary);">Contact Support</a>
+            </p>
+        </div>
+    </div>
+
+    {% if status == 'success' %}
+    <script>
+        // Auto-redirect after 2 seconds
+        setTimeout(function() {
+            const deepLinkUrl = "obsidian://evc-team-relay/billing-ok?status=success{% if subscription_id %}&subscription_id={{ subscription_id }}{% endif %}";
+            window.location.href = deepLinkUrl;
+        }, 2000);
+    </script>
+    {% endif %}
+</body>
+</html>

--- a/apps/control-plane/tests/test_billing.py
+++ b/apps/control-plane/tests/test_billing.py
@@ -542,5 +542,5 @@ class TestNonStubModeMocksExternalBillingClient:
             result = await billing_service.create_checkout_session(
                 "cid-checkout", {"product_id": "prod_relay_builder"}, _FakeDb(), _FakeUser()
             )
-            assert result["checkout_url"].startswith("https://billing.entire.vc")
+            assert result["checkout_url"] == "https://billing.entire.vc/checkout/abc"
             mock_client.create_subscription.assert_awaited_once()

--- a/apps/control-plane/tests/test_billing.py
+++ b/apps/control-plane/tests/test_billing.py
@@ -1,0 +1,546 @@
+"""Tests for the billing integration (enterprise edition, TR·edition/billing #f75f04bb).
+
+Real DB (SQLite in-memory via the shared `client`/`db_session` fixtures) and real
+billing_service/billing_stub code paths throughout — per this repo's mocking
+convention, the only TRUE external boundary is the Billing Service HTTP API
+(app.clients.billing_client.BillingClient), which is mocked only in the
+non-stub-mode tests that specifically exercise that boundary. Everything else
+(DB, router, webhook signature/dedup, entitlements cache) runs for real.
+
+Deliberately NOT covered here: shares.py limit/visibility enforcement
+(check_limit/check_visibility are ported and unit-tested directly, but no
+caller was wired into shares.py in this change — see the task comment on
+#f75f04bb for why that's a separate, product-level decision).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import os
+import time
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.core.config import get_settings
+from app.services import billing_service, billing_stub, usage_service
+
+
+def auth_headers(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def login(client: TestClient, email: str, password: str) -> str:
+    response = client.post("/auth/login", json={"email": email, "password": password})
+    assert response.status_code == 200, response.text
+    return response.json()["access_token"]
+
+
+def register_and_login(client: TestClient, email: str, password: str = "test-pass-123") -> str:
+    admin_token = login(client, "bootstrap@example.com", "super-secret")
+    resp = client.post(
+        "/admin/users",
+        json={"email": email, "password": password, "is_admin": False, "is_active": True},
+        headers=auth_headers(admin_token),
+    )
+    assert resp.status_code in (200, 201), resp.text
+    return login(client, email, password)
+
+
+@pytest.fixture(autouse=True)
+def _billing_enabled_stub_mode():
+    """Default test env for billing endpoints: enabled + stub mode (the safe default)."""
+    os.environ["BILLING_ENABLED"] = "true"
+    os.environ["BILLING_STUB_MODE"] = "true"
+    get_settings.cache_clear()
+    billing_service._entitlements_cache.clear()
+    yield
+    for key in ("BILLING_ENABLED", "BILLING_STUB_MODE", "BILLING_SERVICE_TOKEN"):
+        os.environ.pop(key, None)
+    get_settings.cache_clear()
+    billing_service._entitlements_cache.clear()
+
+
+# ---------------------------------------------------------------------------
+# billing_stub — pure unit tests, no DB
+# ---------------------------------------------------------------------------
+
+
+class TestBillingStub:
+    @pytest.mark.asyncio
+    async def test_get_stub_entitlements_returns_free_plan(self):
+        data = await billing_stub.get_stub_entitlements("any-casdoor-id")
+        assert data["plan"] == "Relay Free"
+        assert data["subscription"] is None
+        assert data["entitlements"]["max_shares"] == {"limit": 3}
+        assert data["entitlements"]["allowed_web_visibility"] == {"allowed": ["public"]}
+
+    @pytest.mark.asyncio
+    async def test_get_stub_plans_returns_both_plans(self):
+        plans = await billing_stub.get_stub_plans()
+        product_ids = {p["product_id"] for p in plans}
+        assert product_ids == {"prod_relay_free", "prod_relay_builder"}
+
+    @pytest.mark.asyncio
+    async def test_create_stub_checkout_not_available(self):
+        result = await billing_stub.create_stub_checkout(
+            "cid", {"product_id": "prod_relay_builder"}
+        )
+        assert result["subscription_id"] is None
+        assert "stub" in result["message"].lower()
+
+
+# ---------------------------------------------------------------------------
+# billing_service — limit/visibility checks, grace period (stub mode, real logic)
+# ---------------------------------------------------------------------------
+
+
+class TestLimitChecking:
+    @pytest.mark.asyncio
+    async def test_check_limit_passes_under_max(self):
+        await billing_service.check_limit("cid-under", "max_shares", current_count=2)
+
+    @pytest.mark.asyncio
+    async def test_check_limit_raises_at_max(self):
+        with pytest.raises(billing_service.LimitExceededError) as exc_info:
+            await billing_service.check_limit("cid-at-max", "max_shares", current_count=3)
+        assert exc_info.value.limit == "max_shares"
+        assert exc_info.value.max_value == 3
+        assert exc_info.value.plan == "Relay Free"
+
+    @pytest.mark.asyncio
+    async def test_check_limit_unlimited_key_never_raises(self):
+        # Unknown entitlement key -> _get_limit returns None -> unlimited
+        await billing_service.check_limit("cid-x", "nonexistent_key", current_count=999_999)
+
+
+class TestVisibilityChecking:
+    @pytest.mark.asyncio
+    async def test_check_visibility_allows_public(self):
+        await billing_service.check_visibility("cid", "public")
+
+    @pytest.mark.asyncio
+    async def test_check_visibility_rejects_private_on_free_plan(self):
+        with pytest.raises(billing_service.VisibilityNotAllowedError) as exc_info:
+            await billing_service.check_visibility("cid", "private")
+        assert exc_info.value.visibility == "private"
+        assert exc_info.value.allowed == ["public"]
+
+
+class TestEntitlementsCache:
+    @pytest.mark.asyncio
+    async def test_cache_hit_returns_same_object_within_ttl(self):
+        first = await billing_service.get_entitlements_cached("cid-cache")
+        second = await billing_service.get_entitlements_cached("cid-cache")
+        assert first is second  # served from cache, not recomputed
+
+    @pytest.mark.asyncio
+    async def test_invalidate_cache_forces_refetch(self):
+        first = await billing_service.get_entitlements_cached("cid-inval")
+        billing_service.invalidate_cache("cid-inval")
+        second = await billing_service.get_entitlements_cached("cid-inval")
+        assert first is not second
+
+
+class TestGracePeriod:
+    def test_no_subscription_not_in_grace(self):
+        assert billing_service.is_in_grace_period(None) is False
+
+    def test_active_subscription_not_in_grace(self):
+        assert billing_service.is_in_grace_period({"status": "active"}) is False
+
+    def test_cancelled_within_grace_window(self):
+        import datetime
+
+        now = datetime.datetime.now(datetime.timezone.utc)
+        period_end = (now - datetime.timedelta(days=1)).isoformat()
+        sub = {"status": "cancelled", "current_period_end": period_end}
+        assert billing_service.is_in_grace_period(sub) is True
+
+    def test_cancelled_past_grace_window(self):
+        import datetime
+
+        period_end = (
+            datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=30)
+        ).isoformat()
+        sub = {"status": "cancelled", "current_period_end": period_end}
+        assert billing_service.is_in_grace_period(sub) is False
+
+
+# ---------------------------------------------------------------------------
+# usage_service — real DB counts
+# ---------------------------------------------------------------------------
+
+
+class TestUsageCounting:
+    def test_count_user_shares(self, client: TestClient, db_session):
+        from app.db import models
+
+        token = register_and_login(client, "usage-shares@example.com")
+        client.post("/shares", json={"kind": "doc", "path": "a.md"}, headers=auth_headers(token))
+        client.post("/shares", json={"kind": "doc", "path": "b.md"}, headers=auth_headers(token))
+
+        user = db_session.query(models.User).filter_by(email="usage-shares@example.com").one()
+        assert usage_service.count_user_shares(db_session, user.id) == 2
+
+    def test_count_web_published_excludes_unpublished(self, client: TestClient, db_session):
+        from app.db import models
+
+        token = register_and_login(client, "usage-web@example.com")
+        client.post(
+            "/shares", json={"kind": "doc", "path": "unpub.md"}, headers=auth_headers(token)
+        )
+
+        user = db_session.query(models.User).filter_by(email="usage-web@example.com").one()
+        assert usage_service.count_web_published(db_session, user.id) == 0
+
+
+# ---------------------------------------------------------------------------
+# Billing disabled -> every /billing/* endpoint 404s (feature-flagged off)
+# ---------------------------------------------------------------------------
+
+
+class TestBillingDisabled:
+    def test_billing_endpoints_404_when_disabled(self, client: TestClient):
+        os.environ["BILLING_ENABLED"] = "false"
+        get_settings.cache_clear()
+        try:
+            token = register_and_login(client, "disabled-billing@example.com")
+            assert client.get("/v1/billing/plan", headers=auth_headers(token)).status_code == 404
+            assert client.get("/v1/billing/plans").status_code == 404
+            checkout_resp = client.post(
+                "/v1/billing/checkout", json={}, headers=auth_headers(token)
+            )
+            assert checkout_resp.status_code == 404
+        finally:
+            os.environ["BILLING_ENABLED"] = "true"
+            get_settings.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# /v1/billing/plan, /plans, /checkout, /cancel, /portal (stub mode)
+# ---------------------------------------------------------------------------
+
+
+class TestBillingPlanEndpoint:
+    def test_get_billing_plan_returns_usage_and_entitlements(self, client: TestClient):
+        token = register_and_login(client, "plan-endpoint@example.com")
+        client.post("/shares", json={"kind": "doc", "path": "p.md"}, headers=auth_headers(token))
+
+        resp = client.get("/v1/billing/plan", headers=auth_headers(token))
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["plan"] == "Relay Free"
+        assert data["usage"]["shares"]["current"] == 1
+        assert data["usage"]["shares"]["max"] == 3
+
+    def test_get_billing_plan_requires_auth(self, client: TestClient):
+        assert client.get("/v1/billing/plan").status_code == 401
+
+
+class TestBillingPlansEndpoint:
+    def test_get_billing_plans_is_public(self, client: TestClient):
+        resp = client.get("/v1/billing/plans")
+        assert resp.status_code == 200
+        assert len(resp.json()["plans"]) == 2
+
+
+class TestCheckoutEndpoint:
+    def test_checkout_stub_mode_returns_not_available(self, client: TestClient):
+        token = register_and_login(client, "checkout@example.com")
+        resp = client.post(
+            "/v1/billing/checkout",
+            json={"product_id": "prod_relay_builder"},
+            headers=auth_headers(token),
+        )
+        assert resp.status_code == 200
+        assert resp.json()["subscription_id"] is None
+
+
+class TestCancelEndpoint:
+    def test_cancel_stub_mode_returns_not_available(self, client: TestClient):
+        token = register_and_login(client, "cancel@example.com")
+        resp = client.post("/v1/billing/cancel", headers=auth_headers(token))
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "not_available"
+
+
+class TestPortalEndpoint:
+    def test_portal_stub_mode(self, client: TestClient):
+        token = register_and_login(client, "portal@example.com")
+        resp = client.post("/v1/billing/portal", json={}, headers=auth_headers(token))
+        assert resp.status_code == 200
+        assert resp.json()["url"] is None
+
+
+# ---------------------------------------------------------------------------
+# GET /billing/callback (public SSR page)
+# ---------------------------------------------------------------------------
+
+
+class TestBillingCallback:
+    def test_callback_success_status(self, client: TestClient):
+        resp = client.get("/billing/callback?payment_status=success&subscription_id=sub_123")
+        assert resp.status_code == 200
+        assert "sub_123" in resp.text
+
+    def test_callback_no_params_defaults_unknown(self, client: TestClient):
+        resp = client.get("/billing/callback")
+        assert resp.status_code == 200
+
+    def test_callback_legacy_cancelled_maps_to_canceled(self, client: TestClient):
+        resp = client.get("/billing/callback?status=cancelled")
+        assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# POST /v1/billing/webhooks
+# ---------------------------------------------------------------------------
+
+
+def _sign(body: bytes, secret: str, timestamp: str) -> str:
+    message = f"{timestamp}.{body.decode('utf-8')}"
+    return hmac.new(secret.encode(), message.encode(), hashlib.sha256).hexdigest()
+
+
+class TestBillingWebhook:
+    SECRET = "test-webhook-secret"
+
+    @pytest.fixture(autouse=True)
+    def _webhook_secret(self):
+        os.environ["BILLING_WEBHOOK_SECRET"] = self.SECRET
+        get_settings.cache_clear()
+        yield
+        os.environ.pop("BILLING_WEBHOOK_SECRET", None)
+        get_settings.cache_clear()
+
+    def _post_webhook(self, client: TestClient, payload: dict, event_id: str | None = None):
+        import json
+
+        body = json.dumps(payload).encode()
+        ts = str(int(time.time()))
+        event_id = event_id or str(uuid.uuid4())
+        headers = {
+            "X-Webhook-Signature": _sign(body, self.SECRET, ts),
+            "X-Webhook-Timestamp": ts,
+            "X-Webhook-Id": event_id,
+            "Content-Type": "application/json",
+        }
+        return client.post("/v1/billing/webhooks", content=body, headers=headers), event_id
+
+    def test_missing_event_id_rejected(self, client: TestClient):
+        resp = client.post(
+            "/v1/billing/webhooks",
+            content=b"{}",
+            headers={"X-Webhook-Signature": "x", "X-Webhook-Timestamp": str(int(time.time()))},
+        )
+        assert resp.status_code == 400
+
+    def test_bad_signature_rejected(self, client: TestClient):
+        resp = client.post(
+            "/v1/billing/webhooks",
+            content=b"{}",
+            headers={
+                "X-Webhook-Signature": "bad-signature",
+                "X-Webhook-Timestamp": str(int(time.time())),
+                "X-Webhook-Id": str(uuid.uuid4()),
+            },
+        )
+        assert resp.status_code == 401
+
+    def test_stale_timestamp_rejected(self, client: TestClient):
+        body = b"{}"
+        old_ts = str(int(time.time()) - 600)  # 10 minutes old, > 5-minute window
+        resp = client.post(
+            "/v1/billing/webhooks",
+            content=body,
+            headers={
+                "X-Webhook-Signature": _sign(body, self.SECRET, old_ts),
+                "X-Webhook-Timestamp": old_ts,
+                "X-Webhook-Id": str(uuid.uuid4()),
+            },
+        )
+        assert resp.status_code == 401
+
+    def test_valid_webhook_processed_and_deduped(self, client: TestClient, db_session):
+        from app.db import models
+
+        resp1, event_id = self._post_webhook(
+            client, {"event": "subscription.created", "data": {"user_id": "casdoor-abc"}}
+        )
+        assert resp1.status_code == 200
+        assert resp1.json()["duplicate"] is False if "duplicate" in resp1.json() else True
+
+        # Replay same event_id -> dedup, no second audit log
+        resp2, _ = self._post_webhook(
+            client,
+            {"event": "subscription.created", "data": {"user_id": "casdoor-abc"}},
+            event_id=event_id,
+        )
+        assert resp2.status_code == 200
+        assert resp2.json()["duplicate"] is True
+
+        count = db_session.query(models.BillingWebhookEvent).filter_by(event_id=event_id).count()
+        assert count == 1
+
+    def test_webhook_creates_audit_log(self, client: TestClient, db_session):
+        from app.db import models
+
+        _, event_id = self._post_webhook(
+            client, {"event": "subscription.activated", "data": {"user_id": "casdoor-audit"}}
+        )
+        audit = (
+            db_session.query(models.AuditLog)
+            .filter_by(action=models.AuditAction.BILLING_SUBSCRIPTION_ACTIVATED)
+            .first()
+        )
+        assert audit is not None
+
+    def test_webhook_stores_subscription_id_on_user(self, client: TestClient, db_session):
+        from app.db import models
+
+        token = register_and_login(client, "webhook-user@example.com")
+        user = db_session.query(models.User).filter_by(email="webhook-user@example.com").one()
+        user.casdoor_id = "casdoor-webhook-user"
+        db_session.commit()
+
+        self._post_webhook(
+            client,
+            {
+                "event": "subscription.created",
+                "data": {"user_id": "casdoor-webhook-user", "subscription_id": "sub_xyz"},
+            },
+        )
+
+        db_session.refresh(user)
+        assert user.billing_subscription_id == "sub_xyz"
+
+    def test_no_secret_configured_rejects_all(self, client: TestClient):
+        os.environ.pop("BILLING_WEBHOOK_SECRET", None)
+        get_settings.cache_clear()
+        try:
+            body = b"{}"
+            ts = str(int(time.time()))
+            resp = client.post(
+                "/v1/billing/webhooks",
+                content=body,
+                headers={
+                    "X-Webhook-Signature": "irrelevant",
+                    "X-Webhook-Timestamp": ts,
+                    "X-Webhook-Id": str(uuid.uuid4()),
+                },
+            )
+            assert resp.status_code == 401
+        finally:
+            os.environ["BILLING_WEBHOOK_SECRET"] = self.SECRET
+            get_settings.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# server/info — billing_enabled feature flag + enterprise edition
+# ---------------------------------------------------------------------------
+
+
+class TestServerInfoBilling:
+    def test_billing_enabled_true_when_configured(self, client: TestClient):
+        resp = client.get("/server/info")
+        assert resp.status_code == 200
+        assert resp.json()["edition"] == "enterprise"
+        assert resp.json()["features"]["billing_enabled"] is True
+
+    def test_billing_enabled_false_by_default(self, client: TestClient):
+        os.environ["BILLING_ENABLED"] = "false"
+        get_settings.cache_clear()
+        try:
+            resp = client.get("/server/info")
+            assert resp.json()["features"]["billing_enabled"] is False
+        finally:
+            os.environ["BILLING_ENABLED"] = "true"
+            get_settings.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# casdoor_id resolution fallback (_get_casdoor_id)
+# ---------------------------------------------------------------------------
+
+
+class TestCasdoorId:
+    def test_uses_user_casdoor_id_when_set(self, client: TestClient, db_session):
+        from app.db import models
+
+        token = register_and_login(client, "casdoor-direct@example.com")
+        user = db_session.query(models.User).filter_by(email="casdoor-direct@example.com").one()
+        user.casdoor_id = "direct-casdoor-id"
+        db_session.commit()
+
+        resp = client.get("/v1/billing/plan", headers=auth_headers(token))
+        assert resp.status_code == 200
+
+    def test_falls_back_to_user_id_when_no_oauth(self, client: TestClient):
+        # No casdoor_id, no oauth account -> falls back to str(user.id), must not crash.
+        token = register_and_login(client, "casdoor-fallback@example.com")
+        resp = client.get("/v1/billing/plan", headers=auth_headers(token))
+        assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Non-stub mode — BillingClient is the true external boundary, mocked here.
+# ---------------------------------------------------------------------------
+
+
+class TestNonStubModeMocksExternalBillingClient:
+    @pytest.fixture(autouse=True)
+    def _non_stub(self):
+        os.environ["BILLING_STUB_MODE"] = "false"
+        os.environ["BILLING_SERVICE_TOKEN"] = "test-service-token"
+        get_settings.cache_clear()
+        billing_service._billing_client = None
+        yield
+        os.environ["BILLING_STUB_MODE"] = "true"
+        os.environ.pop("BILLING_SERVICE_TOKEN", None)
+        get_settings.cache_clear()
+        billing_service._billing_client = None
+
+    @pytest.mark.asyncio
+    async def test_get_entitlements_falls_back_to_stub_on_billing_service_error(self):
+        from app.clients.billing_client import BillingServiceError
+
+        with patch.object(
+            billing_service,
+            "_get_billing_client",
+        ) as mock_get_client:
+            mock_client = AsyncMock()
+            mock_client.get_entitlements.side_effect = BillingServiceError(
+                code="UPSTREAM_DOWN", message="unavailable", status=502
+            )
+            mock_get_client.return_value = mock_client
+
+            data = await billing_service.get_entitlements_cached("cid-nonstub-fallback")
+            # Billing Service failed -> falls back to stub entitlements, does not raise.
+            assert data["plan"] in ("Relay Free", "Unknown")
+
+    @pytest.mark.asyncio
+    async def test_create_checkout_session_calls_billing_client(self):
+        with patch.object(billing_service, "_get_billing_client") as mock_get_client:
+            mock_client = AsyncMock()
+            mock_client.create_subscription.return_value = {
+                "checkout_url": "https://billing.entire.vc/checkout/abc",
+                "id": "sub_new",
+            }
+            mock_get_client.return_value = mock_client
+
+            class _FakeUser:
+                billing_subscription_id = None
+
+            class _FakeDb:
+                def commit(self):
+                    pass
+
+            result = await billing_service.create_checkout_session(
+                "cid-checkout", {"product_id": "prod_relay_builder"}, _FakeDb(), _FakeUser()
+            )
+            assert result["checkout_url"].startswith("https://billing.entire.vc")
+            mock_client.create_subscription.assert_awaited_once()

--- a/apps/control-plane/tests/test_server_info.py
+++ b/apps/control-plane/tests/test_server_info.py
@@ -17,7 +17,7 @@ def test_server_info_returns_metadata(client):
     assert "name" in data
     assert "version" in data
     assert "edition" in data
-    assert data["edition"] == "community"  # OSS edition
+    assert data["edition"] == "enterprise"  # TR·edition/billing (#f75f04bb)
     assert "relay_url" in data
     assert "features" in data
     assert "branding" in data
@@ -31,6 +31,8 @@ def test_server_info_returns_metadata(client):
     # OAuth disabled by default
     assert features["oauth_enabled"] is False
     assert features["oauth_provider"] is None
+    # Billing disabled by default (BILLING_ENABLED unset in test env)
+    assert features["billing_enabled"] is False
 
     # Check branding structure
     branding = data["branding"]


### PR DESCRIPTION
## Что и зачем

Исполнение Pavel-decision «включить billing сейчас». Портирует billing-код из `relay-onprem-enterprise` на текущий OSS `main` вместо того чтобы деплоить отдельный устаревший форк.

- `billing_service`/`billing_stub`/`usage_service`, `billing_client` (клиент к Billing Service — единственная true external boundary), `/v1/billing/*` роутер + webhook-приёмник, SSR billing-callback страница.
- `server.py`: `edition="enterprise"` + новый `billing_enabled` feature-флаг.
- Новая миграция `202607250001`: живой прод уже несёт схему Feb-2026 billing pilot (`casdoor_id`, `billing_subscription_id`, `billing_webhook_events`, 5 enum-лейблов) применённую out-of-band — проверено read-only на проде перед написанием. Миграция идемпотентна: no-op на проде, реальный CREATE на свежей dev/CI базе. Протестирована и upgrade, и downgrade на чистом Postgres 16 (тот же образ, что в CI `check-migration-drift`) — не вносит новый drift (только уже существующий, помеченный `continue-on-error` в CI).
- Исправлен stale-комментарий в `deploy.yml` (ссылался на решённый теперь edition-mismatch; реальная причина, почему job выключен — GitHub-hosted раннеры не достают до приватной сети tr-relay-vm, секретов деплоя тоже нет).

## Осознанно НЕ входит в этот PR

**Enforcement лимитов в `shares.py`** — в enterprise-версии `check_limit`/`check_visibility` вызываются из shares-роутера (лимит на shares/members/web-published/visibility). Портировать это значило бы **начать резать всех текущих прод-юзеров под Free-tier лимиты** (3 shares, 3 members, 1 web-published) в момент деплоя — это не «включить billing API», а самостоятельное продуктовое решение с реальным юзер-visible эффектом. `check_limit`/`check_visibility` портированы и протестированы как функции, но никто их не вызывает.

**Admin UI billing-stats страница** — не было в списке файлов задачи, не покрыто AC.

## Тесты

39 новых тестов (`tests/test_billing.py`), реальная БД (SQLite in-memory, стандартная конвенция репозитория), мок только на `BillingClient` (true external boundary) в non-stub-mode кейсах. Полный сьют: 672 passed, 1 skipped, 0 failed (было 632 passed, 1 failed — единственный existing-тест ожидаемо ловил старый `edition="community"`, поправлен).

## Что дальше (после мерджа)

Деплой на прод — через уже существующий проверенный ручной путь (`docs/DEPLOY.md`/`scripts/deploy.sh` по SSH через `tr-relay-vm`), как все недавние TR-фиксы. Автоматический GH Actions деплой остаётся выключен — для него нужен self-hosted runner/bastion с доступом в приватную Helsinki-сеть + секреты, это отдельная инфра-задача, не блокер для этого PR.