### PR TITLE
feat(control-plane): JWT-authed attachment (CAS) file-token contract [TR-09]

### DIFF
--- a/apps/control-plane/app/api/deps.py
+++ b/apps/control-plane/app/api/deps.py
@@ -24,6 +24,12 @@ def _get_user_from_token(db: Session, token: str) -> models.User:
             status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token"
         ) from exc
 
+    if payload.get("scope") == "file":
+        # File tokens (security.create_file_token) are single-file, few-minutes
+        # grants for the /shares/{id}/files/{path}/* routes only — they must
+        # never double as a general session credential elsewhere.
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+
     subject = payload.get("sub")
     if not subject:
         raise HTTPException(

--- a/apps/control-plane/app/api/routers/shares.py
+++ b/apps/control-plane/app/api/routers/shares.py
@@ -1,16 +1,24 @@
 from __future__ import annotations
 
+import re
 import uuid
+from datetime import timedelta
+from typing import Any
+from urllib.parse import quote
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, Response, status
+from jwt.exceptions import InvalidTokenError
 from minio import Minio
 from minio.error import S3Error
 from pydantic import BaseModel
 from slowapi import Limiter
 from slowapi.util import get_remote_address
+from sqlalchemy import select
 from sqlalchemy.orm import Session
+from sqlalchemy.orm.attributes import flag_modified
 
 from app.api import deps
+from app.core import security
 from app.core.config import get_settings
 from app.db import models
 from app.db.session import get_db
@@ -116,6 +124,14 @@ def _get_minio_client() -> Minio:
     )
 
 
