### PR TITLE
fix(deploy): base64 the SSH key too, and pin its fingerprint

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -87,13 +87,17 @@ jobs:
       TARGET_PORT: '22'
       PROXY_HOST: 66.151.34.194
       PROXY_USER: ghdeploy
+      # Fingerprint of ghdeploy-team-relay@hel01-20260726. Pinned so a truncated,
+      # swapped or rotated key fails with that fact stated, instead of as an
+      # anonymous "Permission denied (publickey)".
+      DEPLOY_KEY_FINGERPRINT: 'SHA256:5DdPar8rAhyfVMEs42EN0zYRFA8a5DDdzMEtsx/cc+E'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Configure SSH (ProxyJump through hel01 into the private network)
         env:
-          SSH_KEY: ${{ secrets.TW_RELAY_SSH_KEY }}
+          SSH_KEY_B64: ${{ secrets.TW_RELAY_SSH_KEY_B64 }}
           KNOWN_HOSTS_B64: ${{ secrets.TW_RELAY_KNOWN_HOSTS_B64 }}
         run: |
           set -euo pipefail
@@ -101,7 +105,7 @@ jobs:
           # Fail closed on a missing secret. Without this an empty HOST would
           # turn into an ssh to nowhere with a confusing error three steps later.
           missing=""
-          for v in SSH_KEY KNOWN_HOSTS_B64; do
+          for v in SSH_KEY_B64 KNOWN_HOSTS_B64; do
             [ -n "${!v:-}" ] || missing="$missing $v"
           done
           if [ -n "$missing" ]; then
@@ -110,8 +114,27 @@ jobs:
           fi
 
           mkdir -p ~/.ssh && chmod 700 ~/.ssh
-          printf '%s\n' "$SSH_KEY" > ~/.ssh/tr_deploy
+
+          # Both secrets travel base64-encoded, for the same reason: a raw
+          # multi-line value does NOT survive `gh secret set` intact. Measured on
+          # this repo: a 12-line known_hosts arrived as its last line only, and a
+          # 432-byte/8-line private key arrived as 418 bytes/7 lines. Base64 is a
+          # single line, so there is nothing to truncate.
+          printf '%s' "$SSH_KEY_B64" | base64 -d > ~/.ssh/tr_deploy
           chmod 600 ~/.ssh/tr_deploy
+
+          # Assert the key is the one we expect. Without this, every way the key
+          # can be wrong — truncated, rotated, replaced — surfaces identically as
+          # "Permission denied (publickey)" from a host that cannot tell you why.
+          actual_fp="$(ssh-keygen -y -f ~/.ssh/tr_deploy 2>/dev/null | ssh-keygen -lf - 2>/dev/null | awk '{print $2}')"
+          if [ -z "$actual_fp" ]; then
+            echo "::error::TW_RELAY_SSH_KEY_B64 did not decode into a usable private key"
+            exit 1
+          fi
+          if [ "$actual_fp" != "$DEPLOY_KEY_FINGERPRINT" ]; then
+            echo "::error::deploy key fingerprint mismatch: got $actual_fp, expected $DEPLOY_KEY_FINGERPRINT"
+            exit 1
+          fi
 
           # Pinned host keys for BOTH hops, with StrictHostKeyChecking on, so a
           # MITM on either hop fails the job instead of silently deploying

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -74,10 +74,8 @@ broken migration makes the `dry_run` run fail at the gate step with the app unto
 Set these under **Settings → Secrets and variables → Actions** (or scoped to the `production`
 environment, which also lets you add a manual-approval protection rule):
 
-| Secret | Required | Description |
-|--------|----------|-------------|
-All eight are set as of 2026-07-26. The workflow fails closed on the first step if any required
-one is missing or empty.
+Both are set as of 2026-07-26. The workflow fails closed on its first step if either is missing
+or empty.
 
 | Secret | Required | Description |
 |--------|----------|-------------|

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -81,7 +81,7 @@ one is missing or empty.
 
 | Secret | Required | Description |
 |--------|----------|-------------|
