### PR TITLE
feat(deploy): add web-publish to scripts/deploy.sh

### DIFF
--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -13,13 +13,18 @@ pulled from a registry.
 > it is not a deploy target. Do not `ssh tw-relay` and run the deploy recipe there.
 
 The `control-plane-migrate` service in `docker-compose.yml` is the **fail-closed gate**: it runs
-`alembic upgrade head` and must exit 0 before `control-plane` (or any worker) starts.
+`alembic upgrade head` and must exit 0 before `control-plane` (or any worker) starts. `web-publish`
+has no migrations, so its deploy skips straight to build + restart.
 
-Two ways to deploy:
-- **[Automated (GitHub Actions)](#automated-deploy-github-actions)** — the default path. Push to
-  `main` (or manual dispatch) runs the gated sequence on `tr-relay-vm`.
-- **[Manual (SSH)](#manual-upgrade-fallback)** — the emergency fallback, also the underlying
-  procedure the pipeline automates.
+Three ways to deploy:
+- **[Automated (GitHub Actions)](#automated-deploy-github-actions)** — control-plane only, and
+  currently disabled (`if: false`, see below). Push to `main` would run the gated sequence on
+  `tr-relay-vm`.
+- **[`scripts/deploy.sh` from a local checkout](#scriptsdeploysh-local-driver)** — the normal path
+  today for both components. Run it from your machine; it rsyncs the source and runs the same
+  build/gate/restart logic on `tr-relay-vm` over SSH.
+- **[Manual (SSH)](#manual-upgrade-fallback)** — the emergency fallback when you're already on the
+  box, or want to run the steps by hand.
 
 ---
 
@@ -80,6 +85,46 @@ environment, which also lets you add a manual-approval protection rule):
 
 ---
 
+## `scripts/deploy.sh` (local driver)
+
+Since the GitHub Actions job is disabled, this is the day-to-day way to ship both
+**control-plane** and **web-publish** — it covers what the Actions workflow above would have
+automated. Run it from a local checkout; it has access to `tr-relay-vm` via the same
+`ProxyJump hel01` alias your `~/.ssh/config` already uses for manual SSH.
+
+```bash
+bash scripts/deploy.sh control-plane   # control-plane + workers (migration gate + edition smoke gate)
+bash scripts/deploy.sh web-publish     # web-publish only (no migrations, no edition gate)
+bash scripts/deploy.sh all             # both, control-plane first
+bash scripts/deploy.sh                 # defaults to control-plane
+```
+
+**What it does**, per component, when `$RELAY_DIR` (default `/opt/relay`) doesn't exist locally
+(i.e. you're not already on the server): rsyncs `apps/<component>/` →
+`tr-relay-vm:/opt/relay/<component>-src/`, then re-invokes itself over SSH on `tr-relay-vm` to run
+the actual build/gate/restart — the exact same server-side logic the (disabled) Actions workflow
+used to run, unified into one script instead of split between a CI rsync step and this script.
+
+- **control-plane**: tag `:prev` → `docker build` → migration gate (fail-closed) →
+  `compose up -d --force-recreate` → health check → edition smoke gate (auto-rolls back on
+  failure). Unchanged from before this script covered web-publish too.
+- **web-publish**: tag `:prev` → `docker build --secret id=github_token,...` (the Dockerfile's
+  `npm ci` needs a GitHub token for scoped package installs; taken from `$GITHUB_TOKEN` in your
+  shell, or read from `tr-relay-vm:/opt/relay/.env` if unset) → `compose up -d --force-recreate` →
+  health check. No migration gate — web-publish has no migrations — and no edition smoke gate,
+  that check is control-plane/billing-specific.
+
+`DRY_RUN=true bash scripts/deploy.sh <component>` builds the image and runs the migration gate
+(control-plane only) but stops before `compose up` — use it to rehearse before a real deploy.
+`SSH_TARGET` overrides the remote host (default `tr-relay-vm`) if you're ever deploying elsewhere.
+
+If you're **already SSH'd into `tr-relay-vm`** with the source already synced, running the script
+there directly (`RELAY_DIR=/opt/relay bash -s -- web-publish < scripts/deploy.sh`, or just running
+a copy of it on the box) skips the rsync/re-invoke step and goes straight to build/restart — that's
+"direct mode", same as how the Actions workflow always invoked it.
+
+---
+
 ## Manual upgrade (fallback)
 
 Use this when CI is unavailable or for an emergency hotfix. It is the same sequence the
@@ -112,9 +157,33 @@ migration failure prevents the app from starting.
 > **Never** run `docker run infra-control-plane:latest` directly — it bypasses the compose
 > dependency graph and the migration gate.
 
+### web-publish
+
+No migration gate — there's nothing to migrate. Source lives in `/opt/relay/web-publish-src/`,
+kept in sync the same way as `control-plane-src/` (rsync from a local checkout, or
+`scripts/deploy.sh web-publish`, which is the recommended path over doing this by hand).
+
+```bash
+# 1. SSH to server
+ssh tr-relay-vm
+cd /opt/relay
+
+# 2. Tag the current image BEFORE overwriting (enables fast rollback)
+docker tag infra-web-publish:latest infra-web-publish:prev
+
+# 3. Build new image — the Dockerfile's `npm ci` needs GITHUB_TOKEN as a BuildKit secret
+GITHUB_TOKEN=$(grep -m1 '^GITHUB_TOKEN=' .env | cut -d= -f2-)
+docker build --secret id=github_token,env=GITHUB_TOKEN -t infra-web-publish:latest web-publish-src/
+
+# 4. Restart
+docker compose up -d --force-recreate web-publish
+```
+
 ---
 
 ## Rollback
+
+**control-plane:**
 
 ```bash
 # 1. Stop app services (keep postgres and minio running — do NOT stop the DB)
@@ -129,6 +198,14 @@ docker compose run --rm control-plane-migrate python -m alembic downgrade <safe-
 
 # 4. Restart with restored image
 docker compose up -d control-plane webhook-worker email-worker
+```
+
+**web-publish** (no migrations to revert):
+
+```bash
+docker compose stop web-publish
+docker tag infra-web-publish:prev infra-web-publish:latest
+docker compose up -d web-publish
 ```
 
 ---
@@ -184,8 +261,11 @@ The same `service_completed_successfully` guard applies to `webhook-worker` and 
   repo's `infra/docker-compose.yml` is the `build:`-context variant of the same gate. The deploy
   pipeline deliberately syncs **only** `apps/control-plane/` → `control-plane-src/` and leaves
   the server's compose file and `.env` alone.
-- **web-publish / relay-server** are not (re)built by the deploy pipeline — it covers the
-  control-plane and its workers only. Rebuild those manually if their source changes.
+- **web-publish** is covered by `scripts/deploy.sh web-publish` (see above) — merges to
+  `apps/web-publish/` do NOT deploy themselves; someone has to run the script. This was a real gap
+  (task `c3f38d9a`): three merged fixes sat undeployed for up to 3 days because nothing rebuilt the
+  container. **relay-server** (the Rust Yjs relay, separate repo `evc-relay-server`) is still not
+  covered by anything here — rebuild it manually if its source changes.
 - **`infra/Caddyfile` is host-managed and NOT synced by the deploy pipeline** (same gap as the
   compose file above). A fix applied here must ALSO be applied live on `tr-relay-vm`
   (`/opt/relay/Caddyfile`, content-preserving write + `caddy validate` + `caddy reload` inside
@@ -221,8 +301,9 @@ The same `service_completed_successfully` guard applies to `webhook-worker` and 
 ## References
 
 - `CLAUDE-workflow.md §1b` — shared deploy-discipline rule (migration before code, always)
-- `.github/workflows/deploy.yml` — automated deploy pipeline (gated)
-- `scripts/deploy.sh` — on-server build → migrate-gate → restart logic
+- `.github/workflows/deploy.yml` — automated deploy pipeline (control-plane only, currently gated off)
+- `scripts/deploy.sh` — rsync (driver mode) → build → migrate-gate (control-plane only) → restart,
+  for both control-plane and web-publish
 - `infra/docker-compose.yml` — dev/local compose template (build-context variant of same gate)
 - `apps/control-plane/app/db/migrations/versions/` — Alembic migration files
 - `apps/control-plane/alembic.ini` — Alembic configuration

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,106 +1,215 @@
 #!/usr/bin/env bash
 #
-# Team Relay — remote deploy script (runs ON tw-relay)
+# Team Relay — deploy script. Covers control-plane (+ its workers) and web-publish.
 #
-# Enforces CLAUDE-workflow.md §1b Deploy Discipline: the migration gate runs and
-# must succeed BEFORE any app container is (re)started. A failed migration aborts
-# the deploy — the running app is left untouched. Fail-closed, never the reverse.
+# Enforces CLAUDE-workflow.md §1b Deploy Discipline: control-plane's migration gate
+# runs and must succeed BEFORE the app container is (re)started. A failed migration
+# aborts the deploy — the running app is left untouched. Fail-closed, never the
+# reverse. web-publish has no migrations, so it skips straight to build+restart.
 #
-# Invoked by .github/workflows/deploy.yml as:  ssh <host> 'bash -s' < scripts/deploy.sh
-# after the workflow has rsynced apps/control-plane/ -> $RELAY_DIR/control-plane-src/.
+# Two invocation shapes, auto-detected via whether $RELAY_DIR exists locally:
+#
+#   1. Driver mode (local checkout, e.g. `bash scripts/deploy.sh web-publish`):
+#      rsyncs apps/<component>/ -> $SSH_TARGET:$RELAY_DIR/<component>-src/, then
+#      re-invokes this same script over SSH on $SSH_TARGET (default tr-relay-vm).
+#   2. Direct mode (running ON the deploy host, e.g. .github/workflows/deploy.yml's
+#      `ssh <host> 'bash -s' < scripts/deploy.sh`, or a human already ssh'd in):
+#      assumes the relevant *-src/ dir is already synced and runs build+deploy.
+#
+# Usage:
+#   bash scripts/deploy.sh [control-plane|web-publish|all]   # default: control-plane
 #
 # Env (all optional, sane prod defaults):
-#   RELAY_DIR   deploy root on the server                (default /opt/relay)
-#   IMAGE       local image tag built from the source    (default infra-control-plane:latest)
-#   DRY_RUN     if "true", run the migrate gate but DO NOT restart the app (rehearsal)
+#   RELAY_DIR          deploy root on the server                    (default /opt/relay)
+#   SSH_TARGET          ssh alias/host used in driver mode            (default tr-relay-vm)
+#   IMAGE               control-plane image tag                      (default infra-control-plane:latest)
+#   WEB_PUBLISH_IMAGE   web-publish image tag                        (default infra-web-publish:latest)
+#   GITHUB_TOKEN         BuildKit secret for web-publish's `npm ci`   (else read from $RELAY_DIR/.env)
+#   DRY_RUN             if "true": run gates/build but do NOT restart (rehearsal)
 #
 set -euo pipefail
 
 RELAY_DIR="${RELAY_DIR:-/opt/relay}"
 IMAGE="${IMAGE:-infra-control-plane:latest}"
+WEB_PUBLISH_IMAGE="${WEB_PUBLISH_IMAGE:-infra-web-publish:latest}"
 DRY_RUN="${DRY_RUN:-false}"
+COMPONENT="${1:-${COMPONENT:-control-plane}}"
 
 log() { printf '\n\033[1;36m==> %s\033[0m\n' "$*"; }
 die() { printf '\n\033[1;31m!! %s\033[0m\n' "$*" >&2; exit 1; }
 
+case "$COMPONENT" in
+  control-plane|web-publish|all) ;;
+  *) die "unknown component '$COMPONENT' (expected control-plane|web-publish|all)" ;;
+esac
+
+# --- Driver mode ------------------------------------------------------------
+# $RELAY_DIR (default /opt/relay) only exists on the deploy host itself, so its
+# absence here means we're running from a local checkout, not on the server.
+if [ ! -d "$RELAY_DIR" ]; then
+  SSH_TARGET="${SSH_TARGET:-tr-relay-vm}"
+  SCRIPT_PATH="${BASH_SOURCE[0]}"
+  REPO_ROOT="$(cd "$(dirname "$SCRIPT_PATH")/.." && pwd)"
+
+  sync_component() {
+    log "syncing apps/$1/ -> $SSH_TARGET:$RELAY_DIR/$1-src/"
+    rsync -az --delete -e ssh "$REPO_ROOT/apps/$1/" "$SSH_TARGET:$RELAY_DIR/$1-src/"
+  }
+
+  case "$COMPONENT" in
+    control-plane) sync_component control-plane ;;
+    web-publish)   sync_component web-publish ;;
+    all)           sync_component control-plane; sync_component web-publish ;;
+  esac
+
+  log "invoking remote deploy on $SSH_TARGET (component=$COMPONENT)"
+  exec ssh "$SSH_TARGET" \
+    "RELAY_DIR='$RELAY_DIR' DRY_RUN='$DRY_RUN' bash -s -- '$COMPONENT'" \
+    < "$SCRIPT_PATH"
+fi
+
+# --- Direct mode (we ARE the deploy host) ------------------------------------
 cd "$RELAY_DIR" || die "deploy root $RELAY_DIR not found on this host"
-[ -d control-plane-src ] || die "control-plane-src/ missing in $RELAY_DIR — source sync did not run"
 [ -f docker-compose.yml ] || die "docker-compose.yml missing in $RELAY_DIR"
 
-# 1. Tag the current image for fast rollback (skip on first-ever deploy).
-if docker image inspect "$IMAGE" >/dev/null 2>&1; then
-  log "tagging current image -> infra-control-plane:prev (rollback point)"
-  docker tag "$IMAGE" infra-control-plane:prev
-else
-  log "no existing $IMAGE — first deploy, nothing to tag for rollback"
-fi
+deploy_control_plane() {
+  local image="$IMAGE"
 
-# 2. Build the new image from the freshly-synced source.
-log "building $IMAGE from control-plane-src/"
-docker build -t "$IMAGE" control-plane-src/
+  [ -d control-plane-src ] || die "control-plane-src/ missing in $RELAY_DIR — source sync did not run"
 
-# 3. Migration gate — FAIL-CLOSED.
-#    docker compose run returns the migrate container's exit code; alembic failure
-#    => non-zero => we abort here and the app is NEVER restarted.
-#
-#    -T:        disable pseudo-TTY (non-interactive CI run).
-#    </dev/null: prevent docker compose run from inheriting bash's stdin.
-#               Without this, when the script is fed via 'bash -s < deploy.sh'
-#               over SSH, docker compose run consumes the rest of the file from
-#               stdin — bash hits EOF and exits before 'compose up' ever runs.
-log "running migration gate (alembic upgrade head)"
-if ! docker compose run --rm -T control-plane-migrate </dev/null; then
-  die "MIGRATION GATE FAILED — app NOT restarted, prod left on previous image. Investigate before retrying."
-fi
-log "migration gate passed (schema at head)"
-
-# 4. Restart app services — only reachable when migrate exited 0.
-if [ "$DRY_RUN" = "true" ]; then
-  log "DRY_RUN=true — gate passed, skipping 'compose up -d' (rehearsal only)"
-  exit 0
-fi
-
-log "restarting app services"
-docker compose up -d --force-recreate control-plane webhook-worker email-worker
-
-# 5. Post-deploy health check (best-effort, non-fatal — restart already issued).
-log "waiting for control-plane health"
-for i in $(seq 1 20); do
-  status="$(docker compose ps --format '{{.Health}}' control-plane 2>/dev/null || true)"
-  case "$status" in
-    healthy) log "control-plane healthy"; break ;;
-    *) sleep 3 ;;
-  esac
-  if [ "$i" -eq 20 ]; then
-    printf '\n\033[1;33m## control-plane not reporting healthy after ~60s — check `docker compose logs control-plane`\033[0m\n' >&2
+  # 1. Tag the current image for fast rollback (skip on first-ever deploy).
+  if docker image inspect "$image" >/dev/null 2>&1; then
+    log "tagging current image -> infra-control-plane:prev (rollback point)"
+    docker tag "$image" infra-control-plane:prev
+  else
+    log "no existing $image — first deploy, nothing to tag for rollback"
   fi