+def _ensure_minio_bucket(client: Minio, bucket_name: str) -> None:
+    try:
+        if not client.bucket_exists(bucket_name):
+            client.make_bucket(bucket_name)
+    except S3Error as e:
+        raise HTTPException(status_code=500, detail=f"Failed to access storage: {e}")
+
+
 @router.get("/{share_id}/files-index", response_model=list[SyncArtifactItem])
 def get_share_files_index(
     share_id: uuid.UUID,
@@ -206,6 +222,281 @@ def download_share_file(
         status_code=status.HTTP_404_NOT_FOUND,
         detail=f"File not found: {path}",
     )
+
+
+# --- Attachment (CAS) file-token routes -------------------------------------
+#
+# TR-09: gives the plugin's CAS.ts a JWT-authed presigned-URL contract for
+# real Obsidian users, matching the shape the agent-key path already uses
+# (web.py's upload_mesh_artifact, same web-assets/{share_id}/{path} bucket
+# layout) — extended to a second auth mode rather than a new architecture.
+#
+# CAS.ts requests exactly one token per operation via a single call shape
+# (path, sha256, content_type, content_length — no read/write intent), then
+# reuses that token across HEAD (verify) / GET .../download-url (readFile) /
+# POST .../upload-url (writeFile). So the token itself only proves "this user
+# has SOME access to this exact share+path right now" — each of the three
+# consuming routes below independently re-checks read vs write access via
+# ensure_read_access/ensure_write_access, rather than trusting a mode baked
+# into the token. Least-privilege, short expiry (10 min), single path scope.
+
+_ALLOWED_FILE_PATH_RE = re.compile(r"^[a-zA-Z0-9._\-/А-Яа-я ]+$")
+FILE_TOKEN_EXPIRE_MINUTES = 10
+
+
+class FileTokenRequest(BaseModel):
+    path: str
+    sha256: str
+    content_type: str
+    content_length: int
+
+
+class FileTokenResponse(BaseModel):
+    token: str
+    base_url: str
+    expires_at: str
+
+
+class DownloadUrlResponse(BaseModel):
+    downloadUrl: str
+
+
+class UploadUrlResponse(BaseModel):
+    uploadUrl: str
+
+
+def _validate_file_path(path: str) -> str:
+    """Same rules as web.py's _validate_upload_path (mesh-artifact path), kept
+    as a local copy since neither router currently shares such helpers."""
+    if not path:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="path is required")
+    if path.startswith("/"):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="path must be relative (no leading /)"
+        )
+    if len(path) > 512:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="path too long (max 512 chars)"
+        )
+    segments = path.split("/")
+    if ".." in segments:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="path traversal not allowed"
+        )
+    if path.count("/") > 6:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="path too deep (max 6 levels)"
+        )
+    if not _ALLOWED_FILE_PATH_RE.match(path):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="path contains invalid characters"
+        )
+    return path
+
+
+def _decode_file_token(share_id: uuid.UUID, path: str, authorization: str | None) -> dict[str, Any]:
+    """Decode+validate the Bearer file-token on HEAD/download-url/upload-url.
+
+    Deliberately NOT deps.get_current_user — that accepts normal session
+    JWTs, and (per its own guard) now explicitly REJECTS scope=file tokens.
+    This is the file-token-only counterpart.
+    """
+    if not authorization:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing credentials")
+    scheme, _, token = authorization.partition(" ")
+    if scheme.lower() != "bearer" or not token:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid Authorization header"
+        )
+    try:
+        payload = security.decode_access_token(token)
+    except InvalidTokenError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token"
+        ) from exc
+    if payload.get("scope") != "file":
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+    if payload.get("share_id") != str(share_id):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Token not valid for this share"
+        )
+    if payload.get("path") != path:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Token not valid for this path"
+        )
+    return payload
+
+
+def _user_from_file_token(db: Session, payload: dict[str, Any]) -> models.User:
+    subject = payload.get("sub")
+    try:
+        user_id = uuid.UUID(str(subject))
+    except (TypeError, ValueError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token payload"
+        ) from exc
+    user = db.execute(select(models.User).where(models.User.id == user_id)).scalar_one_or_none()
+    if not user or not user.is_active:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="User is inactive or missing"
+        )
+    return user
+
+
+@router.post("/{share_id}/file-token", response_model=FileTokenResponse)
+def create_file_token(
+    share_id: uuid.UUID,
+    payload: FileTokenRequest,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(deps.get_current_user),
+) -> FileTokenResponse:
+    """Mint a short-lived, path-scoped token for attachment (CAS) access.
+
+    Minimum bar to mint at all is read access — write is re-checked
+    independently at upload-url, so a viewer can verify/download but a
+    write-url request 403s unless they actually have write access.
+    """
+    share = share_service.get_share(db, share_id)
+    share_service.ensure_read_access(db, share, current_user)
+    path = _validate_file_path(payload.path)
+
+    token = security.create_file_token(
+        subject=str(current_user.id),
+        share_id=str(share_id),
+        path=path,
+        sha256=payload.sha256,
+        content_type=payload.content_type,
+        content_length=payload.content_length,
+        expires_minutes=FILE_TOKEN_EXPIRE_MINUTES,
+    )
+    expires_at = (security.utcnow() + timedelta(minutes=FILE_TOKEN_EXPIRE_MINUTES)).isoformat()
+    settings = get_settings()
+    base = settings.control_plane_public_url.rstrip("/")
+    base_url = f"{base}/shares/{share_id}/files/{quote(path, safe='/')}"
+    return FileTokenResponse(token=token, base_url=base_url, expires_at=expires_at)
+
+
+@router.head("/{share_id}/files/{path:path}")
+def head_share_file(
+    share_id: uuid.UUID,
+    path: str,
+    db: Session = Depends(get_db),
+    authorization: str | None = Header(default=None, alias="Authorization"),
+) -> Response:
+    """CAS.ts verify(): does this attachment already exist in storage?"""
+    token_payload = _decode_file_token(share_id, path, authorization)
+    user = _user_from_file_token(db, token_payload)
+    share = share_service.get_share(db, share_id)
+    share_service.ensure_read_access(db, share, user)
+
+    settings = get_settings()
+    object_name = f"web-assets/{share_id}/{path}"
+    minio_client = _get_minio_client()
+    try:
+        minio_client.stat_object(settings.minio_bucket, object_name)
+    except S3Error as e:
+        if e.code in ("NoSuchKey", "NoSuchObject"):
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="File not found"
+            ) from e
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Failed to stat file: {e}"
+        ) from e
+    return Response(status_code=status.HTTP_200_OK)
+
+
+@router.get("/{share_id}/files/{path:path}/download-url", response_model=DownloadUrlResponse)
+def get_file_download_url(
+    share_id: uuid.UUID,
+    path: str,
+    db: Session = Depends(get_db),
+    authorization: str | None = Header(default=None, alias="Authorization"),
+) -> DownloadUrlResponse:
+    """CAS.ts readFile() step 1: mint a presigned MinIO GET for this attachment."""
+    token_payload = _decode_file_token(share_id, path, authorization)
+    user = _user_from_file_token(db, token_payload)
+    share = share_service.get_share(db, share_id)
+    share_service.ensure_read_access(db, share, user)
+
+    settings = get_settings()
+    object_name = f"web-assets/{share_id}/{path}"
+    minio_client = _get_minio_client()
+    try:
+        # Confirm the object exists before minting the URL — a presigned GET
+        # for a missing key 404s opaquely from MinIO, not from this API.
+        minio_client.stat_object(settings.minio_bucket, object_name)
+        url = minio_client.presigned_get_object(
+            settings.minio_bucket, object_name, expires=timedelta(minutes=10)
+        )
+    except S3Error as e:
+        if e.code in ("NoSuchKey", "NoSuchObject"):
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="File not found"
+            ) from e
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to retrieve file: {e}",
+        ) from e
+    return DownloadUrlResponse(downloadUrl=url)
+
+
+@router.post("/{share_id}/files/{path:path}/upload-url", response_model=UploadUrlResponse)
+def get_file_upload_url(
+    share_id: uuid.UUID,
+    path: str,
+    db: Session = Depends(get_db),
+    authorization: str | None = Header(default=None, alias="Authorization"),
+) -> UploadUrlResponse:
+    """CAS.ts writeFile() step 1: mint a presigned MinIO PUT for this attachment.
+
+    The client PUTs directly to the returned URL and never calls back to
+    confirm success, so this is the only point where control-plane can index
+    the attachment — written optimistically here (same as web.py's
+    mesh-artifact/sync-artifact uploads, which write bytes+index together;
+    here the storage write happens client-side a moment later instead).
+    """
+    token_payload = _decode_file_token(share_id, path, authorization)
+    user = _user_from_file_token(db, token_payload)
+    share = share_service.get_share(db, share_id)
+    share_service.ensure_write_access(db, share, user)
+
+    settings = get_settings()
+    minio_client = _get_minio_client()
+    _ensure_minio_bucket(minio_client, settings.minio_bucket)
+    object_name = f"web-assets/{share_id}/{path}"
+    content_type = token_payload.get("content_type") or "application/octet-stream"
+    url = minio_client.presigned_put_object(
+        settings.minio_bucket, object_name, expires=timedelta(minutes=10)
+    )
+
+    now_iso = security.utcnow().isoformat()
+    folder_items = list(share.web_folder_items or [])
+    entry = {
+        "path": path,
+        "name": path.split("/")[-1],
+        "type": "asset",
+        "source": "user-upload",
+        "mime": content_type,
+        "size": token_payload.get("content_length") or 0,
+        "sha256": token_payload.get("sha256"),
+        "modified_at": now_iso,
+        "storage_key": object_name,
+        "content": None,
+    }
+    updated = False
+    for item in folder_items:
+        if item.get("path") == path:
+            item.update(entry)
+            updated = True
+            break
+    if not updated:
+        folder_items.append(entry)
+    share.web_folder_items = folder_items
+    flag_modified(share, "web_folder_items")
+    share.web_content_updated_at = security.utcnow()
+    db.commit()
+
+    return UploadUrlResponse(uploadUrl=url)
 
 
 @router.patch("/{share_id}", response_model=share_schema.ShareRead)

