### PR TITLE
fix(ci): unbreak main — ruff errors + GitHub Packages auth for svelte jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,15 @@ jobs:
 
   typecheck-svelte:
     runs-on: ubuntu-latest
+    # apps/web-publish/.npmrc points @entire-vc/* at npm.pkg.github.com, so
+    # `npm ci` needs a token that may read this org's packages. Without it npm
+    # sends no credential and GitHub Packages answers 401 "unauthenticated" —
+    # which is exactly how this job and test-svelte were born red on 2026-07-09
+    # (#104) and stayed red for every run after. Same fix the web-publish Docker
+    # build already got in #30, just applied to the bare-runner jobs too.
+    permissions:
+      contents: read
+      packages: read
     steps:
       - uses: actions/checkout@v4
 
@@ -63,6 +72,10 @@ jobs:
 
       - name: Install deps
         working-directory: apps/web-publish
+        # .npmrc reads the token from ${GITHUB_TOKEN}; an unset var expands to
+        # an empty _authToken, which npm sends as an anonymous request.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npm ci
 
       - name: Typecheck
@@ -71,6 +84,10 @@ jobs:
 
   test-svelte:
     runs-on: ubuntu-latest
+    # See typecheck-svelte above: private @entire-vc packages need packages:read.
+    permissions:
+      contents: read
+      packages: read
     steps:
       - uses: actions/checkout@v4
 
@@ -82,6 +99,8 @@ jobs:
 
       - name: Install deps
         working-directory: apps/web-publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npm ci
 
       - name: Run tests

--- a/apps/control-plane/app/api/routers/web.py
+++ b/apps/control-plane/app/api/routers/web.py
@@ -1511,7 +1511,9 @@ def _auth_share_read_access(share: models.Share, request: Request, db: Session) 
             select(models.ShareAgentKey).where(models.ShareAgentKey.key_hash == key_hash)
         ).scalar_one_or_none()
         if agent_key is None:
-            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid agent key")
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid agent key"
+            )
         if agent_key.share_id != share.id:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN, detail="Agent key not valid for this share"
@@ -1571,13 +1573,14 @@ def _auth_share_read_access(share: models.Share, request: Request, db: Session) 
         except HTTPException:
             raise
         except Exception:
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token"
-            )
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
 
     raise HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
-        detail="Authentication required: provide X-Agent-Key header or Authorization: Bearer <token>",
+        detail=(
+            "Authentication required: provide X-Agent-Key header "
+            "or Authorization: Bearer <token>"
+        ),
         headers={"WWW-Authenticate": "Bearer"},
     )
 

--- a/apps/control-plane/tests/test_bearer_download_auth.py
+++ b/apps/control-plane/tests/test_bearer_download_auth.py
@@ -18,7 +18,6 @@ from sqlalchemy.orm import Session
 
 from app.db import models
 
-
 # ── helpers ──────────────────────────────────────────────────────────────────
 
 
