### PR TITLE
chore(deps-dev): bump postcss to 8.5.23 (GHSA-r28c-9q8g-f849)

### DIFF
--- a/apps/web-publish/package-lock.json
+++ b/apps/web-publish/package-lock.json
@@ -35,7 +35,7 @@
         "@types/node": "^26.1.1",
         "@vitest/coverage-v8": "^4.1.10",
         "autoprefixer": "^10.4.24",
-        "postcss": "^8.5.6",
+        "postcss": "^8.5.23",
         "svelte": "^5.0.0",
         "svelte-check": "^4.0.0",
         "tailwindcss": "^3.4.19",
@@ -4395,9 +4395,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -4588,9 +4588,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -4608,7 +4608,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/apps/web-publish/package.json
+++ b/apps/web-publish/package.json
@@ -24,7 +24,7 @@
     "@types/node": "^26.1.1",
     "@vitest/coverage-v8": "^4.1.10",
     "autoprefixer": "^10.4.24",
-    "postcss": "^8.5.6",
+    "postcss": "^8.5.23",
     "svelte": "^5.0.0",
     "svelte-check": "^4.0.0",
     "tailwindcss": "^3.4.19",


### PR DESCRIPTION
Clears Dependabot alert [#116](https://github.com/entire-vc/evc-team-relay/security/dependabot/116) — GHSA-r28c-9q8g-f849 (high), the last remaining high-severity alert on this repo.

## What

`apps/web-publish` devDependency `postcss` 8.5.15 → 8.5.23 (patched line is 8.5.18). Pulls `nanoid` 3.3.12 → 3.3.16 transitively. Lockfile-only change beyond the one version range in `package.json`.

## Why

postcss `<= 8.5.17` auto-detects a `/*# sourceMappingURL=... */` comment in the CSS it is asked to parse and loads that path from disk as a previous source map, unless the caller explicitly passes `map: false`. The candidate path is joined without containment checks, so a stylesheet that reaches the parser can disclose arbitrary `.map` files. Opt-out rather than opt-in, so every `postcss.parse()` / `process()` call is affected by default. Dev-scope dependency, so the exposure here is the build toolchain, not the deployed runtime.

## Relationship to #153

#153 proposed the same bump. Its checks were red because the run was from 10:31 on 2026-07-26, before #159 landed at 11:30 that day — so it carried both the ruff failures and the GitHub Packages 401 that #159 fixed. A rebase would most likely have gone green; this branch simply got there first.

An earlier version of this description claimed the 401 was a permanent limitation of Dependabot-triggered runs. That was wrong — Dependabot PR #105 passed both svelte jobs on 2026-07-27, after #159. Corrected here and on #153 so the thread is not read as evidence that Dependabot npm PRs cannot merge in this repo.