-| `TW_RELAY_SSH_KEY` | ✅ | Private half of the dedicated `ghdeploy-team-relay@hel01-20260726` ed25519 deploy key. Public half is in `tr-relay-vm:~/.ssh/authorized_keys` **and** in `hel01:/home/ghdeploy/.ssh/authorized_keys` (restricted, see network note). |
+| `TW_RELAY_SSH_KEY_B64` | ✅ | Private half of the dedicated `ghdeploy-team-relay@hel01-20260726` ed25519 deploy key, **base64-encoded**. Public half is in `tr-relay-vm:~/.ssh/authorized_keys` **and** in `hel01:/home/ghdeploy/.ssh/authorized_keys` (restricted, see network note). |
 | `TW_RELAY_KNOWN_HOSTS_B64` | ✅ | Pinned host keys for **both** hops (hel01 and `10.10.10.40`), **base64-encoded**. There is no TOFU fallback — an unknown or changed host key fails the deploy. |
 
 Only those two. Everything else the job needs — `TARGET_HOST`, `TARGET_USER`, `TARGET_PORT`,
@@ -95,20 +95,31 @@ evc-spark's `DEPLOY_HOST`/`DEPLOY_USER`/`DEPLOY_PATH`.
 > resulting `no pinned host key` failure was impossible to diagnose from the run output. Plain
 > `env:` keeps the logs readable and puts the value under code review.
 
-> ⚠️ **Why that one is base64 and the SSH key is not.** A raw multi-line value does not
-> round-trip reliably through `gh secret set` — the first cut of this workflow uploaded a
-> 12-line `known_hosts` and the runner received only its **last** line, leaving the ProxyJump
-> hop entirely unpinned. (The multi-line `TW_RELAY_SSH_KEY` was measured arriving intact at 418
-> bytes / 6 newlines, so this is not a blanket rule about multi-line secrets.) Regenerate with:
+> ⚠️ **Why both are base64.** A raw multi-line value does not survive `gh secret set` intact.
+> Measured on this repo during the 2026-07-26 bring-up: a 12-line `known_hosts` arrived at the
+> runner as its **last line only** (94 bytes, 0 newlines), leaving the ProxyJump hop entirely
+> unpinned; and the 432-byte / 8-line private key arrived as **418 bytes / 7 lines**, which
+> presents as a bare `Permission denied (publickey)`. Base64 is a single line, so there is
+> nothing to truncate — verified byte-identical on round-trip.
+>
+> Regenerate them with:
 >
 > ```bash
+> # known_hosts (both hops)
 > { ssh-keyscan -t rsa,ecdsa,ed25519 66.151.34.194
 >   ssh hel01 'ssh-keyscan -t rsa,ecdsa,ed25519 10.10.10.40'
 > } | base64 | tr -d '\n' | gh secret set TW_RELAY_KNOWN_HOSTS_B64 -R entire-vc/evc-team-relay
+>
+> # private key
+> base64 < /path/to/deploy_key | tr -d '\n' \
+>   | gh secret set TW_RELAY_SSH_KEY_B64 -R entire-vc/evc-team-relay
 > ```
 >
-> The workflow does not trust the value either way: after decoding it asserts with
-> `ssh-keygen -F` that **both** hops are actually pinned, and refuses to deploy otherwise.
+> **The workflow does not trust either value.** After decoding it asserts that both SSH hops are
+> actually pinned (`ssh-keygen -F`) and that the private key's fingerprint matches
+> `DEPLOY_KEY_FINGERPRINT`, pinned in plain `env:`. If you rotate the key, update that
+> fingerprint in the same commit — otherwise the deploy fails closed, by design, naming the
+> mismatch rather than dying as an anonymous auth error.
 
 > **Network note.** `tr-relay-vm` (`10.10.10.40`) has no public address; it sits on the private
 > Helsinki network (`vmbr1`, `10.10.10.0/24`) behind hel01 (`66.151.34.194`). The workflow reaches


### PR DESCRIPTION
Same failure family as #155/#156, now measured on the private key.

With host/user in plain `env:` the logs are readable, and the rehearsal failed with a clean `ghdeploy@<redacted-ip>: Permission denied (publickey)` — host-key verification passing, auth not.

The key is truncated exactly the way `known_hosts` was:

| | bytes | lines |
|---|---|---|
| local file (works end-to-end) | 432 | 8 |
| what the runner received | 418 | 7 |

So `gh secret set` mangling multi-line values is **general**, not a one-off.

## Changes

1. The key travels base64-encoded (`TW_RELAY_SSH_KEY_B64`) — verified byte-identical on round-trip.
2. The workflow derives the public key from what it decoded and asserts the fingerprint matches `DEPLOY_KEY_FINGERPRINT`, pinned in plain `env:`.

Point 2 is the durable part. Truncated, rotated and swapped keys all present identically as `Permission denied (publickey)` — an error the remote is deliberately unwilling to explain. Each of those now says what it actually is, at the step that owns it.

Rotating the key means updating the fingerprint in the same commit; otherwise the deploy fails closed, by design.