@@ -56,9 +55,7 @@ def make_folder_share(
 def make_agent_key(db: Session, share: models.Share, scopes: str = "read") -> str:
     raw = "tr_agent_" + secrets.token_hex(24)
     key_hash = hashlib.sha256(raw.encode()).hexdigest()
-    ak = models.ShareAgentKey(
-        share_id=share.id, key_hash=key_hash, label="test-key", scopes=scopes
-    )
+    ak = models.ShareAgentKey(share_id=share.id, key_hash=key_hash, label="test-key", scopes=scopes)
     db.add(ak)
     db.commit()
     return raw
@@ -75,9 +72,24 @@ def add_member(db: Session, share: models.Share, user: models.User) -> None:
 
 
 MIXED_ITEMS = [
-    {"path": "artifact.md", "type": "sync-artifact", "content": "artifact content", "mime": "text/markdown"},
-    {"path": "vault-doc.md", "type": "doc", "content": "vault doc", "mime": "text/markdown"},
-    {"path": "another-artifact.txt", "type": "sync-artifact", "content": "other artifact", "mime": "text/plain"},
+    {
+        "path": "artifact.md",
+        "type": "sync-artifact",
+        "content": "artifact content",
+        "mime": "text/markdown",
+    },
+    {
+        "path": "vault-doc.md",
+        "type": "doc",
+        "content": "vault doc",
+        "mime": "text/markdown",
+    },
+    {
+        "path": "another-artifact.txt",
+        "type": "sync-artifact",
+        "content": "other artifact",
+        "mime": "text/plain",
+    },
 ]
 
 
@@ -88,6 +100,7 @@ MIXED_ITEMS = [
 def web_enabled(monkeypatch):
     monkeypatch.setenv("WEB_PUBLISH_DOMAIN", "docs.test.com")
     from app.core.config import get_settings
+
     get_settings.cache_clear()
     yield
     get_settings.cache_clear()
@@ -96,6 +109,7 @@ def web_enabled(monkeypatch):
 @pytest.fixture
 def second_user(db_session: Session) -> models.User:
     from app.core import security as sec
+
     user = models.User(
         email="member@example.com",
         password_hash=sec.get_password_hash("test123456"),
@@ -111,6 +125,7 @@ def second_user(db_session: Session) -> models.User:
 @pytest.fixture
 def stranger_user(db_session: Session) -> models.User:
     from app.core import security as sec
+
     user = models.User(
         email="stranger@example.com",
         password_hash=sec.get_password_hash("test123456"),
@@ -219,7 +234,12 @@ class TestDownloadBearerAuth:
     """Bearer JWT auth on GET /v1/web/shares/{id}/download."""
 
     ITEMS = [
-        {"path": "file.md", "type": "sync-artifact", "content": "hello world", "mime": "text/markdown"},
+        {
+            "path": "file.md",
+            "type": "sync-artifact",
+            "content": "hello world",
+            "mime": "text/markdown",
+        },
     ]
 
     def test_no_auth_returns_401(


### PR DESCRIPTION
CI на `main` красный **каждый прогон с 2026-07-09**, а не с 07-24, как было в первом отчёте. Последний зелёный прогон — `7b39c8d9` (07-08); два svelte-джоба были добавлены на следующий день в #104 и **не проходили ни разу**.

Две независимые причины, обе починены здесь.

## 1. `lint-python` — 6 ошибок ruff + 2 файла не прошли `ruff format --check`

- `app/api/routers/web.py` — два слишком длинных `HTTPException` перевёрстаны. Многострочный `detail` собирается в **байт-идентичный** текст, тело 401 не меняется.
- `tests/test_bearer_download_auth.py` — отсортирован блок импортов (I001), три длинных dict-а элементов разложены по ключам.

## 2. `typecheck-svelte` / `test-svelte` — падали в `npm ci`, до запуска самих проверок

```
npm error 401 Unauthorized - GET
https://npm.pkg.github.com/download/@entire-vc/ui-svelte/0.1.0/...
unauthenticated: User cannot be authenticated with the token provided.
```

`apps/web-publish/.npmrc` направляет `@entire-vc/*` в GitHub Packages и берёт токен из `${GITHUB_TOKEN}`. Ни один из двух джобов эту переменную не выставлял → npm отправлял пустой `_authToken` → приватная зависимость отвечала 401. Починено выдачей `packages: read` и передачей `secrets.GITHUB_TOKEN` в install-шаг — ровно тот же фикс, который сборка web-publish в Docker несёт с #30.

**С самим содержимым svelte-джобов проблем не было.** Локально на этой ветке:

- `npm run check` → `svelte-check found 0 errors and 0 warnings`
- `npm test` → `Test Files 6 passed (6) / Tests 71 passed (71)`
- `ruff check` → `All checks passed!`, `ruff format --check` → `156 files already formatted`
- `pytest` → `690 passed, 1 skipped`

## Известное ограничение

`secrets.GITHUB_TOKEN` недоступен для PR из форков, так что на fork-PR эти два джоба останутся красными на `npm ci`. Это ровно то же свойство, что уже есть у docker-сборки web-publish, и отдельная задача (vendoring или публичное зеркало `@entire-vc/ui-svelte`), а не регресс этого PR.

Вопрос «должен ли `deploy.yml` зависеть от `ci.yml`» умышленно **не** входит в этот PR — сначала зелёный `main`, потом изменение прод-пути отдельно. #83f305c3