-done
 
-# 6. Edition smoke gate — FAIL-CLOSED.
-#    Hits /server/info after a successful health-check to verify the running image
-#    is the enterprise build (edition=enterprise + billing_enabled=true).
-#    If not, rolls back to the :prev image automatically.
-#    Override SMOKE_URL if the server info endpoint is at a different URL.
-SMOKE_URL="${SMOKE_URL:-https://cp.tr.entire.vc/server/info}"
-log "checking edition smoke gate ($SMOKE_URL)"
-_EDITION=""
-_BILLING="False"
-for _i in $(seq 1 5); do
-  _RESP=$(curl -sf --max-time 10 "$SMOKE_URL" 2>/dev/null || true)
-  if [ -n "$_RESP" ]; then
-    _EDITION=$(printf '%s' "$_RESP" | python3 -c "import json,sys; print(json.load(sys.stdin).get('edition',''))" 2>/dev/null || true)
-    _BILLING=$(printf '%s' "$_RESP" | python3 -c "import json,sys; d=json.load(sys.stdin); print(str(d.get('features',{}).get('billing_enabled','False')))" 2>/dev/null || true)
-    break
+  # 2. Build the new image from the freshly-synced source.
+  log "building $image from control-plane-src/"
+  docker build -t "$image" control-plane-src/
+
+  # 3. Migration gate — FAIL-CLOSED.
+  #    docker compose run returns the migrate container's exit code; alembic failure
+  #    => non-zero => we abort here and the app is NEVER restarted.
+  #
+  #    -T:        disable pseudo-TTY (non-interactive CI run).
+  #    </dev/null: prevent docker compose run from inheriting bash's stdin.
+  #               Without this, when the script is fed via 'bash -s < deploy.sh'
+  #               over SSH, docker compose run consumes the rest of the file from
+  #               stdin — bash hits EOF and exits before 'compose up' ever runs.
+  log "running migration gate (alembic upgrade head)"
+  if ! docker compose run --rm -T control-plane-migrate </dev/null; then
+    die "MIGRATION GATE FAILED — app NOT restarted, prod left on previous image. Investigate before retrying."
   fi