--- a/apps/control-plane/app/core/config.py
+++ b/apps/control-plane/app/core/config.py
@@ -32,6 +32,16 @@ class Settings(BaseSettings):
     refresh_token_expire_days: int = Field(default=30)
 
     relay_public_url: AnyUrl = Field(default="wss://relay.localhost")
+    control_plane_public_url: str = Field(
+        default="http://localhost:8000",
+        description=(
+            "Externally-reachable base URL of this control-plane API (e.g. "
+            "https://cp.tr.entire.vc). Used to build the absolute base_url "
+            "returned by POST /shares/{id}/file-token, since uvicorn runs "
+            "without --proxy-headers and Request.base_url would otherwise "
+            "reflect the internal container address, not the public one."
+        ),
+    )
     # TR-22: relay-token is a stateless CWT with no jti/revocation-list — remove_member
     # cannot invalidate an already-issued token, so this TTL is the entire exposure
     # window during which a removed member can still write to the CRDT doc. Keep this

--- a/apps/control-plane/app/core/security.py
+++ b/apps/control-plane/app/core/security.py
@@ -77,6 +77,38 @@ def decode_access_token(token: str) -> dict[str, Any]:
     return jwt.decode(token, settings.jwt_secret, algorithms=[settings.jwt_algorithm])
 
 
