### PR TITLE
ci(control-plane): fresh-DB alembic smoke to catch broken migration graphs

### DIFF
--- a/.github/workflows/checks-control-plane.yml
+++ b/.github/workflows/checks-control-plane.yml
@@ -58,3 +58,59 @@ jobs:
         run: |
           uv sync --extra dev --extra test
           uv run pytest -v --tb=short
+
+  alembic-migration-smoke:
+    # Fresh-DB migration smoke — nothing else in this workflow exercises the
+    # alembic graph against a real database. Without this, a broken revision
+    # chain (a down_revision pointing at a script that doesn't exist) only
+    # ever surfaces on a self-hoster's first `alembic upgrade head` against an
+    # empty database — prod never notices, because prod's alembic_version is
+    # already past the break. That's exactly what shipped in v1.9.0 for two
+    # months (GH #177 / Mesh #1ca96abc): every fresh install failed at
+    # `KeyError: '202602190001'` before creating a single table.
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: control_plane
+          POSTGRES_PASSWORD: control_plane
+          POSTGRES_DB: control_plane
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      DATABASE_URL: postgresql+psycopg://control_plane:control_plane@localhost:5432/control_plane
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install deps
+        working-directory: apps/control-plane
+        run: uv sync --extra dev --extra test
+
+      - name: Migration graph integrity (exactly one head)
+        working-directory: apps/control-plane
+        run: |
+          heads=$(uv run alembic heads)
+          echo "$heads"
+          count=$(grep -c '(head)' <<< "$heads")
+          if [ "$count" -ne 1 ]; then
+            echo "::error::expected exactly 1 alembic head, found $count — resolve the split before merging"
+            exit 1
+          fi
+
+      - name: Fresh-DB alembic upgrade head
+        working-directory: apps/control-plane
+        run: uv run alembic upgrade head


### PR DESCRIPTION
## Summary

Adds a fresh-DB alembic migration smoke test to `checks-control-plane.yml`, the reusable workflow that both `ci.yml` and `deploy.yml`'s fail-closed prod gate call. Closes the class of defect behind #177.

## Background

Published images `1.9.0`/`1.9`/`latest` couldn't migrate a fresh DB for two months: `alembic upgrade head` failed with `KeyError: '202602190001'` before creating a single table. Root cause: `main` itself was broken for 12 days (`202605220001` landed with a `down_revision` pointing at a migration script that didn't exist in the repo), and the `v1.9.0` tag was cut from inside that window. Prod never noticed because its `alembic_version` was already past the break — only a fresh install (self-hosters) hit it. Nothing in CI exercised the migration graph against a real database, so there was no signal.

## Change

New `alembic-migration-smoke` job in `checks-control-plane.yml`:
- `postgres:16` service (matches `infra/docker-compose.yml`)
- **Graph-integrity step**: asserts exactly one alembic head. Cheap, catches an unmerged head split (there was one at `202607210002`/`202607220002` before the `202607240001` merge migration) independent of DB state.
- **Fresh-DB smoke**: `alembic upgrade head` against the just-created postgres service.

Because `ci.yml`'s `checks-control-plane` job and `deploy.yml`'s `gate` job both `uses:` this same reusable workflow, this closes the gap in CI and in the prod deploy gate with one change.

## Test plan

- [x] **Negative control**: ran the new job's exact steps against the `v1.9.0` tree (`git worktree add ... v1.9.0`) with a throwaway `postgres:16` container — `alembic heads` fails with `KeyError: '202602190001'`, RC=1, `count(head)=0` → step would fail closed.
- [x] **Positive control**: same steps against current `main` (`d3ae231`) — `alembic heads` → `202607250001 (head)`, `count(head)=1`; `alembic upgrade head` → RC=0, all 31 migrations applied cleanly.
- [x] Multi-head detection sanity check: ran against the pre-merge commit `3aa8b70` (before `202607240001` reconciled two heads) — correctly reports `count(head)=2`.
- [x] YAML validated (`python3 -c "import yaml; yaml.safe_load(...)"`).
- [ ] CI itself green on this PR (will confirm once Actions run).
