### PR TITLE
fix(deploy): move non-secret deploy config out of secrets into plain env

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,7 +73,20 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     env:
-      RELAY_DIR: ${{ secrets.TW_RELAY_PATH || '/opt/relay' }}
+      # Deliberately NOT secrets. None of these are sensitive — the target IP is
+      # named in this file's own header, in docs/DEPLOY.md and in the fleet's
+      # CLAUDE.md — and putting them in secrets actively hurt: GitHub masks every
+      # secret as `***` in the logs, so when TW_RELAY_HOST turned out to carry two
+      # stray characters the resulting "no pinned host key" failure was
+      # undebuggable from the run output. Same convention as evc-spark's deploy.yml
+      # (DEPLOY_HOST/DEPLOY_USER/DEPLOY_PATH in plain env). Only the SSH key and
+      # the pinned host keys are secrets, because only those are actually secret.
+      RELAY_DIR: /opt/relay
+      TARGET_HOST: 10.10.10.40
+      TARGET_USER: root
+      TARGET_PORT: '22'
+      PROXY_HOST: 66.151.34.194
+      PROXY_USER: ghdeploy
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -82,18 +95,13 @@ jobs:
         env:
           SSH_KEY: ${{ secrets.TW_RELAY_SSH_KEY }}
           KNOWN_HOSTS_B64: ${{ secrets.TW_RELAY_KNOWN_HOSTS_B64 }}
-          TARGET_HOST: ${{ secrets.TW_RELAY_HOST }}
-          TARGET_USER: ${{ secrets.TW_RELAY_USER }}
-          TARGET_PORT: ${{ secrets.TW_RELAY_PORT || '22' }}
-          PROXY_HOST: ${{ secrets.TW_RELAY_PROXY_HOST }}
-          PROXY_USER: ${{ secrets.TW_RELAY_PROXY_USER }}
         run: |
           set -euo pipefail
 
           # Fail closed on a missing secret. Without this an empty HOST would
           # turn into an ssh to nowhere with a confusing error three steps later.
           missing=""
-          for v in SSH_KEY KNOWN_HOSTS_B64 TARGET_HOST TARGET_USER PROXY_HOST PROXY_USER; do
+          for v in SSH_KEY KNOWN_HOSTS_B64; do
             [ -n "${!v:-}" ] || missing="$missing $v"
           done
           if [ -n "$missing" ]; then

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -82,13 +82,18 @@ one is missing or empty.
 | Secret | Required | Description |
 |--------|----------|-------------|
 | `TW_RELAY_SSH_KEY` | ✅ | Private half of the dedicated `ghdeploy-team-relay@hel01-20260726` ed25519 deploy key. Public half is in `tr-relay-vm:~/.ssh/authorized_keys` **and** in `hel01:/home/ghdeploy/.ssh/authorized_keys` (restricted, see network note). |
-| `TW_RELAY_HOST` | ✅ | Deploy host address — `10.10.10.40` (`tr-relay-vm`, current prod). |
-| `TW_RELAY_USER` | ✅ | SSH user on the target with permission to run `docker` — `root`. |
-| `TW_RELAY_PROXY_HOST` | ✅ | ProxyJump host — `66.151.34.194` (hel01). |
-| `TW_RELAY_PROXY_USER` | ✅ | ProxyJump user — `ghdeploy`. |
-| `TW_RELAY_PORT` | — | SSH port on the target. Defaults to `22`. |
-| `TW_RELAY_PATH` | — | Deploy root on the server. Defaults to `/opt/relay`. |
-| `TW_RELAY_KNOWN_HOSTS_B64` | ✅ | Pinned host keys for **both** hops (hel01 and `10.10.10.40`), **base64-encoded**. Unlike the previous revision there is no TOFU fallback — an unknown or changed host key fails the deploy. |
+| `TW_RELAY_KNOWN_HOSTS_B64` | ✅ | Pinned host keys for **both** hops (hel01 and `10.10.10.40`), **base64-encoded**. There is no TOFU fallback — an unknown or changed host key fails the deploy. |
+
+Only those two. Everything else the job needs — `TARGET_HOST`, `TARGET_USER`, `TARGET_PORT`,
+`PROXY_HOST`, `PROXY_USER`, `RELAY_DIR` — lives in plain `env:` at the top of the job, matching
+evc-spark's `DEPLOY_HOST`/`DEPLOY_USER`/`DEPLOY_PATH`.
+
+> **Why they are not secrets.** None of them are sensitive: the target IP is named in this very
+> document, in the workflow's own header comment, and in the fleet CLAUDE.md. Storing them as
+> secrets was actively harmful — GitHub masks every secret as `***` in run logs, so when
+> `TW_RELAY_HOST` turned out to hold two stray characters (13 bytes for an 11-byte address), the
+> resulting `no pinned host key` failure was impossible to diagnose from the run output. Plain
+> `env:` keeps the logs readable and puts the value under code review.
 
 > ⚠️ **Why that one is base64 and the SSH key is not.** A raw multi-line value does not
 > round-trip reliably through `gh secret set` — the first cut of this workflow uploaded a


### PR DESCRIPTION
Third and final fix in the CD bring-up chain (#152 → #155 → this).

The second rehearsal still failed the host-key assertion. Instrumentation localised it exactly:

| measurement | value | verdict |
|---|---|---|
| `B64_len` | 2664, 0 newlines | secret intact |
| decoded known_hosts | 12 lines, 2 hosts, 2 ed25519 | **#155 fix worked** |
| `PROXY_HOST_len` | 13 (`<redacted-ip>`) | correct |
| `TARGET_HOST_len` | **13** for `<redacted-ip>` | **11 expected — two stray chars** |

So `TW_RELAY_HOST` was corrupt, and `ssh-keygen -F` could never match it.

## The actual fix is to stop making these secrets

None of these values are sensitive — the target IP is in this workflow's own header comment, in `docs/DEPLOY.md`, and in the fleet CLAUDE.md. Making them secrets bought nothing and cost real debuggability: GitHub masks every secret as `***` in logs, so a two-character corruption was invisible and surfaced only as an opaque `no pinned host key`. It took two instrumented runs to see it.

`TARGET_HOST`, `TARGET_USER`, `TARGET_PORT`, `PROXY_HOST`, `PROXY_USER`, `RELAY_DIR` move to plain `env:` — same shape as evc-spark's `DEPLOY_HOST`/`DEPLOY_USER`/`DEPLOY_PATH`. Only `TW_RELAY_SSH_KEY` and `TW_RELAY_KNOWN_HOSTS_B64` stay secrets, because only those are secret.

Values under code review beat values in an opaque store that nothing validates.

The host-key assertion from #155 is what caught this, and is kept unchanged.