-  sleep 3
-done
-if [ "$_EDITION" != "enterprise" ] || [ "$_BILLING" != "True" ]; then
-  printf '\n\033[1;31m!! EDITION SMOKE GATE FAILED: edition=%s billing_enabled=%s\033[0m\n' "$_EDITION" "$_BILLING" >&2
-  printf '\033[1;31m!! Rolling back to infra-control-plane:prev\033[0m\n' >&2
-  docker tag infra-control-plane:prev "$IMAGE" 2>/dev/null || true
-  docker compose up -d --force-recreate control-plane webhook-worker email-worker 2>/dev/null || true
-  die "Edition smoke gate failed — rolled back to prev image. Prod /server/info must return edition=enterprise + billing_enabled=true. Check that prod source is from relay-onprem-enterprise, not OSS."
-fi
-log "smoke gate PASSED: edition=enterprise billing_enabled=true"
+  log "migration gate passed (schema at head)"
 
-log "deploy complete — image $IMAGE live, prev image retained as infra-control-plane:prev"
+  # 4. Restart app services — only reachable when migrate exited 0.
+  if [ "$DRY_RUN" = "true" ]; then
+    log "DRY_RUN=true — gate passed, skipping 'compose up -d' (rehearsal only)"
+    return 0
+  fi
+
+  log "restarting app services"
+  docker compose up -d --force-recreate control-plane webhook-worker email-worker
+
+  # 5. Post-deploy health check (best-effort, non-fatal — restart already issued).
+  log "waiting for control-plane health"
+  for i in $(seq 1 20); do
+    status="$(docker compose ps --format '{{.Health}}' control-plane 2>/dev/null || true)"
+    case "$status" in
+      healthy) log "control-plane healthy"; break ;;
+      *) sleep 3 ;;
+    esac
+    if [ "$i" -eq 20 ]; then
+      printf '\n\033[1;33m## control-plane not reporting healthy after ~60s — check `docker compose logs control-plane`\033[0m\n' >&2
+    fi
+  done
+
+  # 6. Edition smoke gate — FAIL-CLOSED.
+  #    Hits /server/info after a successful health-check to verify the running image
+  #    is the enterprise build (edition=enterprise + billing_enabled=true).
+  #    If not, rolls back to the :prev image automatically.
+  #    Override SMOKE_URL if the server info endpoint is at a different URL.
+  local smoke_url="${SMOKE_URL:-https://cp.tr.entire.vc/server/info}"
+  log "checking edition smoke gate ($smoke_url)"
+  local _edition="" _billing="False" _resp
+  for _i in $(seq 1 5); do
+    _resp=$(curl -sf --max-time 10 "$smoke_url" 2>/dev/null || true)
+    if [ -n "$_resp" ]; then
+      _edition=$(printf '%s' "$_resp" | python3 -c "import json,sys; print(json.load(sys.stdin).get('edition',''))" 2>/dev/null || true)
+      _billing=$(printf '%s' "$_resp" | python3 -c "import json,sys; d=json.load(sys.stdin); print(str(d.get('features',{}).get('billing_enabled','False')))" 2>/dev/null || true)
+      break
+    fi
+    sleep 3
+  done
+  if [ "$_edition" != "enterprise" ] || [ "$_billing" != "True" ]; then
+    printf '\n\033[1;31m!! EDITION SMOKE GATE FAILED: edition=%s billing_enabled=%s\033[0m\n' "$_edition" "$_billing" >&2
+    printf '\033[1;31m!! Rolling back to infra-control-plane:prev\033[0m\n' >&2
+    docker tag infra-control-plane:prev "$image" 2>/dev/null || true
+    docker compose up -d --force-recreate control-plane webhook-worker email-worker 2>/dev/null || true
+    die "Edition smoke gate failed — rolled back to prev image. Prod /server/info must return edition=enterprise + billing_enabled=true. Check that prod source is from relay-onprem-enterprise, not OSS."
+  fi
+  log "smoke gate PASSED: edition=enterprise billing_enabled=true"
+
+  log "control-plane deploy complete — image $image live, prev image retained as infra-control-plane:prev"
+}
+
+deploy_web_publish() {
+  local image="$WEB_PUBLISH_IMAGE"
+
+  [ -d web-publish-src ] || die "web-publish-src/ missing in $RELAY_DIR — source sync did not run"
+
+  # 1. Tag the current image for fast rollback (skip on first-ever deploy).
+  if docker image inspect "$image" >/dev/null 2>&1; then
+    log "tagging current image -> infra-web-publish:prev (rollback point)"
+    docker tag "$image" infra-web-publish:prev
+  else
+    log "no existing $image — first deploy, nothing to tag for rollback"
+  fi
+
+  # 2. Build. The Dockerfile's `npm ci` reads GITHUB_TOKEN via a BuildKit secret
+  #    mount (never baked into a layer) — pull it from the environment, falling
+  #    back to the server's own $RELAY_DIR/.env so this works unattended too.
+  local github_token="${GITHUB_TOKEN:-}"
+  if [ -z "$github_token" ] && [ -f "$RELAY_DIR/.env" ]; then
+    github_token="$(grep -m1 '^GITHUB_TOKEN=' "$RELAY_DIR/.env" | cut -d= -f2-)"
+  fi
+  [ -n "$github_token" ] || die "GITHUB_TOKEN not set and not found in $RELAY_DIR/.env — required as the npm-ci build secret"
+
+  log "building $image from web-publish-src/"
+  GITHUB_TOKEN="$github_token" docker build --secret id=github_token,env=GITHUB_TOKEN -t "$image" web-publish-src/
+
+  # web-publish has no migrations — no fail-closed gate needed here. Do not add
+  # one; control-plane's gate above is the only migration-bearing component.
+
+  # 3. Restart — no migration gate to wait on.
+  if [ "$DRY_RUN" = "true" ]; then
+    log "DRY_RUN=true — image built, skipping 'compose up -d' (rehearsal only)"
+    return 0
+  fi
+
+  log "restarting web-publish"
+  docker compose up -d --force-recreate web-publish
+
+  # 4. Post-deploy health check (best-effort, non-fatal — restart already issued).
+  log "waiting for web-publish health"
+  for i in $(seq 1 20); do
+    status="$(docker compose ps --format '{{.Health}}' web-publish 2>/dev/null || true)"
+    case "$status" in
+      healthy) log "web-publish healthy"; break ;;
+      *) sleep 3 ;;
+    esac
+    if [ "$i" -eq 20 ]; then
+      printf '\n\033[1;33m## web-publish not reporting healthy after ~60s — check `docker compose logs web-publish`\033[0m\n' >&2
+    fi
+  done
+
+  log "web-publish deploy complete — image $image live, prev image retained as infra-web-publish:prev"
+}
+
+case "$COMPONENT" in
+  control-plane) deploy_control_plane ;;
+  web-publish)   deploy_web_publish ;;
+  all)           deploy_control_plane; deploy_web_publish ;;
+esac


