### PR TITLE
fix(deploy): consolidate control-plane workers onto one image tag

### DIFF
--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -48,7 +48,8 @@ On-server logic: [`scripts/deploy.sh`](../scripts/deploy.sh).
    (syncs only the app source; never touches the server-managed `docker-compose.yml` / `.env`).
 3. Runs `scripts/deploy.sh` over SSH, which on the server: tags the current image as
    `:prev`, builds `infra-control-plane:latest`, runs the **migration gate**, and — only on
-   gate success — `docker compose up -d control-plane webhook-worker email-worker`.
+   gate success — `docker compose up -d control-plane webhook-worker email-worker
+   listmonk-sync-worker lifecycle-worker`.
 
 **Fail-closed guarantee.** `scripts/deploy.sh` runs under `set -euo pipefail` and the migration
 gate is an explicit check:
@@ -57,7 +58,7 @@ gate is an explicit check:
 if ! docker compose run --rm control-plane-migrate; then
   die "MIGRATION GATE FAILED — app NOT restarted ..."   # exits non-zero
 fi
-docker compose up -d control-plane webhook-worker email-worker   # unreachable on failure
+docker compose up -d control-plane webhook-worker email-worker listmonk-sync-worker lifecycle-worker   # unreachable on failure
 ```
 
 A non-zero exit from `alembic upgrade head` ends the script (and fails the workflow step)
@@ -208,7 +209,7 @@ docker build -t infra-control-plane:latest control-plane-src/
 docker compose run --rm control-plane-migrate
 
 # 5. Restart app services ONLY after migrate exits 0
-docker compose up -d control-plane webhook-worker email-worker
+docker compose up -d control-plane webhook-worker email-worker listmonk-sync-worker lifecycle-worker
 ```
 
 Using `docker compose up -d` (whole stack) is also safe: the `depends_on:
@@ -248,7 +249,7 @@ docker compose up -d --force-recreate web-publish
 
 ```bash
 # 1. Stop app services (keep postgres and minio running — do NOT stop the DB)
-docker compose stop control-plane webhook-worker email-worker
+docker compose stop control-plane webhook-worker email-worker listmonk-sync-worker lifecycle-worker
 
 # 2. Restore previous image
 docker tag infra-control-plane:prev infra-control-plane:latest
@@ -258,8 +259,12 @@ docker compose run --rm control-plane-migrate python -m alembic current
 docker compose run --rm control-plane-migrate python -m alembic downgrade <safe-revision>
 
 # 4. Restart with restored image
-docker compose up -d control-plane webhook-worker email-worker
+docker compose up -d control-plane webhook-worker email-worker listmonk-sync-worker lifecycle-worker
 ```
+
+Since 2026-08-06 all five services (`control-plane`, `webhook-worker`, `email-worker`,
+`listmonk-sync-worker`, `lifecycle-worker`) share the single `infra-control-plane:latest` tag —
+step 2 rolls back all five at once, by construction. There is no per-worker `:prev` tag to manage.
 
 **web-publish** (no migrations to revert):
 
@@ -285,6 +290,19 @@ docker compose run --rm control-plane-migrate python -m alembic history
 
 ## docker-compose.yml gate
 
+**All six control-plane-family services MUST share one image tag: `infra-control-plane:latest`.**
+`control-plane`, `control-plane-migrate`, `webhook-worker`, `email-worker`,
+`listmonk-sync-worker`, and `lifecycle-worker` all run the exact same image — only `command:`
+differs. `scripts/deploy.sh` only ever builds and tags `infra-control-plane:latest` (step 2 of
+`deploy_control_plane`); it never builds anything else. Any service in this family declaring its
+own distinct `image:` (e.g. `infra-webhook-worker:latest`) will **never be rebuilt by the deploy
+pipeline** — it sits on whatever content it had the day someone first `docker build`-ed that tag
+by hand, silently drifting from the rest of the fleet. This is exactly what happened
+2026-07-25 → 2026-08-06: the four workers held `cryptography==48.0.1` while `control-plane` had
+already moved to `50.0.0` (task `#148cdf9e`). Every `up -d --force-recreate` looked successful —
+the containers restarted fine — because recreate only swaps which image tag a container runs,
+it does not rebuild that tag.
+
 The production `docker-compose.yml` must include:
 
 ```yaml
@@ -301,6 +319,7 @@ control-plane-migrate:
   restart: "no"
 
 control-plane:
+  image: infra-control-plane:latest
   depends_on:
     postgres:
       condition: service_healthy
@@ -308,20 +327,56 @@ control-plane:
       condition: service_completed_successfully   # <-- fail-closed gate
     minio-init:
       condition: service_completed_successfully
+
+webhook-worker:
+  image: infra-control-plane:latest        # <-- same tag as control-plane, NOT infra-webhook-worker
+  command: ["python", "-m", "app.workers.webhook_worker"]
+
+email-worker:
+  image: infra-control-plane:latest        # <-- same tag, NOT infra-email-worker
+  command: ["python", "-m", "app.workers.email_worker"]
+
+listmonk-sync-worker:
+  image: infra-control-plane:latest        # <-- same tag, NOT infra-listmonk-sync-worker
+  command: ["python", "-m", "app.workers.listmonk_sync_worker"]
+
+lifecycle-worker:
+  image: infra-control-plane:latest        # <-- same tag, NOT infra-lifecycle-worker
+  command: ["python", "-m", "app.workers.lifecycle_worker"]
 ```
 
