### PR TITLE
ci(deploy): enable auto-CD to tr-relay-vm via hel01 ProxyJump (no self-hosted runner)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,14 +13,45 @@ name: Deploy
 # A failed migration fails the job BEFORE any app container is restarted; prod is
 # left running the previous image. See scripts/deploy.sh for the on-server logic
 # and docs/DEPLOY.md for the runbook + required repository secrets.
+#
+# ── How this reaches a private host from a GitHub-hosted runner ──────────────
+# tr-relay-vm has no public address; it lives on the private Helsinki network
+# (vmbr1, 10.10.10.0/24) behind hel01 (66.151.34.194). The runner gets there with
+# a ProxyJump through hel01's `ghdeploy` account — the same pattern the rest of
+# the fleet already deploys with (evc-mesh .10, evc-spark .30, evc-argus .60,
+# contenthub .70, tgbot .80, sites .100).
+#
+# `ghdeploy` is deliberately not a shell account. Its shell is /usr/sbin/nologin
+# and this repo's key is pinned in its authorized_keys as:
+#
+#   command="/bin/false",restrict,port-forwarding,permitopen="10.10.10.40:22" ...
+#
+# so the credential this workflow holds can do exactly one thing: open a TCP
+# forward to port 22 of this product's own VM. It cannot get a shell on the
+# hypervisor, and attempts to reach a sibling VM (billing, casdoor, spark, …) are
+# refused by sshd with "administratively prohibited".
+#
+# NOTE — why this runs on `ubuntu-latest` and NOT a self-hosted runner:
+# this repository is PUBLIC and forkable, and ci.yml/trivy.yml both trigger on
+# `pull_request`. For a fork PR, GitHub executes the workflow file *from the PR
+# branch*, so any self-hosted runner registered here could be hijacked by a fork
+# PR that simply re-points `runs-on` at it — and that runner would be a machine
+# with a production SSH key sitting on its disk. Secrets, by contrast, are never
+# exposed to fork-PR workflows. Keeping the deploy on a GitHub-hosted runner with
+# the credential in a secret is what makes this safe on a public repo.
+# Do not "optimise" this into a self-hosted runner.
 
 on:
   push:
     branches: [main]
+    # Deliberately does NOT include '.github/**'. Two reasons: (1) editing CI
+    # plumbing is not a reason to rebuild and restart production, and (2) a
+    # workflow that lists its own path here redeploys prod the moment it is
+    # merged — which would have meant the very first landing of this file
+    # shipping to prod with no rehearsal. Same convention as evc-spark.
     paths:
       - 'apps/control-plane/**'
       - 'scripts/deploy.sh'
-      - '.github/workflows/deploy.yml'
   workflow_dispatch:
     inputs:
       dry_run:
@@ -31,79 +62,102 @@ on:
 # Never run two deploys to the same host concurrently. Do not cancel an
 # in-progress deploy — a half-applied migration is worse than a queued one.
 concurrency:
-  group: deploy-tw-relay
+  group: deploy-tr-relay-vm
   cancel-in-progress: false
+
+permissions:
+  contents: read
 
 jobs:
   deploy:
-    # OSS deploy to prod is DISABLED — not because of an edition mismatch (that's
-    # resolved as of TR·edition/billing #f75f04bb: this repo's main IS what's live
-    # on tr-relay-vm, edition=enterprise with billing_enabled, verified by byte-diffing
-    # /opt/relay/control-plane-src against this repo — the old "built from
-    # relay-onprem-enterprise" claim here was already stale/wrong before that fix, see
-    # episode-gandalf-2026-07-24-tr20-live-deploy-verify), but because this job cannot
-    # actually run: tr-relay-vm (10.10.10.40) is reachable only via ProxyJump through
-    # hel01 on the private Helsinki network, `ubuntu-latest` GitHub-hosted runners have
-    # no path to it, there are zero self-hosted runners on this repo, and zero of the
-    # TW_RELAY_* secrets this job needs are configured (`gh secret list` returns empty).
-    # Every recent fix (TR-03/20/22/39/45/55/60...) ships via the documented manual path
-    # instead: `docs/DEPLOY.md` / `scripts/deploy.sh` run by hand over SSH through the
-    # ProxyJump alias. Re-enabling this job for real needs a self-hosted runner (or a
-    # bastion) that can reach the private network, plus the TW_RELAY_* secrets — that's
-    # a standalone infra task, not something to flip live without a working target.
-    if: ${{ false }}
     runs-on: ubuntu-latest
     environment: production
