### PR TITLE
ci: drop dead DockerHub login from build-docker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,11 +139,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      # No DockerHub login here on purpose: both builds below use push:false
+      # (this job only validates the image builds — the real push+login lives
+      # in release.yml, gated on push-to-main). A login step here served no
+      # purpose except failing on Dependabot PRs, which never receive repo
+      # secrets by GitHub design (`DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN` come
+      # back empty) — every Dependabot-authored PR hit this unconditionally.
 
       - name: Build control-plane
         uses: docker/build-push-action@v6


### PR DESCRIPTION
## Why

`build-docker` runs `docker/login-action` before two `docker/build-push-action` steps that are both `push: false`. The login is unused — it exists to support a push that never happens in this job (the real push+login lives in `release.yml`, gated on `push` to `main`).

GitHub does not pass repository secrets to workflow runs triggered by Dependabot PRs (security policy — prevents a malicious dependency bump from exfiltrating secrets via CI). So `secrets.DOCKERHUB_USERNAME`/`secrets.DOCKERHUB_TOKEN` come back empty on every Dependabot-authored PR, and `docker/login-action` hard-fails with `Username and password required`. Confirmed on #154 and #162 — every other check (lint, tests, typecheck, migration-drift, trivy) is green; only this dead login step is red.

Net effect before this fix: **every Dependabot PR on this repo permanently fails build-docker**, regardless of whether the dependency bump is safe, because build-docker `needs` the other jobs and the login step runs unconditionally.

## What changed

Removed the login step. Both build steps keep `push: false`; base images (`python:3.12-slim`, `node:20-alpine`) are public, so no registry auth is needed to build.

## Verify

CI on this PR itself is the proof — build-docker should go green without a DockerHub login.