### PR TITLE
ci(deploy): gate the production deploy on the control-plane checks

### DIFF
--- a/.github/workflows/checks-control-plane.yml
+++ b/.github/workflows/checks-control-plane.yml
@@ -1,0 +1,60 @@
+name: Checks (control-plane)
+
+# The control-plane's lint + test suite, factored out of ci.yml so that ci.yml
+# and deploy.yml run the SAME checks instead of two copies that drift.
+#
+# Why this exists: until 2026-07-26 `deploy.yml` shipped to production on every
+# push to main with no relationship to `ci.yml` whatsoever — no `needs:`, no
+# `workflow_run`, and no `required_status_checks` in branch protection. CI was
+# red on every run for 17 days and deployed anyway, because nothing connected
+# the two. Making both callers depend on one reusable definition is what turns
+# "CI is green" into an actual precondition for reaching prod.
+#
+# Scope is deliberately control-plane only — NOT the svelte jobs. deploy.yml
+# rsyncs `apps/control-plane/` and runs `deploy.sh control-plane`; it does not
+# ship web-publish at all. Gating a backend deploy on a frontend test would
+# block correct deploys for an unrelated failure. When web-publish gets its own
+# automated deploy path, it gets its own gate alongside this one.
+
+on:
+  workflow_call:
+
+jobs:
+  lint-python:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Lint with Ruff
+        working-directory: apps/control-plane
+        run: |
+          uv sync --extra dev --extra test
+          uv run ruff check app/ tests/
+          uv run ruff format --check app/ tests/
+
+  test-python:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Run tests
+        working-directory: apps/control-plane
+        run: |
+          uv sync --extra dev --extra test
+          uv run pytest -v --tb=short

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,44 +11,12 @@ on:
       - '.github/workflows/ci.yml'
 
 jobs:
-  lint-python:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v4
-        with:
-          version: "latest"
-
-      - name: Set up Python
-        run: uv python install 3.12
-
-      - name: Lint with Ruff
-        working-directory: apps/control-plane
-        run: |
-          uv sync --extra dev --extra test
-          uv run ruff check app/ tests/
-          uv run ruff format --check app/ tests/
-
-  test-python:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v4
-        with:
-          version: "latest"
-
-      - name: Set up Python
-        run: uv python install 3.12
-
-      - name: Run tests
-        working-directory: apps/control-plane
-        run: |
-          uv sync --extra dev --extra test
-          uv run pytest -v --tb=short
+  # control-plane lint + tests. Defined in a reusable workflow because
+  # deploy.yml gates the production deploy on these exact same checks — one
+  # definition, two callers, no drift between "what CI ran" and "what the
+  # deploy gate ran". See checks-control-plane.yml for why.
+  checks-control-plane:
+    uses: ./.github/workflows/checks-control-plane.yml
 
   typecheck-svelte:
     runs-on: ubuntu-latest
@@ -161,7 +129,7 @@ jobs:
 
   build-docker:
     runs-on: ubuntu-latest
-    needs: [lint-python, test-python, typecheck-svelte, test-svelte, check-migration-drift]
+    needs: [checks-control-plane, typecheck-svelte, test-svelte, check-migration-drift]
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,7 +69,33 @@ permissions:
   contents: read
 
 jobs:
+  # ── Gate: do not ship control-plane code that does not lint and pass tests ──
+  #
+  # Until this landed, deploy.yml had NO relationship to ci.yml — no `needs:`,
+  # no `workflow_run`, and branch protection carries no required_status_checks.
+  # So `main` sat red for 17 straight days (since 2026-07-09) while every push
+  # deployed to production regardless. A check that gates nothing also hides new
+  # breakage, because a job that is always red is a job nobody reads.
+  #
+  # This runs the SAME reusable definition ci.yml runs, so the gate cannot drift
+  # from CI. It is scoped to the control-plane on purpose: the deploy job below
+  # rsyncs `apps/control-plane/` and calls `deploy.sh control-plane`, so the
+  # svelte jobs are not in this deploy's blast radius and must not be able to
+  # block it. web-publish is still deployed by hand; when it gets an automated
+  # path it gets its own gate, not a share of this one.
+  #
+  # Cost: ~10 min (pytest) added before prod is touched. That is the price of
+  # not shipping untested code, and it is paid in parallel with nothing else —
+  # the on-server migration gate and edition smoke gate in scripts/deploy.sh
+  # still run after this, and still fail closed with a rollback to `:prev`.
+  #
+  # A gate can only fail closed: if these checks fail, prod keeps running the
+  # previous image and the deploy workflow goes red with the reason.
+  gate:
+    uses: ./.github/workflows/checks-control-plane.yml
+
   deploy:
+    needs: [gate]
     runs-on: ubuntu-latest
     environment: production
     env:


### PR DESCRIPTION
Отвечает на второй, открытый вопрос из #83f305c3: должен ли `deploy.yml` зависеть от `ci.yml`?

**Да, но узко — и не через зависимость от `ci.yml` как такового.**

## Что починено

До сегодня `deploy.yml` не был связан с `ci.yml` вообще: ни `needs:`, ни `workflow_run`, а в branch protection нет `required_status_checks`. `main` был красным каждый прогон 17 дней (с 2026-07-09), и каждый push всё равно уезжал на прод. Чек, который ничего не гейтит, вдобавок **прячет следующую настоящую поломку** — джоб, который красный всегда, никто не читает.

Живое подтверждение прямо сейчас: мерж #159 (`0ec0cec1`) улетел на прод за ~1.5 минуты, вообще без связи с CI, который в этот момент ещё шёл. Это ровно то поведение, которое здесь закрывается.

## Почему НЕ `workflow_run` на CI

У двух workflow **разные `paths`-фильтры**. `deploy.yml` срабатывает на `scripts/deploy.sh`, которого нет в фильтре `ci.yml` — значит для изменения только деплой-скрипта CI-прогон не появится никогда, и `workflow_run` не дождётся ничего: деплой просто не поедет. Гейт на завершение соседнего workflow молча привязывает деплой к чужим trigger-условиям.

Вместо этого python-проверки вынесены в reusable workflow (`checks-control-plane.yml`), который вызывают **и** `ci.yml`, **и** `deploy.yml`. Одно определение, два вызова: гейт не может разъехаться с тем, что реально прогнал CI, и гейт всегда запускается вместе с деплоем.

## Почему только control-plane, а не svelte

`deploy.yml` делает `rsync apps/control-plane/` и вызывает `deploy.sh control-plane` — **web-publish он не деплоит вовсе** (в `deploy.sh` путь для web-publish есть, но автоматический workflow его не вызывает, это остаётся ручным). Сломанный фронтовый тест не имеет права блокировать деплой бэкенда. Когда у web-publish появится свой автоматический путь — у него будет свой гейт, а не доля в этом.

## Цена

~10 минут pytest до того, как трогается прод. Это цена того, чтобы не выкатывать нерабочий код. On-server гейты в `scripts/deploy.sh` (migration gate + edition smoke gate с откатом на `:prev`) продолжают работать после этого — они ловят сломанную миграцию и не-enterprise сборку, но не ловят просто сломанный код. Этот слой закрывает именно его.

Гейт может провалиться только закрыто: если проверки красные, прод остаётся на предыдущем образе, а deploy-workflow краснеет с причиной.

## Проверка

- Все три workflow парсятся как YAML.
- `checks-control-plane.yml` содержит те же самые шаги `lint-python` / `test-python`, что были в `ci.yml` (перенос без изменения содержимого).
- `build-docker` в `ci.yml` перевешен с `[lint-python, test-python, ...]` на `[checks-control-plane, ...]`.

Зелёный CI на этом PR — сам по себе доказательство, что reusable-вызов из `ci.yml` работает. Что гейт реально держит `deploy.yml`, будет видно на первом же push в `main`, трогающем `apps/control-plane/**`, после мержа.

#83f305c3