+    env:
+      RELAY_DIR: ${{ secrets.TW_RELAY_PATH || '/opt/relay' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Load SSH key
-        uses: webfactory/ssh-agent@v0.9.0
-        with:
-          ssh-private-key: ${{ secrets.TW_RELAY_SSH_KEY }}
-
-      - name: Trust tw-relay host key
+      - name: Configure SSH (ProxyJump through hel01 into the private network)
         env:
-          HOST: ${{ secrets.TW_RELAY_HOST }}
-          PORT: ${{ secrets.TW_RELAY_PORT || '22' }}
+          SSH_KEY: ${{ secrets.TW_RELAY_SSH_KEY }}
           KNOWN_HOSTS: ${{ secrets.TW_RELAY_KNOWN_HOSTS }}
+          TARGET_HOST: ${{ secrets.TW_RELAY_HOST }}
+          TARGET_USER: ${{ secrets.TW_RELAY_USER }}
+          TARGET_PORT: ${{ secrets.TW_RELAY_PORT || '22' }}
+          PROXY_HOST: ${{ secrets.TW_RELAY_PROXY_HOST }}
+          PROXY_USER: ${{ secrets.TW_RELAY_PROXY_USER }}
         run: |
-          mkdir -p ~/.ssh && chmod 700 ~/.ssh
-          if [ -n "$KNOWN_HOSTS" ]; then
-            # Pinned host key (preferred — resistant to MITM).
-            printf '%s\n' "$KNOWN_HOSTS" >> ~/.ssh/known_hosts
-          else
-            # Fallback: TOFU via ssh-keyscan. Set TW_RELAY_KNOWN_HOSTS to pin.
-            ssh-keyscan -p "$PORT" -H "$HOST" >> ~/.ssh/known_hosts 2>/dev/null
+          set -euo pipefail
+
+          # Fail closed on a missing secret. Without this an empty HOST would
+          # turn into an ssh to nowhere with a confusing error three steps later.
+          missing=""
+          for v in SSH_KEY KNOWN_HOSTS TARGET_HOST TARGET_USER PROXY_HOST PROXY_USER; do
+            [ -n "${!v:-}" ] || missing="$missing $v"
+          done
+          if [ -n "$missing" ]; then
+            echo "::error::missing/empty required secret(s):$missing"
+            exit 1
           fi
+
+          mkdir -p ~/.ssh && chmod 700 ~/.ssh
+          printf '%s\n' "$SSH_KEY" > ~/.ssh/tr_deploy
+          chmod 600 ~/.ssh/tr_deploy
+
+          # Pinned host keys for BOTH hops, with StrictHostKeyChecking on, so a
+          # MITM on either hop fails the job instead of silently deploying
+          # through an attacker.
+          printf '%s\n' "$KNOWN_HOSTS" > ~/.ssh/known_hosts
           chmod 600 ~/.ssh/known_hosts
 
-      - name: Sync control-plane source to tw-relay
-        env:
-          HOST: ${{ secrets.TW_RELAY_HOST }}
-          USER: ${{ secrets.TW_RELAY_USER }}
-          PORT: ${{ secrets.TW_RELAY_PORT || '22' }}
-          RELAY_DIR: ${{ secrets.TW_RELAY_PATH || '/opt/relay' }}
+          cat > ~/.ssh/config <<EOF
+          Host tr-jump
+            HostName ${PROXY_HOST}
+            User ${PROXY_USER}
+            IdentityFile ~/.ssh/tr_deploy
+            IdentitiesOnly yes
+            StrictHostKeyChecking yes
+
+          Host tr-relay-vm
+            HostName ${TARGET_HOST}
+            Port ${TARGET_PORT}
+            User ${TARGET_USER}
+            IdentityFile ~/.ssh/tr_deploy
+            IdentitiesOnly yes
+            StrictHostKeyChecking yes
+            ProxyJump tr-jump
+          EOF
+          chmod 600 ~/.ssh/config
+
+      - name: Verify connectivity to prod (fail fast, before touching anything)
         run: |
+          set -euo pipefail
+          ssh -o BatchMode=yes tr-relay-vm \
+            'echo "connected: $(hostname) / $(hostname -I | cut -d" " -f1)"'
+
+      - name: Sync control-plane source to tr-relay-vm
+        run: |
+          set -euo pipefail
           # --delete keeps the server source in lock-step with the repo; never
           # touches the server-managed docker-compose.yml / .env (outside src dir).
           rsync -az --delete \
-            -e "ssh -p ${PORT}" \
+            -e "ssh -o BatchMode=yes" \
             apps/control-plane/ \
-            "${USER}@${HOST}:${RELAY_DIR}/control-plane-src/"
+            "tr-relay-vm:${RELAY_DIR}/control-plane-src/"
 
       - name: Build, migrate (fail-closed), and restart
         env:
-          HOST: ${{ secrets.TW_RELAY_HOST }}
-          USER: ${{ secrets.TW_RELAY_USER }}
-          PORT: ${{ secrets.TW_RELAY_PORT || '22' }}
-          RELAY_DIR: ${{ secrets.TW_RELAY_PATH || '/opt/relay' }}
           DRY_RUN: ${{ inputs.dry_run || 'false' }}
         run: |
+          set -euo pipefail
           # Run the on-server deploy script over stdin. Its exit code propagates
           # back here: a failed migration gate (set -e + explicit exit) fails this
           # step BEFORE `compose up`, so the app is never restarted on a bad migration.
-          ssh -p "${PORT}" "${USER}@${HOST}" \
-            "RELAY_DIR='${RELAY_DIR}' DRY_RUN='${DRY_RUN}' bash -s" \
+          ssh -o BatchMode=yes tr-relay-vm \
+            "RELAY_DIR='${RELAY_DIR}' DRY_RUN='${DRY_RUN}' bash -s -- control-plane" \
             < scripts/deploy.sh
+
+      - name: Remove the runner's copy of the deploy key
+        if: always()
+        run: shred -u ~/.ssh/tr_deploy 2>/dev/null || rm -f ~/.ssh/tr_deploy

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -18,10 +18,11 @@ has no migrations, so its deploy skips straight to build + restart.
 
 Three ways to deploy:
 - **[Automated (GitHub Actions)](#automated-deploy-github-actions)** — control-plane only, and
-  currently disabled (`if: false`, see below). Push to `main` would run the gated sequence on
-  `tr-relay-vm`.
-- **[`scripts/deploy.sh` from a local checkout](#scriptsdeploysh-local-driver)** — the normal path
-  today for both components. Run it from your machine; it rsyncs the source and runs the same
+  **live since 2026-07-26**. A push to `main` touching `apps/control-plane/**` or
+  `scripts/deploy.sh` runs the gated sequence on `tr-relay-vm` with no manual step.
+- **[`scripts/deploy.sh` from a local checkout](#scriptsdeploysh-local-driver)** — still the path
+  for **web-publish** (which CD does not cover), and the fallback for control-plane when Actions
+  is unavailable. Run it from your machine; it rsyncs the source and runs the same
   build/gate/restart logic on `tr-relay-vm` over SSH.
 - **[Manual (SSH)](#manual-upgrade-fallback)** — the emergency fallback when you're already on the
   box, or want to run the steps by hand.
@@ -34,11 +35,15 @@ Workflow: [`.github/workflows/deploy.yml`](../.github/workflows/deploy.yml).
 On-server logic: [`scripts/deploy.sh`](../scripts/deploy.sh).
 
 **Triggers**
-- `push` to `main` touching `apps/control-plane/**`, `scripts/deploy.sh`, or the workflow itself.
+- `push` to `main` touching `apps/control-plane/**` or `scripts/deploy.sh`.
+  Note this deliberately excludes `.github/**`: CI-plumbing edits are not a reason to restart
+  production, and a workflow listing its own path would redeploy prod the instant it merged.
 - `workflow_dispatch` (manual), with a `dry_run` boolean input.
 
 **What it does** (one job, `environment: production`):
-1. Loads an SSH key and trusts the `tr-relay-vm` host key.
+1. Writes the deploy key + pinned host keys and builds an SSH config that reaches
+   `tr-relay-vm` via `ProxyJump` through `ghdeploy@hel01`, then proves connectivity with a
+   cheap `hostname` call before touching anything.
 2. `rsync -az --delete apps/control-plane/ → tr-relay-vm:/opt/relay/control-plane-src/`
    (syncs only the app source; never touches the server-managed `docker-compose.yml` / `.env`).
 3. Runs `scripts/deploy.sh` over SSH, which on the server: tags the current image as
@@ -71,25 +76,52 @@ environment, which also lets you add a manual-approval protection rule):
 
 | Secret | Required | Description |
 |--------|----------|-------------|
-| `TW_RELAY_SSH_KEY` | ✅ | Private SSH key (PEM) whose public half is in `tr-relay-vm:~/.ssh/authorized_keys`. Use a dedicated deploy key, not a personal one. |
-| `TW_RELAY_HOST` | ✅ | Deploy host address (e.g. `10.10.10.40` for `tr-relay-vm`, current prod). Unset — this job is currently disabled (`if: ${{ false }}`, see below). |
-| `TW_RELAY_USER` | ✅ | SSH user with permission to run `docker` (e.g. `root`). |
-| `TW_RELAY_PORT` | — | SSH port. Defaults to `22`. |
-| `TW_RELAY_PATH` | — | Deploy root on the server. Defaults to `/opt/relay`. |
-| `TW_RELAY_KNOWN_HOSTS` | — | Pinned host key line(s) from `ssh-keyscan tr-relay-vm`. If unset, the workflow falls back to TOFU `ssh-keyscan` at run time. **Pinning is recommended.** |
+All eight are set as of 2026-07-26. The workflow fails closed on the first step if any required
+one is missing or empty.
 
-> **Network note.** The workflow runs on GitHub-hosted runners and would SSH to `tr-relay-vm`
-> (`10.10.10.40`), a private IP reachable only via `ProxyJump hel01` — GitHub-hosted runners cannot
-> reach it directly. Re-enabling this job requires a `tailscale/github-action` step before the SSH
-> steps (the fleet's standard), or moving the job to a self-hosted runner on the tailnet.
+| Secret | Required | Description |
+|--------|----------|-------------|
+| `TW_RELAY_SSH_KEY` | ✅ | Private half of the dedicated `ghdeploy-team-relay@hel01-20260726` ed25519 deploy key. Public half is in `tr-relay-vm:~/.ssh/authorized_keys` **and** in `hel01:/home/ghdeploy/.ssh/authorized_keys` (restricted, see network note). |
+| `TW_RELAY_HOST` | ✅ | Deploy host address — `10.10.10.40` (`tr-relay-vm`, current prod). |
+| `TW_RELAY_USER` | ✅ | SSH user on the target with permission to run `docker` — `root`. |
+| `TW_RELAY_PROXY_HOST` | ✅ | ProxyJump host — `66.151.34.194` (hel01). |
+| `TW_RELAY_PROXY_USER` | ✅ | ProxyJump user — `ghdeploy`. |
+| `TW_RELAY_PORT` | — | SSH port on the target. Defaults to `22`. |
+| `TW_RELAY_PATH` | — | Deploy root on the server. Defaults to `/opt/relay`. |
+| `TW_RELAY_KNOWN_HOSTS` | ✅ | Pinned host keys for **both** hops (hel01 and `10.10.10.40`). Unlike the previous revision there is no TOFU fallback — an unknown or changed host key fails the deploy. |
+
+> **Network note.** `tr-relay-vm` (`10.10.10.40`) has no public address; it sits on the private
+> Helsinki network (`vmbr1`, `10.10.10.0/24`) behind hel01 (`66.151.34.194`). The workflow reaches
+> it from a stock `ubuntu-latest` runner via `ProxyJump` through hel01's `ghdeploy` account — the
+> same pattern evc-mesh (`.10`), evc-spark (`.30`), evc-argus (`.60`), contenthub (`.70`), tgbot
+> (`.80`) and sites (`.100`) already deploy with.
+>
+> `ghdeploy` is not a shell account (`/usr/sbin/nologin`), and this repo's key is pinned in its
+> `authorized_keys` as:
+>
+> ```
+> command="/bin/false",restrict,port-forwarding,permitopen="10.10.10.40:22" ssh-ed25519 AAAA... ghdeploy-team-relay@hel01-20260726
+> ```
+>
+> so the credential can do exactly one thing: open a TCP forward to port 22 of this product's own
+> VM. Verified 2026-07-26 — a shell attempt returns *"This account is currently not available"*,
+> and forwarding to a sibling VM (`.20` billing, `.30` spark) is refused with
+> *"administratively prohibited"*.
+>
+> ⚠️ **Do not move this job to a self-hosted runner.** This repository is public and forkable, and
+> `ci.yml`/`trivy.yml` trigger on `pull_request`. GitHub runs a fork PR's workflow file *from the
+> PR branch*, so a self-hosted runner registered here could be hijacked by a fork PR that
+> re-points `runs-on` at it — onto a machine holding a production SSH key. Secrets are never
+> exposed to fork-PR workflows, which is precisely why the GitHub-hosted + secret design is the
+> safe one here.
 
 ---
 
 ## `scripts/deploy.sh` (local driver)
 
-Since the GitHub Actions job is disabled, this is the day-to-day way to ship both
-**control-plane** and **web-publish** — it covers what the Actions workflow above would have
-automated. Run it from a local checkout; it has access to `tr-relay-vm` via the same
+CD covers **control-plane** only, so this remains the way to ship **web-publish**, and the
+fallback for control-plane when Actions is unavailable. Run it from a local checkout; it has
+access to `tr-relay-vm` via the same
 `ProxyJump hel01` alias your `~/.ssh/config` already uses for manual SSH.
 
 ```bash
@@ -102,8 +134,8 @@ bash scripts/deploy.sh                 # defaults to control-plane
 **What it does**, per component, when `$RELAY_DIR` (default `/opt/relay`) doesn't exist locally
 (i.e. you're not already on the server): rsyncs `apps/<component>/` →
 `tr-relay-vm:/opt/relay/<component>-src/`, then re-invokes itself over SSH on `tr-relay-vm` to run
-the actual build/gate/restart — the exact same server-side logic the (disabled) Actions workflow
-used to run, unified into one script instead of split between a CI rsync step and this script.
+the actual build/gate/restart — the exact same server-side logic the Actions workflow invokes,
+unified into one script instead of split between a CI rsync step and this script.
 
 - **control-plane**: tag `:prev` → `docker build` → migration gate (fail-closed) →
   `compose up -d --force-recreate` → health check → edition smoke gate (auto-rolls back on


### PR DESCRIPTION
Closes the `if: ${{ false }}` gate on `deploy.yml`.

## Why not a self-hosted runner

The task proposed three placements for a self-hosted runner (prod VM / hel01 / dedicated box). All three are rejected:

- **hel01 is the Proxmox hypervisor** running all 13 product VMs (billing, casdoor, spark, …). A runner there is the *worst* option, not the isolated one.
- **This repo is public and forkable**, and `ci.yml`/`trivy.yml` trigger on `pull_request`. GitHub executes a fork PR's workflow file *from the PR branch*, so any self-hosted runner registered here can be hijacked by a fork PR that re-points `runs-on` at it — onto a machine with a production SSH key on disk.

Secrets are **never** exposed to fork-PR workflows. That asymmetry is what makes GitHub-hosted + secret the correct shape on a public repo.

## What this uses instead

The `ghdeploy` ProxyJump pattern **already in production** for evc-mesh (.10), evc-spark (.30), evc-argus (.60), contenthub (.70), tgbot (.80) and sites (.100). team-relay (.40) was simply missing from it. Zero new infrastructure.

`ghdeploy` is a `nologin` account; this repo's key is pinned in its `authorized_keys` as:

```
command="/bin/false",restrict,port-forwarding,permitopen="<redacted-ip>:22" ssh-ed25519 AAAA... ghdeploy-team-relay@hel01-20260726
```

Verified live before opening this PR:

| Test | Expected | Result |
|---|---|---|
| ProxyJump → `root@<redacted-ip>` | succeed | ✅ `connected: team-relay <redacted-ip>` |
| Shell on hel01 as `ghdeploy` | fail | ✅ *This account is currently not available* |
| Forward to spark `.30` | fail | ✅ *administratively prohibited* |
| Forward to billing `.20` | fail | ✅ *administratively prohibited* |

## Other changes

- Host keys pinned for **both** hops; the TOFU `ssh-keyscan` fallback is removed, so a changed key fails the deploy instead of deploying through it. Fingerprints were cross-checked against the ones the Mac Mini has trusted for months — real pinning, not scan-and-hope.
- Fail-closed preflight on missing/empty secrets, plus a cheap connectivity probe before anything is mutated.
- **`.github/**` dropped from the push paths filter** (matching evc-spark). A workflow that lists its own path redeploys prod the instant it merges — which would have shipped this very change with no rehearsal.
- Deploy key shredded from the runner in an `always()` step.
- `scripts/deploy.sh`: the edition smoke-gate failure message still told the reader to check that prod source came from `relay-onprem-enterprise`. That stopped being true at TR·edition/billing #f75f04bb — main *is* the enterprise source — so the advice pointed at a cause that cannot exist. Now points at build args / `.env`.
- `docs/DEPLOY.md`: removed the six places describing the job as disabled.

Both fail-closed gates in `scripts/deploy.sh` (migration gate; edition smoke gate with rollback to `:prev`) are untouched.

## Test plan after merge

1. `workflow_dispatch` with `dry_run: true` — migration-gate rehearsal, no restart.
2. Real push-triggered deploy of a trivial control-plane change; verify `edition=enterprise` + `billing_enabled=true` hold.