-The same `service_completed_successfully` guard applies to `webhook-worker` and `email-worker`
-(they depend on `control-plane` which transitively requires migrate to succeed).
+The same `service_completed_successfully` guard applies to every worker (they either depend on
+`control-plane` directly, or transitively require `control-plane-migrate` to succeed).
+
+**Verifying the gate holds** (agent-runnable, no eyeballing):
+
+```bash
+ssh tr-relay-vm "for c in relay-control-plane-1 relay-email-worker-1 relay-webhook-worker-1 relay-listmonk-sync-worker-1 relay-lifecycle-worker-1; do echo -n \"\$c: \"; docker exec \$c python -c 'import cryptography;print(cryptography.__version__)'; done"
+# all five lines must print the same version
+```
 
 ---
 
 ## Notes & limitations
 
 - **Server-managed compose.** The production `docker-compose.yml` lives on `tr-relay-vm`
-  (`/opt/relay/`) and uses `image: infra-control-plane:latest` (built locally), whereas the
-  repo's `infra/docker-compose.yml` is the `build:`-context variant of the same gate. The deploy
-  pipeline deliberately syncs **only** `apps/control-plane/` → `control-plane-src/` and leaves
-  the server's compose file and `.env` alone.
+  (`/opt/relay/`) and uses `image: infra-control-plane:latest` (built locally) on all six
+  control-plane-family services, whereas the repo's `infra/docker-compose.yml` is the
+  `build:`-context variant of the same gate (each service keeps its own `build:` block for
+  self-contained local/self-hosted bring-up, but all six also tag `image: infra-control-plane:latest`
+  so a rebuild-then-recreate cycle can't leave one service behind — see §docker-compose.yml gate).
+  The deploy pipeline deliberately syncs **only** `apps/control-plane/` → `control-plane-src/` and
+  leaves the server's compose file and `.env` alone — this means fixing the compose *structure*
+  (as opposed to the app source) always requires a manual edit on `tr-relay-vm` itself, backed up
+  first (`cp docker-compose.yml docker-compose.yml.bak-<ts>-<reason>`).
+- **Worker image consolidation (2026-08-06, task `#148cdf9e`).** Before this date `webhook-worker`,
+  `email-worker`, `listmonk-sync-worker`, and `lifecycle-worker` each had their own `image:` tag
+  (`infra-webhook-worker:latest` etc.), built once by hand and never touched again by
+  `scripts/deploy.sh` — 12 days of dependency drift went undetected because `--force-recreate`
+  makes a stale container look freshly deployed. All four now share `infra-control-plane:latest`
+  with `control-plane`; the old per-worker tags are left on the host (unused, not deleted) as a
+  rollback path. The old tags will accumulate as dead weight — safe to `docker rmi` them after a
+  few successful deploys confirm the new tag is stable.
 - **web-publish** is covered by `scripts/deploy.sh web-publish` (see above) — merges to
   `apps/web-publish/` do NOT deploy themselves; someone has to run the script. This was a real gap
   (task `c3f38d9a`): three merged fixes sat undeployed for up to 3 days because nothing rebuilt the

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -84,6 +84,7 @@ services:
     build:
       context: ../apps/control-plane
       dockerfile: Dockerfile
+    image: infra-control-plane:latest
     env_file:
       - ./.env
     environment:
@@ -98,6 +99,7 @@ services:
     build:
       context: ../apps/control-plane
       dockerfile: Dockerfile
+    image: infra-control-plane:latest
     env_file:
       - ./.env
     environment:
@@ -142,6 +144,7 @@ services:
     build:
       context: ../apps/control-plane
       dockerfile: Dockerfile
+    image: infra-control-plane:latest
     env_file:
       - ./.env
     environment:
@@ -160,6 +163,7 @@ services:
     build:
       context: ../apps/control-plane
       dockerfile: Dockerfile
+    image: infra-control-plane:latest
     env_file:
       - ./.env
     environment:
@@ -186,6 +190,7 @@ services:
     build:
       context: ../apps/control-plane
       dockerfile: Dockerfile
+    image: infra-control-plane:latest
     env_file:
       - ./.env
     environment:
@@ -207,6 +212,7 @@ services:
     build:
       context: ../apps/control-plane
       dockerfile: Dockerfile
+    image: infra-control-plane:latest
     env_file:
       - ./.env
     environment:

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -111,7 +111,7 @@ deploy_control_plane() {
   fi
 
   log "restarting app services"
-  docker compose up -d --force-recreate control-plane webhook-worker email-worker
+  docker compose up -d --force-recreate control-plane webhook-worker email-worker listmonk-sync-worker lifecycle-worker
 
   # 5. Post-deploy health check (best-effort, non-fatal — restart already issued).
   log "waiting for control-plane health"
@@ -147,7 +147,7 @@ deploy_control_plane() {
     printf '\n\033[1;31m!! EDITION SMOKE GATE FAILED: edition=%s billing_enabled=%s\033[0m\n' "$_edition" "$_billing" >&2
     printf '\033[1;31m!! Rolling back to infra-control-plane:prev\033[0m\n' >&2
     docker tag infra-control-plane:prev "$image" 2>/dev/null || true
-    docker compose up -d --force-recreate control-plane webhook-worker email-worker 2>/dev/null || true
+    docker compose up -d --force-recreate control-plane webhook-worker email-worker listmonk-sync-worker lifecycle-worker 2>/dev/null || true
     die "Edition smoke gate failed — rolled back to prev image. Prod /server/info must return edition=enterprise + billing_enabled=true. This repo's main IS the enterprise source (settled in TR·edition/billing #f75f04bb, byte-diffed against /opt/relay/control-plane-src), so a community reading here means the built image or its runtime env drifted — check the build args and $RELAY_DIR/.env, not which repo the source came from."
   fi
   log "smoke gate PASSED: edition=enterprise billing_enabled=true"


### PR DESCRIPTION
## Что было

`webhook-worker`, `email-worker`, `listmonk-sync-worker`, `lifecycle-worker` на проде каждый держал свой собственный image tag (`infra-webhook-worker:latest` и т.д.), собранный один раз вручную и никогда не пересобираемый `scripts/deploy.sh` — он собирает только `infra-control-plane:latest`. `--force-recreate` пересоздаёт контейнер, но не образ, поэтому 4 из 5 контейнеров тихо оставались на 12-дневных зависимостях, хотя деплой отчитывался успехом.

Обнаружено при выкатке фикса `cryptography` 48.0.1 → 50.0.0 (GHSA-g6cj-pr64-35w5, задача `#9af3db9a`): на проде control-plane был 50.0.0, все 4 воркера — 48.0.1.

## Что сделано

Все пять сервисов теперь смотрят на один тег `infra-control-plane:latest` — они и так гоняют идентичный код, отличается только `command:`. Класс бага убран by construction: один `docker build` наполняет образ для всех пяти контейнеров разом, и существующий `:prev`/rollback в deploy.sh автоматически покрывает всю пятёрку.

- `scripts/deploy.sh` — добавил `listmonk-sync-worker` и `lifecycle-worker` в оба `--force-recreate` списка (обычный деплой + smoke-gate rollback); раньше их не было вообще ни в одном.
- `infra/docker-compose.yml` (self-host шаблон) — добавил `image: infra-control-plane:latest` рядом с существующим `build:` у всех 6 control-plane-семейных сервисов, чтобы self-hosted инсталляции не унаследовали тот же класс дрейфа на будущих апдейтах.
- `docs/DEPLOY.md` — явно задокументировал требование общего тега (раньше в доке это было показано только для `control-plane-migrate`, что, похоже, и стало причиной, по которой воркеры в своё время получили отдельные теги) + agent-runnable команда проверки.

## Прод

`/opt/relay/docker-compose.yml` на `tr-relay-vm` — server-managed, CD его не трогает — правил напрямую: бэкап (`docker-compose.yml.bak-20260806-032518-worker-image-consolidation`), правка 4 строк `image:`, `docker compose config` для валидации, затем `--force-recreate` четырёх воркеров.

```
relay-control-plane-1: 50.0.0
relay-email-worker-1: 50.0.0
relay-webhook-worker-1: 50.0.0
relay-listmonk-sync-worker-1: 50.0.0
relay-lifecycle-worker-1: 50.0.0
```

Migration gate вышел с кодом 0. `docker logs --since 3m | grep -icE 'traceback|error'` — 0 у всех четырёх воркеров. Старые отдельные теги (`infra-webhook-worker:latest` и т.д.) оставлены на хосте нетронутыми как rollback-путь.

## Test plan

- [x] `docker compose config` на изменённом проде — валиден
- [x] `docker compose config` на изменённом `infra/docker-compose.yml` — валиден
- [x] Все 5 контейнеров живьём отдают одну версию `cryptography` (команда из AC #2 задачи)
- [x] Migration gate exit code 0
- [x] Логи воркеров чистые, нет restart-петли
- [ ] CI на этом PR

Source: `#148cdf9e`.