### PR TITLE
fix(deploy): base64 known_hosts + assert both SSH hops are pinned

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Configure SSH (ProxyJump through hel01 into the private network)
         env:
           SSH_KEY: ${{ secrets.TW_RELAY_SSH_KEY }}
-          KNOWN_HOSTS: ${{ secrets.TW_RELAY_KNOWN_HOSTS }}
+          KNOWN_HOSTS_B64: ${{ secrets.TW_RELAY_KNOWN_HOSTS_B64 }}
           TARGET_HOST: ${{ secrets.TW_RELAY_HOST }}
           TARGET_USER: ${{ secrets.TW_RELAY_USER }}
           TARGET_PORT: ${{ secrets.TW_RELAY_PORT || '22' }}
@@ -93,7 +93,7 @@ jobs:
           # Fail closed on a missing secret. Without this an empty HOST would
           # turn into an ssh to nowhere with a confusing error three steps later.
           missing=""
-          for v in SSH_KEY KNOWN_HOSTS TARGET_HOST TARGET_USER PROXY_HOST PROXY_USER; do
+          for v in SSH_KEY KNOWN_HOSTS_B64 TARGET_HOST TARGET_USER PROXY_HOST PROXY_USER; do
             [ -n "${!v:-}" ] || missing="$missing $v"
           done
           if [ -n "$missing" ]; then
@@ -108,8 +108,26 @@ jobs:
           # Pinned host keys for BOTH hops, with StrictHostKeyChecking on, so a
           # MITM on either hop fails the job instead of silently deploying
           # through an attacker.
-          printf '%s\n' "$KNOWN_HOSTS" > ~/.ssh/known_hosts
+          #
+          # This travels base64-encoded on purpose. A raw multi-line value does
+          # NOT round-trip reliably through `gh secret set`: the first revision of
+          # this workflow uploaded a 12-line known_hosts and the runner received
+          # only its LAST line, which left the ProxyJump hop completely unpinned.
+          # Base64 is a single line, so there is nothing to truncate.
+          printf '%s' "$KNOWN_HOSTS_B64" | base64 -d > ~/.ssh/known_hosts
           chmod 600 ~/.ssh/known_hosts
+
+          # ...and do not TRUST that it arrived intact — assert it. A pin that
+          # silently covers only one of the two hops still *looks* like pinning:
+          # the deploy either dies with an opaque "Host key verification failed"
+          # halfway through, or, if anyone ever re-adds a TOFU fallback, sails
+          # through unpinned. Fail closed here instead, where the cause is obvious.
+          for h in "$PROXY_HOST" "$TARGET_HOST"; do
+            if ! ssh-keygen -F "$h" -f ~/.ssh/known_hosts >/dev/null 2>&1; then
+              echo "::error::TW_RELAY_KNOWN_HOSTS_B64 has no pinned key for one of the two SSH hops (proxy or target) — refusing to deploy"
+              exit 1
+            fi
+          done
 
           cat > ~/.ssh/config <<EOF
           Host tr-jump

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -88,7 +88,22 @@ one is missing or empty.
 | `TW_RELAY_PROXY_USER` | ✅ | ProxyJump user — `ghdeploy`. |
 | `TW_RELAY_PORT` | — | SSH port on the target. Defaults to `22`. |
 | `TW_RELAY_PATH` | — | Deploy root on the server. Defaults to `/opt/relay`. |
-| `TW_RELAY_KNOWN_HOSTS` | ✅ | Pinned host keys for **both** hops (hel01 and `10.10.10.40`). Unlike the previous revision there is no TOFU fallback — an unknown or changed host key fails the deploy. |
+| `TW_RELAY_KNOWN_HOSTS_B64` | ✅ | Pinned host keys for **both** hops (hel01 and `10.10.10.40`), **base64-encoded**. Unlike the previous revision there is no TOFU fallback — an unknown or changed host key fails the deploy. |
+
+> ⚠️ **Why that one is base64 and the SSH key is not.** A raw multi-line value does not
+> round-trip reliably through `gh secret set` — the first cut of this workflow uploaded a
+> 12-line `known_hosts` and the runner received only its **last** line, leaving the ProxyJump
+> hop entirely unpinned. (The multi-line `TW_RELAY_SSH_KEY` was measured arriving intact at 418
+> bytes / 6 newlines, so this is not a blanket rule about multi-line secrets.) Regenerate with:
+>
+> ```bash
+> { ssh-keyscan -t rsa,ecdsa,ed25519 66.151.34.194
+>   ssh hel01 'ssh-keyscan -t rsa,ecdsa,ed25519 10.10.10.40'
+> } | base64 | tr -d '\n' | gh secret set TW_RELAY_KNOWN_HOSTS_B64 -R entire-vc/evc-team-relay
+> ```
+>
+> The workflow does not trust the value either way: after decoding it asserts with
+> `ssh-keygen -F` that **both** hops are actually pinned, and refuses to deploy otherwise.
 
 > **Network note.** `tr-relay-vm` (`10.10.10.40`) has no public address; it sits on the private
 > Helsinki network (`vmbr1`, `10.10.10.0/24`) behind hel01 (`66.151.34.194`). The workflow reaches


### PR DESCRIPTION
Follow-up to #152, found by the first `dry_run` rehearsal.

The rehearsal failed at the connectivity probe with `No ED25519 host key is known`. Runner instrumentation showed the cause:

| secret | length | newlines | verdict |
|---|---|---|---|
| `TW_RELAY_SSH_KEY` | 418 | 6 | intact |
| `TW_RELAY_KNOWN_HOSTS` | 94 | **0** | **only the last of 12 lines** |

The local file was verifiably correct (12 lines, both hosts resolving via `ssh-keygen -F`), so the value was truncated in transit through `gh secret set`. Net effect: the target hop was pinned, the **ProxyJump hop was not pinned at all**.

Note this is *not* a blanket multi-line-secret problem — the SSH key round-tripped fine in the same run.

## Changes

1. known_hosts now travels **base64-encoded** (`TW_RELAY_KNOWN_HOSTS_B64`) — one line, nothing to truncate.
2. The workflow no longer *trusts* the value: after decoding it asserts via `ssh-keygen -F` that **both** hops are pinned, and refuses to deploy otherwise.

Point 2 is the one that matters. A pin covering one of two hops still looks like pinning from the outside; it would keep resurfacing as an opaque mid-deploy failure, or sail through unpinned if anyone re-added a TOFU fallback.

No prod state was touched — the probe runs before the rsync and the build, which is exactly what it is for.