### PR DESCRIPTION
## Summary

`apps/web-publish/` had no deploy path — `scripts/deploy.sh` only ever covered control-plane, and the GitHub Actions workflow that would rsync+deploy it is disabled (GitHub-hosted runners can't reach `tr-relay-vm`, which is only reachable via `ProxyJump hel01`). Result: merged fixes sat undeployed silently — confirmed live, three merged web-publish PRs (#140, #141, #143) were all undeployed for up to 3 days because nothing ever rebuilt the container, while a control-plane PR merged in the same window deployed fine.

- `scripts/deploy.sh` is now parametrized: `deploy.sh [control-plane|web-publish|all]` (default `control-plane`, backward compatible with the existing disabled CI invocation).
- New `web-publish` branch: tag `:prev` for rollback → build (with the `GITHUB_TOKEN` BuildKit secret the Dockerfile's `npm ci` needs) → `compose up -d --force-recreate web-publish` → health-check wait. No migration gate (web-publish has none); control-plane's fail-closed migration/edition gates are untouched.
- New local-driver mode: when `$RELAY_DIR` doesn't exist locally (not running on the server), the script rsyncs `apps/<component>/` to `tr-relay-vm` and re-invokes itself there over SSH — makes `bash scripts/deploy.sh web-publish` a real one-shot command from a local checkout instead of a manual rsync-then-ssh dance. On-server/CI invocation is unchanged.
- `docs/DEPLOY.md` updated: documents the web-publish path in the automated/local-driver/manual/rollback sections, and corrects the stale "web-publish is not rebuilt by the pipeline" note.

## Verified live

Ran `bash scripts/deploy.sh web-publish` end-to-end against `tr-relay-vm`:
- `relay-web-publish-1` rebuilt+recreated from current `main`, reports `healthy`.
- TR-62 (PNG `og:image`, absolute URL): `curl https://docs.entire.vc/rogozhin` → `og:image` resolves to `https://cp.tr.entire.vc/static/img/evc-ava.png`, `content-type: image/png`.
- Sitemap regression check: `curl https://docs.entire.vc/sitemap.xml` → 200, valid `<urlset>`.
- TR-60 (Cache-Control forwarding, private/protected shares get no `Cache-Control` header): assets-proxy unit suite 5/5 pass; live authenticated-session curl of a private share's asset wasn't performed (requires a real browser/cookie session — code path confirmed unchanged in the deployed source, conditional logic in `web.py` traced directly).

Also freed disk on `tr-relay-vm` (was 99% full, blocking any build): pruned Docker build cache/dangling images and removed a single month-old pre-Helsinki-cutover backup batch (`*-src.bak.20260710-*` dirs + `:backup-20260710-*` image tags, all 15-45 days past the §1h 24-72h rollback window) — recent `:backup-pre-tr*`/`:prev` rollback anchors from the last few days were left untouched.

## Test plan

- [x] `bash -n scripts/deploy.sh` — syntax check
- [x] `DRY_RUN=true bash scripts/deploy.sh web-publish` — rehearsal (rsync + build, no restart)
- [x] `bash scripts/deploy.sh web-publish` — real deploy, container recreated + healthy
- [x] `npx vitest run src/tests/assetsProxy.test.ts` (apps/web-publish) — 5/5 pass
- [x] Live curl: sitemap 200, og:image PNG absolute URL
- [ ] Live curl of a private-share asset's `Cache-Control` header (needs authenticated session — not performed)

Task: #c3f38d9a