### PR TITLE
fix(deploy): correct the stale edition smoke-gate failure message

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -148,7 +148,7 @@ deploy_control_plane() {
     printf '\033[1;31m!! Rolling back to infra-control-plane:prev\033[0m\n' >&2
     docker tag infra-control-plane:prev "$image" 2>/dev/null || true
     docker compose up -d --force-recreate control-plane webhook-worker email-worker 2>/dev/null || true
-    die "Edition smoke gate failed — rolled back to prev image. Prod /server/info must return edition=enterprise + billing_enabled=true. Check that prod source is from relay-onprem-enterprise, not OSS."
+    die "Edition smoke gate failed — rolled back to prev image. Prod /server/info must return edition=enterprise + billing_enabled=true. This repo's main IS the enterprise source (settled in TR·edition/billing #f75f04bb, byte-diffed against /opt/relay/control-plane-src), so a community reading here means the built image or its runtime env drifted — check the build args and $RELAY_DIR/.env, not which repo the source came from."
   fi
   log "smoke gate PASSED: edition=enterprise billing_enabled=true"
 


### PR DESCRIPTION
Last item, and deliberately also the **first real push-triggered deploy** through the CD pipeline enabled in #152.

The edition smoke gate's failure message told the reader to `Check that prod source is from relay-onprem-enterprise, not OSS`. That stopped being true at TR·edition/billing #f75f04bb — this repo's main *is* the enterprise source, verified by byte-diffing against `/opt/relay/control-plane-src`.

So the message sent whoever tripped this gate chasing a cause that cannot exist — during an incident, immediately after an automatic rollback. It now points at what can actually produce a community reading: the build args, or the runtime env in `$RELAY_DIR/.env`.

Message-only; gate behaviour unchanged.

`scripts/deploy.sh` is in the workflow's paths filter, so merging this fires the real deploy. The `dry_run` rehearsal on this same source already passed the migration gate cleanly (run 30198886898) with prod untouched.