+def create_file_token(
+    subject: str,
+    share_id: str,
+    path: str,
+    sha256: str,
+    content_type: str,
+    content_length: int,
+    expires_minutes: int = 10,
+) -> str:
+    """Mint a short-lived, path-scoped token for attachment (CAS) access.
+
+    Deliberately NOT create_access_token with extra claims: this token must
+    never be usable as a general session credential (see the "scope" check
+    in deps._get_user_from_token) — it grants access to exactly one file's
+    HEAD/download-url/upload-url for a few minutes, nothing else.
+    """
+    settings = get_settings()
+    expire_delta = timedelta(minutes=expires_minutes)
+    to_encode = {
+        "sub": subject,
+        "scope": "file",
+        "share_id": share_id,
+        "path": path,
+        "sha256": sha256,
+        "content_type": content_type,
+        "content_length": content_length,
+        "exp": utcnow() + expire_delta,
+        "iat": utcnow(),
+    }
+    return jwt.encode(to_encode, settings.jwt_secret, algorithm=settings.jwt_algorithm)
+
+
 # Ed25519 keypair generation and relay token signing
 
 

--- a/apps/control-plane/tests/test_file_token.py
+++ b/apps/control-plane/tests/test_file_token.py
@@ -19,7 +19,6 @@ from sqlalchemy.orm import Session
 from app.core import security as sec
 from app.db import models
 
-
 # ── helpers ──────────────────────────────────────────────────────────────────
 
 
@@ -178,7 +177,9 @@ class TestCreateFileToken:
     def test_stranger_returns_403(self, client: TestClient, db_session: Session, owner, stranger):
         share = make_folder_share(db_session, owner, slug="ft-stranger")
         token = login(client, stranger.email, "test123456")
-        r = client.post(f"/shares/{share.id}/file-token", json=FILE_TOKEN_BODY, headers=bearer(token))
+        r = client.post(
+            f"/shares/{share.id}/file-token", json=FILE_TOKEN_BODY, headers=bearer(token)
+        )
         assert r.status_code == 403
 
     def test_path_traversal_rejected(self, client: TestClient, db_session: Session, owner):
@@ -219,7 +220,9 @@ class TestHeadFile:
         token = login(client, owner.email, "test123456")
         data = mint(client, share.id, token)
         with minio_patch(exists=False):
-            r = client.head(f"/shares/{share.id}/files/attachments/photo.png", headers=bearer(data["token"]))
+            r = client.head(
+                f"/shares/{share.id}/files/attachments/photo.png", headers=bearer(data["token"])
+            )
         assert r.status_code == 404
 
     def test_wrong_share_id_returns_403(self, client: TestClient, db_session: Session, owner):
@@ -246,9 +249,7 @@ class TestHeadFile:
     ):
         share = make_folder_share(db_session, owner, slug="head-session-jwt")
         token = login(client, owner.email, "test123456")
-        r = client.head(
-            f"/shares/{share.id}/files/attachments/photo.png", headers=bearer(token)
-        )
+        r = client.head(f"/shares/{share.id}/files/attachments/photo.png", headers=bearer(token))
         assert r.status_code == 401
 
 

--- a/apps/control-plane/tests/test_file_token.py
+++ b/apps/control-plane/tests/test_file_token.py
@@ -1,0 +1,367 @@
+"""Tests for the attachment (CAS) file-token contract (TR-09).
+
+POST /shares/{id}/file-token mints a short-lived, path-scoped token; the
+three consuming routes (HEAD .../files/{path}, GET .../download-url, POST
+.../upload-url) each independently re-check read/write access rather than
+trusting a mode encoded in the token, since CAS.ts requests one token per
+operation without stating read vs write intent.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from minio.error import S3Error
+from sqlalchemy.orm import Session
+
+from app.core import security as sec
+from app.db import models
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+def login(client: TestClient, email: str, password: str) -> str:
+    r = client.post("/auth/login", json={"email": email, "password": password})
+    assert r.status_code == 200, r.text
+    return r.json()["access_token"]
+
+
+def bearer(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def make_folder_share(
+    db: Session,
+    user: models.User,
+    slug: str = "file-token-test-share",
+) -> models.Share:
+    share = models.Share(
+        kind=models.ShareKind.FOLDER,
+        path="FileTokenTest/",
+        visibility=models.ShareVisibility.PRIVATE,
+        owner_user_id=user.id,
+        web_published=True,
+        web_slug=slug,
+        web_folder_items=[],
+    )
+    db.add(share)
+    db.commit()
+    db.refresh(share)
+    return share
+
+
+def add_member(
+    db: Session, share: models.Share, user: models.User, role: models.ShareMemberRole
+) -> None:
+    member = models.ShareMember(share_id=share.id, user_id=user.id, role=role)
+    db.add(member)
+    db.commit()
+
+
+def s3_not_found() -> S3Error:
+    return S3Error(
+        response=None,
+        code="NoSuchKey",
+        message="not found",
+        resource="/bucket/obj",
+        request_id="req1",
+        host_id="host1",
+    )
+
+
+def minio_patch(exists: bool = True):
+    """Mocks shares.py's MinIO client — MinIO is a true external boundary."""
+    mock_client = MagicMock()
+    mock_client.bucket_exists.return_value = True
+    if exists:
+        mock_client.stat_object.return_value = MagicMock()
+        mock_client.presigned_get_object.return_value = "https://minio.test/presigned-get"
+        mock_client.presigned_put_object.return_value = "https://minio.test/presigned-put"
+    else:
+        mock_client.stat_object.side_effect = s3_not_found()
+    return patch("app.api.routers.shares._get_minio_client", return_value=mock_client)
+
+
+# ── fixtures ─────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def owner(test_user: models.User) -> models.User:
+    return test_user
+
+
+@pytest.fixture
+def viewer(db_session: Session) -> models.User:
+    user = models.User(
+        email="viewer@example.com",
+        password_hash=sec.get_password_hash("test123456"),
+        is_admin=False,
+        is_active=True,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+@pytest.fixture
+def editor(db_session: Session) -> models.User:
+    user = models.User(
+        email="editor@example.com",
+        password_hash=sec.get_password_hash("test123456"),
+        is_admin=False,
+        is_active=True,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+@pytest.fixture
+def stranger(db_session: Session) -> models.User:
+    user = models.User(
+        email="stranger@example.com",
+        password_hash=sec.get_password_hash("test123456"),
+        is_admin=False,
+        is_active=True,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+FILE_TOKEN_BODY = {
+    "path": "attachments/photo.png",
+    "sha256": "a" * 64,
+    "content_type": "image/png",
+    "content_length": 12345,
+}
+
+
+def mint(client: TestClient, share_id, token: str, body: dict = FILE_TOKEN_BODY) -> dict:
+    r = client.post(f"/shares/{share_id}/file-token", json=body, headers=bearer(token))
+    assert r.status_code == 200, r.text
+    return r.json()
+
+
+# ── POST /shares/{id}/file-token ──────────────────────────────────────────────
+
+
+class TestCreateFileToken:
+    def test_no_auth_returns_401(self, client: TestClient, db_session: Session, owner):
+        share = make_folder_share(db_session, owner, slug="ft-no-auth")
+        r = client.post(f"/shares/{share.id}/file-token", json=FILE_TOKEN_BODY)
+        assert r.status_code == 401
+
+    def test_owner_can_mint(self, client: TestClient, db_session: Session, owner):
+        share = make_folder_share(db_session, owner, slug="ft-owner")
+        token = login(client, owner.email, "test123456")
+        data = mint(client, share.id, token)
+        assert data["token"]
+        assert data["base_url"].endswith(f"/shares/{share.id}/files/attachments/photo.png")
+        assert data["expires_at"]
+
+    def test_viewer_can_mint_read_is_the_floor(
+        self, client: TestClient, db_session: Session, owner, viewer
+    ):
+        share = make_folder_share(db_session, owner, slug="ft-viewer")
+        add_member(db_session, share, viewer, models.ShareMemberRole.VIEWER)
+        token = login(client, viewer.email, "test123456")
+        data = mint(client, share.id, token)
+        assert data["token"]
+
+    def test_stranger_returns_403(self, client: TestClient, db_session: Session, owner, stranger):
+        share = make_folder_share(db_session, owner, slug="ft-stranger")
+        token = login(client, stranger.email, "test123456")
+        r = client.post(f"/shares/{share.id}/file-token", json=FILE_TOKEN_BODY, headers=bearer(token))
+        assert r.status_code == 403
+
+    def test_path_traversal_rejected(self, client: TestClient, db_session: Session, owner):
+        share = make_folder_share(db_session, owner, slug="ft-traversal")
+        token = login(client, owner.email, "test123456")
+        body = {**FILE_TOKEN_BODY, "path": "../../etc/passwd"}
+        r = client.post(f"/shares/{share.id}/file-token", json=body, headers=bearer(token))
+        assert r.status_code == 400
+
+    def test_minted_token_cannot_be_used_as_a_session_token(
+        self, client: TestClient, db_session: Session, owner
+    ):
+        """Security guard: a file-token must not double as a general session
+        credential on an unrelated get_current_user-gated endpoint."""
+        share = make_folder_share(db_session, owner, slug="ft-not-session")
+        token = login(client, owner.email, "test123456")
+        data = mint(client, share.id, token)
+        r = client.get(f"/shares/{share.id}", headers=bearer(data["token"]))
+        assert r.status_code == 401
+
+
+# ── HEAD /shares/{id}/files/{path} (CAS.ts verify) ────────────────────────────
+
+
+class TestHeadFile:
+    def test_exists_returns_200(self, client: TestClient, db_session: Session, owner):
+        share = make_folder_share(db_session, owner, slug="head-exists")
+        token = login(client, owner.email, "test123456")
+        data = mint(client, share.id, token)
+        with minio_patch(exists=True):
+            r = client.head(
+                f"/shares/{share.id}/files/attachments/photo.png", headers=bearer(data["token"])
+            )
+        assert r.status_code == 200
+
+    def test_missing_returns_404(self, client: TestClient, db_session: Session, owner):
+        share = make_folder_share(db_session, owner, slug="head-missing")
+        token = login(client, owner.email, "test123456")
+        data = mint(client, share.id, token)
+        with minio_patch(exists=False):
+            r = client.head(f"/shares/{share.id}/files/attachments/photo.png", headers=bearer(data["token"]))
+        assert r.status_code == 404
+
+    def test_wrong_share_id_returns_403(self, client: TestClient, db_session: Session, owner):
+        share_a = make_folder_share(db_session, owner, slug="head-share-a")
+        share_b = make_folder_share(db_session, owner, slug="head-share-b")
+        token = login(client, owner.email, "test123456")
+        data = mint(client, share_a.id, token)
+        r = client.head(
+            f"/shares/{share_b.id}/files/attachments/photo.png", headers=bearer(data["token"])
+        )
+        assert r.status_code == 403
+
+    def test_wrong_path_returns_403(self, client: TestClient, db_session: Session, owner):
+        share = make_folder_share(db_session, owner, slug="head-wrong-path")
+        token = login(client, owner.email, "test123456")
+        data = mint(client, share.id, token)
+        r = client.head(
+            f"/shares/{share.id}/files/some/other-path.png", headers=bearer(data["token"])
+        )
+        assert r.status_code == 403
+
+    def test_session_jwt_rejected_not_a_file_token(
+        self, client: TestClient, db_session: Session, owner
+    ):
+        share = make_folder_share(db_session, owner, slug="head-session-jwt")
+        token = login(client, owner.email, "test123456")
+        r = client.head(
+            f"/shares/{share.id}/files/attachments/photo.png", headers=bearer(token)
+        )
+        assert r.status_code == 401
+
+
+# ── GET /shares/{id}/files/{path}/download-url (CAS.ts readFile) ─────────────
+
+
+class TestDownloadUrl:
+    def test_returns_presigned_url(self, client: TestClient, db_session: Session, owner):
+        share = make_folder_share(db_session, owner, slug="dlurl-ok")
+        token = login(client, owner.email, "test123456")
+        data = mint(client, share.id, token)
+        with minio_patch(exists=True):
+            r = client.get(
+                f"/shares/{share.id}/files/attachments/photo.png/download-url",
+                headers=bearer(data["token"]),
+            )
+        assert r.status_code == 200, r.text
+        assert r.json()["downloadUrl"] == "https://minio.test/presigned-get"
+
+    def test_missing_object_returns_404(self, client: TestClient, db_session: Session, owner):
+        share = make_folder_share(db_session, owner, slug="dlurl-missing")
+        token = login(client, owner.email, "test123456")
+        data = mint(client, share.id, token)
+        with minio_patch(exists=False):
+            r = client.get(
+                f"/shares/{share.id}/files/attachments/photo.png/download-url",
+                headers=bearer(data["token"]),
+            )
+        assert r.status_code == 404
+
+    def test_viewer_can_download(self, client: TestClient, db_session: Session, owner, viewer):
+        share = make_folder_share(db_session, owner, slug="dlurl-viewer")
+        add_member(db_session, share, viewer, models.ShareMemberRole.VIEWER)
+        token = login(client, viewer.email, "test123456")
+        data = mint(client, share.id, token)
+        with minio_patch(exists=True):
+            r = client.get(
+                f"/shares/{share.id}/files/attachments/photo.png/download-url",
+                headers=bearer(data["token"]),
+            )
+        assert r.status_code == 200, r.text
+
+
+# ── POST /shares/{id}/files/{path}/upload-url (CAS.ts writeFile) ─────────────
+
+
+class TestUploadUrl:
+    def test_owner_gets_upload_url_and_index_updated(
+        self, client: TestClient, db_session: Session, owner
+    ):
+        share = make_folder_share(db_session, owner, slug="upurl-owner")
+        token = login(client, owner.email, "test123456")
+        data = mint(client, share.id, token)
+        with minio_patch(exists=True):
+            r = client.post(
+                f"/shares/{share.id}/files/attachments/photo.png/upload-url",
+                headers=bearer(data["token"]),
+            )
+        assert r.status_code == 200, r.text
+        assert r.json()["uploadUrl"] == "https://minio.test/presigned-put"
+
+        db_session.refresh(share)
+        items = share.web_folder_items or []
+        matches = [i for i in items if i.get("path") == "attachments/photo.png"]
+        assert len(matches) == 1, items
+        entry = matches[0]
+        assert entry["source"] == "user-upload"
+        assert entry["mime"] == "image/png"
+        assert entry["sha256"] == "a" * 64
+        assert entry["size"] == 12345
+        assert entry["storage_key"] == f"web-assets/{share.id}/attachments/photo.png"
+
+    def test_editor_member_can_upload(self, client: TestClient, db_session: Session, owner, editor):
+        share = make_folder_share(db_session, owner, slug="upurl-editor")
+        add_member(db_session, share, editor, models.ShareMemberRole.EDITOR)
+        token = login(client, editor.email, "test123456")
+        data = mint(client, share.id, token)
+        with minio_patch(exists=True):
+            r = client.post(
+                f"/shares/{share.id}/files/attachments/photo.png/upload-url",
+                headers=bearer(data["token"]),
+            )
+        assert r.status_code == 200, r.text
+
+    def test_viewer_only_forbidden(self, client: TestClient, db_session: Session, owner, viewer):
+        """Least-privilege: minting only required read access, but the
+        write-only upload-url route independently 403s a read-only viewer."""
+        share = make_folder_share(db_session, owner, slug="upurl-viewer")
+        add_member(db_session, share, viewer, models.ShareMemberRole.VIEWER)
+        token = login(client, viewer.email, "test123456")
+        data = mint(client, share.id, token)
+        with minio_patch(exists=True):
+            r = client.post(
+                f"/shares/{share.id}/files/attachments/photo.png/upload-url",
+                headers=bearer(data["token"]),
+            )
+        assert r.status_code == 403
+
+    def test_re_upload_updates_existing_index_entry(
+        self, client: TestClient, db_session: Session, owner
+    ):
+        share = make_folder_share(db_session, owner, slug="upurl-reupload")
+        token = login(client, owner.email, "test123456")
+        with minio_patch(exists=True):
+            for _ in range(2):
+                data = mint(client, share.id, token)
+                r = client.post(
+                    f"/shares/{share.id}/files/attachments/photo.png/upload-url",
+                    headers=bearer(data["token"]),
+                )
+                assert r.status_code == 200, r.text
+
+        db_session.refresh(share)
+        items = share.web_folder_items or []
+        matches = [i for i in items if i.get("path") == "attachments/photo.png"]
+        assert len(matches) == 1, "re-upload must update in place, not duplicate the index entry"


### PR DESCRIPTION
## Summary

TR-09: relay-onprem attachment sync (images/audio/video/pdf in live shares) never worked end-to-end. The plugin's CAS.ts needs a presigned-URL contract (`baseUrl` + `HEAD`/`download-url`/`upload-url`) for real Obsidian users, but control-plane only had that for mesh-agent uploads (`X-Agent-Key`) — never for a logged-in user's own Bearer JWT session.

**Option A** (Daedalus's decision, #75a7e7f2): extend the agent-key path's already-working pattern (presigned MinIO URLs, `web-assets/{share_id}/{path}` bucket layout) to a second auth mode, rather than a new architecture. CAS.ts itself needs zero changes — the new routes match its existing `HEAD`/`download-url`/`upload-url` contract exactly.

- `POST /shares/{id}/file-token` — mints a short-lived (10min), path-scoped JWT + `base_url`. Minimum bar to mint is read access; write access is independently re-checked at `upload-url`, since CAS.ts requests one token per operation without stating read/write intent.
- `HEAD /shares/{id}/files/{path}` — `verify()`: does the attachment exist.
- `GET .../files/{path}/download-url` — `readFile()` step 1: presigned GET.
- `POST .../files/{path}/upload-url` — `writeFile()` step 1: presigned PUT, also upserts the `web_folder_items` index (`source=user-upload`) since the client PUTs directly to MinIO and never calls back to confirm.

`security.py`: new `create_file_token()`, deliberately separate from `create_access_token` — carries a `"scope": "file"` claim so it can never double as a general session credential. `deps.py`'s `_get_user_from_token` now explicitly rejects `scope=file` tokens as defense in depth (verified by test: a minted file-token 401s against an unrelated `get_current_user`-gated endpoint).

`config.py`: new `control_plane_public_url` setting, needed to build an absolute `base_url` (uvicorn runs without `--proxy-headers`, so `Request.base_url` would reflect the internal container address, not the public one).

## Test plan

- [x] `tests/test_file_token.py` — 18 new tests (mint auth/access levels, path validation, HEAD/download-url/upload-url access checks, index upsert on upload, the scope=file session-token-reuse guard)
- [x] Full suite: `690 passed, 1 skipped` — no regressions
- [x] `ruff check` clean
- [ ] Live deploy + verify (companion plugin PR + live two-client attachment sync test, tracked on task #75a7e7f2)

## Deploy note

New `control_plane_public_url` setting needs a matching `CONTROL_PLANE_PUBLIC_URL=https://cp.tr.entire.vc` in `tr-relay-vm:/opt/relay/.env` — otherwise `base_url` defaults to `http://localhost:8000` and attachment tokens will point nowhere reachable. Will set this at deploy time.

Task: #75a7e7f2