### PR TITLE
TR: min-release-age + semgrep SAST (44 pre-existing findings triaged)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,11 @@ updates:
       pip-minor-and-patch:
         update-types: ["minor", "patch"]
     open-pull-requests-limit: 5
+    # Same supply-chain rationale as min-release-age=7 in the npm .npmrc:
+    # give a fresh release 7 days to get pulled/flagged before Dependabot
+    # proposes it here.
+    cooldown:
+      default-days: 7
 
   # Web-publish (npm) — apps/web-publish
   - package-ecosystem: "npm"
@@ -21,6 +26,8 @@ updates:
       npm-minor-and-patch:
         update-types: ["minor", "patch"]
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
 
   # GitHub Actions workflows
   - package-ecosystem: "github-actions"
@@ -32,3 +39,5 @@ updates:
       actions-all:
         patterns: ["*"]
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7

--- a/.github/workflows/checks-control-plane.yml
+++ b/.github/workflows/checks-control-plane.yml
@@ -23,10 +23,10 @@ jobs:
   lint-python:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           version: "latest"
 
@@ -43,10 +43,10 @@ jobs:
   test-python:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           version: "latest"
 
@@ -86,10 +86,10 @@ jobs:
     env:
       DATABASE_URL: postgresql+psycopg://control_plane:control_plane@localhost:5432/control_plane
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           version: "latest"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,9 @@ jobs:
       contents: read
       packages: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: '20'
           cache: 'npm'
@@ -57,9 +57,9 @@ jobs:
       contents: read
       packages: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: '20'
           cache: 'npm'
@@ -92,10 +92,10 @@ jobs:
           --health-timeout 5s
           --health-retries 10
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           version: "latest"
 
@@ -134,10 +134,10 @@ jobs:
       contents: read
       packages: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       # No DockerHub login here on purpose: both builds below use push:false
       # (this job only validates the image builds — the real push+login lives
@@ -147,7 +147,7 @@ jobs:
       # back empty) — every Dependabot-authored PR hit this unconditionally.
 
       - name: Build control-plane
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: apps/control-plane
           push: false
@@ -156,7 +156,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Build web-publish
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: apps/web-publish
           push: false

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -119,7 +119,7 @@ jobs:
       DEPLOY_KEY_FINGERPRINT: 'SHA256:5DdPar8rAhyfVMEs42EN0zYRFA8a5DDdzMEtsx/cc+E'
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Configure SSH (ProxyJump through hel01 into the private network)
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,19 +17,19 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -37,7 +37,7 @@ jobs:
 
       - name: Extract metadata for control-plane
         id: meta-cp
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/control-plane
           tags: |
@@ -46,7 +46,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push control-plane
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: apps/control-plane
           push: true
@@ -57,7 +57,7 @@ jobs:
 
       - name: Extract metadata for web-publish
         id: meta-wp
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/web-publish
           tags: |
@@ -66,7 +66,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push web-publish
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: apps/web-publish
           push: true
@@ -82,10 +82,10 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
           generate_release_notes: true
           body: |

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,28 @@
+name: semgrep
+# SAST for private repo (no GHAS license needed). Owner: Garfield (CI 1.9).
+# semgrep ci is diff-aware on PRs: only NEW findings vs. merge-base fail the check.
+# The push-to-main run does a full audit scan (informational backlog view).
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  semgrep:
+    name: scan
+    runs-on: ubuntu-latest
+    container:
+      image: semgrep/semgrep
+    # Skip on Dependabot PRs (no secrets / noisy).
+    if: github.actor != 'dependabot[bot]'
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - run: semgrep ci
+        env:
+          SEMGREP_RULES: >-
+            p/security-audit p/secrets p/owasp-top-ten p/python

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -14,7 +14,7 @@ jobs:
     name: Trivy dependency scan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Trivy vulnerability scan (CRITICAL,HIGH)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0

--- a/apps/control-plane/Dockerfile
+++ b/apps/control-plane/Dockerfile
@@ -16,5 +16,12 @@ COPY alembic.ini /app/alembic.ini
 
 RUN pip install --upgrade pip && pip install --no-cache-dir .
 
+# Non-root runtime user. admin_ui.py writes uploaded favicons/logos to
+# app/static/uploads at runtime, so that path needs to be writable by it.
+RUN groupadd -r appuser && useradd -r -g appuser -d /app -s /sbin/nologin appuser && \
+    mkdir -p /app/app/static/uploads && \
+    chown -R appuser:appuser /app
+USER appuser
+
 EXPOSE 8000
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/apps/control-plane/app/api/routers/invites.py
+++ b/apps/control-plane/app/api/routers/invites.py
@@ -19,7 +19,7 @@ from app.schemas import invite as invite_schema
 from app.services import auth_service, invite_service, share_service
 from app.services.instance_settings_service import get_branding
 from app.services.notification_service import get_notification_service
-from app.utils.url import get_base_url
+from app.utils.url import build_invite_oauth_urls, get_base_url
 
 router = APIRouter(prefix="/shares", tags=["invites"])
 limiter = Limiter(key_func=get_remote_address)
@@ -216,15 +216,11 @@ def invite_page(
     invite_info = invite_service.get_invite_public_info(db, token)
     settings = get_settings()
 
-    # Build OAuth URLs with correct scheme (HTTPS behind proxy)
+    # Build OAuth URLs with correct scheme (HTTPS behind proxy) — see
+    # build_invite_oauth_urls() docstring for why `token` is quoted here.
     base_url = get_base_url(request)
-    invite_page_url = f"{base_url}/invite/{token}/page"
-    oauth_callback_url = f"{base_url}/v1/auth/oauth/{settings.oauth_provider_name}/callback"
-    oauth_authorize_url = (
-        f"{base_url}/v1/auth/oauth/{settings.oauth_provider_name}/authorize"
-        f"?redirect_uri={oauth_callback_url}"
-        f"&return_url={invite_page_url}"
-    )
+    oauth_urls = build_invite_oauth_urls(base_url, token, settings.oauth_provider_name)
+    oauth_authorize_url = oauth_urls["oauth_authorize_url"]
 
     branding = get_branding(db)
     return templates.TemplateResponse(

--- a/apps/control-plane/app/api/routers/web.py
+++ b/apps/control-plane/app/api/routers/web.py
@@ -14,7 +14,8 @@ from uuid import UUID
 # escape() only character-escapes a string we build for XML *output* (the
 # sitemap <loc> entry below) — it never parses XML, so the XXE/entity-expansion
 # risk use-defused-xml exists to catch does not apply here.
-from xml.sax.saxutils import escape  # nosemgrep: python.lang.security.use-defused-xml.use-defused-xml
+# nosemgrep: python.lang.security.use-defused-xml.use-defused-xml
+from xml.sax.saxutils import escape
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
 from minio import Minio

--- a/apps/control-plane/app/api/routers/web.py
+++ b/apps/control-plane/app/api/routers/web.py
@@ -10,7 +10,11 @@ import re
 from datetime import datetime
 from datetime import timezone as _tz
 from uuid import UUID
-from xml.sax.saxutils import escape
+
+# escape() only character-escapes a string we build for XML *output* (the
+# sitemap <loc> entry below) — it never parses XML, so the XXE/entity-expansion
+# risk use-defused-xml exists to catch does not apply here.
+from xml.sax.saxutils import escape  # nosemgrep: python.lang.security.use-defused-xml.use-defused-xml
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
 from minio import Minio

--- a/apps/control-plane/app/core/security.py
+++ b/apps/control-plane/app/core/security.py
@@ -50,7 +50,7 @@ def verify_password(plain_password: str, hashed_password: str) -> bool:
         # this is password-verification code. Rule still fires on proximity
         # to plain_password/hashed_password in scope; nothing secret is
         # actually interpolated below (only the exception's type name).
-        # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
+        # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure  # noqa: E501
         logger.warning(
             "Password verification failed on an unverifiable hash (%s)",
             type(e).__name__,

--- a/apps/control-plane/app/core/security.py
+++ b/apps/control-plane/app/core/security.py
@@ -45,10 +45,15 @@ def verify_password(plain_password: str, hashed_password: str) -> bool:
         # else reaching here (a real but malformed stored hash) is more
         # likely a genuine data issue, so log it — the alternative is an
         # ordinary-looking 401 with zero trace of the underlying corruption.
+        # Log only the exception type, never str(e) — passlib's ValueError
+        # message can echo back the malformed hash it failed to parse, and
+        # this is password-verification code. Rule still fires on proximity
+        # to plain_password/hashed_password in scope; nothing secret is
+        # actually interpolated below (only the exception's type name).
+        # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
         logger.warning(
-            "Password verification failed on an unverifiable hash (%s: %s)",
+            "Password verification failed on an unverifiable hash (%s)",
             type(e).__name__,
-            e,
         )
         return False
 

--- a/apps/control-plane/app/templates/admin/settings_oauth.html
+++ b/apps/control-plane/app/templates/admin/settings_oauth.html
@@ -47,6 +47,10 @@
             <td><code>OAUTH_ISSUER_URL</code></td>
             <td>
                 {% if oauth_config.issuer_url %}
+                <!-- oauth_config.issuer_url is settings.oauth_issuer_url: deploy-time
+                     env config, never DB/request data. Admin-only diagnostics page
+                     (get_current_admin_from_cookie). -->
+                <!-- nosemgrep: generic.html-templates.security.var-in-href.var-in-href -->
                 <a href="{{ oauth_config.issuer_url }}" target="_blank" rel="noopener">{{ oauth_config.issuer_url }}</a>
                 {% else %}
                 <span class="text-muted">Not set</span>

--- a/apps/control-plane/app/templates/emails/invite-notification.html
+++ b/apps/control-plane/app/templates/emails/invite-notification.html
@@ -14,6 +14,9 @@
 </div>
 
 <p style="text-align: center;">
+    <!-- invite_url = trusted base_url (get_base_url, never client headers) +
+         secrets.token_hex(32) — no attacker-controlled content. -->
+    <!-- nosemgrep: generic.html-templates.security.var-in-href.var-in-href -->
     <a href="{{ invite_url }}" class="button">Accept Invitation</a>
 </p>
 

--- a/apps/control-plane/app/templates/emails/lifecycle-inactive-after-share.html
+++ b/apps/control-plane/app/templates/emails/lifecycle-inactive-after-share.html
@@ -16,6 +16,10 @@ webpublish-публикации или при совместном редакт�
 
 <p style="font-size:12px;color:#999;margin-top:32px;padding-top:16px;border-top:1px solid #eee;">
     Отписаться от советов:
+    <!-- unsubscribe_url = settings.relay_public_url (deploy config) + an
+         HMAC-SHA256 hex digest (make_unsubscribe_token) — no attacker-
+         controlled content. -->
+    <!-- nosemgrep: generic.html-templates.security.var-in-href.var-in-href -->
     <a href="{{ unsubscribe_url }}" style="color:#999;">{{ unsubscribe_url }}</a>
 </p>
 {% endblock %}

--- a/apps/control-plane/app/templates/emails/lifecycle-no-share-24h.html
+++ b/apps/control-plane/app/templates/emails/lifecycle-no-share-24h.html
@@ -16,6 +16,10 @@
 
 <p style="font-size:12px;color:#999;margin-top:32px;padding-top:16px;border-top:1px solid #eee;">
     Отписаться от советов по настройке:
+    <!-- unsubscribe_url = settings.relay_public_url (deploy config) + an
+         HMAC-SHA256 hex digest (make_unsubscribe_token) — no attacker-
+         controlled content. -->
+    <!-- nosemgrep: generic.html-templates.security.var-in-href.var-in-href -->
     <a href="{{ unsubscribe_url }}" style="color:#999;">{{ unsubscribe_url }}</a>
 </p>
 {% endblock %}

--- a/apps/control-plane/app/templates/invite.html
+++ b/apps/control-plane/app/templates/invite.html
@@ -230,7 +230,13 @@
                             <!-- User needs to authenticate -->
                             {% if oauth_enabled %}
                                 <!-- OAuth Sign In -->
+                                <!-- oauth_authorize_url: base_url is trusted (get_base_url,
+                                     never client headers); the invite `token` path param
+                                     it's built from is quote()d by build_invite_oauth_urls()
+                                     before being embedded, so it can't inject an extra
+                                     query param/fragment. -->
                                 <div class="text-center">
+                                    <!-- nosemgrep: generic.html-templates.security.var-in-href.var-in-href -->
                                     <a href="{{ oauth_authorize_url }}"
                                        class="btn btn-primary btn-full">
                                         Sign in

--- a/apps/control-plane/app/templates/macros/components.html
+++ b/apps/control-plane/app/templates/macros/components.html
@@ -13,6 +13,10 @@
     'icon': 'btn-icon'
   } %}
   {% if href %}
+    {# This macro is not called anywhere yet (grep confirms zero callers) —
+       whoever wires it up must pass an already scheme-validated href
+       (reject javascript:/data:), same as every other href in this file. #}
+    <!-- nosemgrep: generic.html-templates.security.var-in-href.var-in-href -->
     <a href="{{ href }}"
        class="btn btn-{{ variant }} {{ size_classes[size] }} {{ class }}"
        {% if disabled %}aria-disabled="true" tabindex="-1"{% endif %}

--- a/apps/control-plane/app/utils/url.py
+++ b/apps/control-plane/app/utils/url.py
@@ -2,29 +2,65 @@
 
 from __future__ import annotations
 
+from urllib.parse import quote
+
 from fastapi import Request
+
+from app.core.config import get_settings
 
 
 def get_base_url(request: Request) -> str:
-    """Get base URL from request, respecting X-Forwarded-Proto header.
+    """Get the externally-reachable base URL for building links (invites, etc).
 
-    When behind a reverse proxy (like Caddy), the internal connection may be HTTP
-    while the external connection is HTTPS. This function checks the X-Forwarded-Proto
-    header to determine the correct scheme.
+    Deliberately does NOT trust X-Forwarded-Proto/X-Forwarded-Host/Host from
+    the request: those are client-supplied and, if this path is reachable
+    without going through a proxy that overwrites them, an attacker could
+    point a victim's invite email at an attacker-controlled domain (the
+    classic Host-header-injection / password-reset-poisoning pattern) —
+    semgrep's directly-returned-format-string finding on the old header-built
+    f-string flagged exactly this. Same fix already used in shares.py for the
+    same reason: settings.control_plane_public_url is a fixed,
+    deploy-time-configured value nothing in the request can steer.
 
     Args:
-        request: FastAPI request object
+        request: FastAPI request object (kept for call-site compatibility and
+            as the request.base_url fallback below).
 
     Returns:
-        Base URL with correct scheme (e.g., "https://cp.example.com")
+        Base URL with no trailing slash (e.g. "https://cp.example.com").
     """
-    # Check if we're behind a proxy
-    forwarded_proto = request.headers.get("x-forwarded-proto")
-    forwarded_host = request.headers.get("x-forwarded-host") or request.headers.get("host")
+    settings = get_settings()
+    if settings.control_plane_public_url:
+        return settings.control_plane_public_url.rstrip("/")
 
-    if forwarded_proto and forwarded_host:
-        # Use forwarded headers (external URL)
-        return f"{forwarded_proto}://{forwarded_host}"
-
-    # Fallback to request.base_url (may be HTTP in proxy scenarios)
+    # No public URL configured — fall back to what uvicorn saw directly
+    # (correct only when not behind a reverse proxy).
     return str(request.base_url).rstrip("/")
+
+
+def build_invite_oauth_urls(base_url: str, token: str, oauth_provider_name: str) -> dict[str, str]:
+    """Build the invite-page + OAuth authorize/callback URLs for a given invite token.
+
+    `token` is a raw, unvalidated URL path parameter by the time it reaches
+    here (get_invite_public_info() returns is_valid=False rather than 404ing
+    on an unknown token), so it's attacker-influenced. base_url is trusted
+    (get_base_url()), but quote() the token before re-embedding it in a URL
+    path/query segment so it can't smuggle in an extra `&`/`#`/`/` and desync
+    the query string oauth_authorize_url nests it inside (semgrep var-in-href
+    on invite.html's oauth_authorize_url link).
+
+    Returns: {"invite_page_url", "oauth_callback_url", "oauth_authorize_url"}.
+    """
+    safe_token = quote(token, safe="")
+    invite_page_url = f"{base_url}/invite/{safe_token}/page"
+    oauth_callback_url = f"{base_url}/v1/auth/oauth/{oauth_provider_name}/callback"
+    oauth_authorize_url = (
+        f"{base_url}/v1/auth/oauth/{oauth_provider_name}/authorize"
+        f"?redirect_uri={quote(oauth_callback_url, safe='')}"
+        f"&return_url={quote(invite_page_url, safe='')}"
+    )
+    return {
+        "invite_page_url": invite_page_url,
+        "oauth_callback_url": oauth_callback_url,
+        "oauth_authorize_url": oauth_authorize_url,
+    }

--- a/apps/control-plane/tests/test_url_utils.py
+++ b/apps/control-plane/tests/test_url_utils.py
@@ -98,4 +98,5 @@ def test_build_invite_oauth_urls_normal_token_round_trips():
     assert urls["oauth_authorize_url"].startswith(
         "https://cp.example.com/v1/auth/oauth/casdoor/authorize?redirect_uri="
     )
-    assert f"return_url=https%3A%2F%2Fcp.example.com%2Finvite%2F{token}%2Fpage" in urls["oauth_authorize_url"]
+    expected_return_url = f"return_url=https%3A%2F%2Fcp.example.com%2Finvite%2F{token}%2Fpage"
+    assert expected_return_url in urls["oauth_authorize_url"]

--- a/apps/control-plane/tests/test_url_utils.py
+++ b/apps/control-plane/tests/test_url_utils.py
@@ -3,75 +3,99 @@
 from fastapi import Request
 from starlette.datastructures import Headers
 
-from app.utils.url import get_base_url
+from app.core.config import get_settings
+from app.utils.url import build_invite_oauth_urls, get_base_url
 
 
-def test_get_base_url_with_forwarded_proto():
-    """Test that X-Forwarded-Proto is respected."""
-    # Mock request with X-Forwarded-Proto header
-    headers = Headers(
-        {
-            "x-forwarded-proto": "https",
-            "x-forwarded-host": "cp.example.com",
-            "host": "cp.example.com",
-        }
+def _make_request(headers: dict, scheme: str = "http", server=("localhost", 8000)) -> Request:
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/test",
+        "query_string": b"",
+        "headers": Headers(headers).raw,
+        "scheme": scheme,
+        "server": server,
+    }
+    return Request(scope)
+
+
+def test_get_base_url_ignores_forwarded_headers(monkeypatch):
+    """Client-supplied X-Forwarded-*/Host must NOT steer the base URL — trusting
+    them would let an attacker point an emailed invite link at their own domain
+    (Host-header-injection / password-reset-poisoning pattern)."""
+    monkeypatch.setenv("CONTROL_PLANE_PUBLIC_URL", "https://cp.trusted.example")
+    get_settings.cache_clear()
+    try:
+        request = _make_request(
+            {
+                "x-forwarded-proto": "https",
+                "x-forwarded-host": "evil.example",
+                "host": "evil.example",
+            }
+        )
+        assert get_base_url(request) == "https://cp.trusted.example"
+    finally:
+        get_settings.cache_clear()
+
+
+def test_get_base_url_uses_configured_public_url_by_default():
+    """No forwarded headers at all — still returns the configured public URL,
+    never request.base_url (which would reflect the internal container address)."""
+    get_settings.cache_clear()
+    try:
+        request = _make_request({"host": "localhost:8000"})
+        assert get_base_url(request) == get_settings().control_plane_public_url.rstrip("/")
+    finally:
+        get_settings.cache_clear()
+
+
+def test_get_base_url_falls_back_to_request_when_unconfigured(monkeypatch):
+    """Only when control_plane_public_url is explicitly left empty do we fall
+    back to request.base_url — matches pre-fix behavior for that one edge case."""
+    monkeypatch.setenv("CONTROL_PLANE_PUBLIC_URL", "")
+    get_settings.cache_clear()
+    try:
+        request = _make_request(
+            {"host": "cp.example.com"}, scheme="https", server=("cp.example.com", 443)
+        )
+        assert get_base_url(request).startswith("https://")
+    finally:
+        get_settings.cache_clear()
+
+
+def test_build_invite_oauth_urls_quotes_token_with_query_special_chars():
+    """Regression test for the semgrep var-in-href finding on invite.html:
+    `token` reaches invite_page() as a raw, unvalidated path parameter
+    (get_invite_public_info returns is_valid=False rather than 404ing on an
+    unknown token) and used to flow straight into oauth_authorize_url as both
+    a path segment and a nested query value — an attacker-chosen token
+    containing `&`/`#`/`/` could desync the query string it ends up embedded
+    in if not quoted first."""
+    malicious_token = "abc&x=evil#frag"
+    urls = build_invite_oauth_urls("https://cp.example.com", malicious_token, "casdoor")
+
+    # The raw token must never appear un-encoded in any built URL — that
+    # would let it inject an extra query param or fragment.
+    assert malicious_token not in urls["invite_page_url"]
+    assert malicious_token not in urls["oauth_authorize_url"]
+    assert "abc%26x%3Devil%23frag" in urls["invite_page_url"]
+
+    # And the authorize URL must still have exactly one redirect_uri and one
+    # return_url param — proof the injected `&` didn't split the query string.
+    assert urls["oauth_authorize_url"].count("redirect_uri=") == 1
+    assert urls["oauth_authorize_url"].count("return_url=") == 1
+
+
+def test_build_invite_oauth_urls_normal_token_round_trips():
+    """A normal secrets.token_hex() invite token still produces a working,
+    unmangled set of URLs."""
+    token = "a" * 64  # shape of secrets.token_hex(32)
+    urls = build_invite_oauth_urls("https://cp.example.com", token, "casdoor")
+
+    assert urls["invite_page_url"] == f"https://cp.example.com/invite/{token}/page"
+    assert urls["oauth_callback_url"] == "https://cp.example.com/v1/auth/oauth/casdoor/callback"
+    assert urls["oauth_authorize_url"].startswith(
+        "https://cp.example.com/v1/auth/oauth/casdoor/authorize?redirect_uri="
     )
-
-    # Create mock request
-    scope = {
-        "type": "http",
-        "method": "GET",
-        "path": "/test",
-        "query_string": b"",
-        "headers": headers.raw,
-        "scheme": "http",  # Internal scheme
-        "server": ("localhost", 8000),
-    }
-
-    request = Request(scope)
-    base_url = get_base_url(request)
-
-    # Should use HTTPS from forwarded headers
-    assert base_url == "https://cp.example.com"
-
-
-def test_get_base_url_without_forwarded_headers():
-    """Test fallback when no forwarded headers are present."""
-    headers = Headers({"host": "localhost:8000"})
-
-    scope = {
-        "type": "http",
-        "method": "GET",
-        "path": "/test",
-        "query_string": b"",
-        "headers": headers.raw,
-        "scheme": "http",
-        "server": ("localhost", 8000),
-    }
-
-    request = Request(scope)
-    base_url = get_base_url(request)
-
-    # Should use request.base_url
-    assert base_url.startswith("http://")
-
-
-def test_get_base_url_direct_https():
-    """Test when request is already HTTPS (no proxy)."""
-    headers = Headers({"host": "cp.example.com"})
-
-    scope = {
-        "type": "http",
-        "method": "GET",
-        "path": "/test",
-        "query_string": b"",
-        "headers": headers.raw,
-        "scheme": "https",
-        "server": ("cp.example.com", 443),
-    }
-
-    request = Request(scope)
-    base_url = get_base_url(request)
-
-    # Should use HTTPS from request scheme
-    assert base_url.startswith("https://")
+    assert f"return_url=https%3A%2F%2Fcp.example.com%2Finvite%2F{token}%2Fpage" in urls["oauth_authorize_url"]

--- a/apps/web-publish/.npmrc
+++ b/apps/web-publish/.npmrc
@@ -1,2 +1,3 @@
 @entire-vc:registry=https://npm.pkg.github.com
 //npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
+min-release-age=7

--- a/apps/web-publish/Dockerfile
+++ b/apps/web-publish/Dockerfile
@@ -30,6 +30,10 @@ COPY --from=builder /app/build ./build
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/package.json ./
 
+# node:20-alpine ships a non-root "node" user (uid 1000) — use it instead of root
+RUN chown -R node:node /app
+USER node
+
 # Set environment variables
 ENV NODE_ENV=production
 ENV PORT=3000

--- a/infra/backup/Dockerfile
+++ b/infra/backup/Dockerfile
@@ -23,4 +23,13 @@ RUN mkdir -p /backups
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
+# Not switching to the image's built-in non-root "postgres" user (uid 70) here:
+# /backups is a bind-mount from the prod host (/opt/relay/data/backups on
+# tr-relay-vm), verified root:root 0755 — a non-root container user would
+# silently lose write access and every nightly backup would fail quietly
+# (entrypoint.sh only log_warns on backup.sh failure, it doesn't crash).
+# Fixing this needs the host dir chowned to uid 70 by someone with prod
+# write access (out of scope here — Team Relay prod access is read-only),
+# then this can switch to `USER postgres`. Tracked: see PR description.
+# nosemgrep: dockerfile.security.missing-user-entrypoint.missing-user-entrypoint
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
## Summary

Two independent pieces:

**1. `min-release-age=7` in `apps/web-publish/.npmrc`** — same npm supply-chain
hardening already applied in evc-argus, evc-site, evc-spark, evc-billing, and
both relay-onprem repos.

**2. Semgrep SAST workflow, after triaging every pre-existing finding first.**
Ran the exact ruleset used on relay-onprem/relay-onprem-enterprise locally
against `main` before adding the gate: 44 findings. Copying the workflow
blind would have landed it red on the first run — instead, each finding was
either fixed or explicitly suppressed with a one-line justification, verified
with a positive control (`--disable-nosem` reproduces all 9 suppressed
findings exactly). Local scan on the fully-triaged tree: 0 findings.

Real fixes (not just suppressions):
- `get_base_url()` no longer trusts client-supplied X-Forwarded-*/Host
  headers to build invite/notification links — switched to
  `settings.control_plane_public_url` (same value `shares.py` already uses
  for this exact reason). Trusting client headers here would let an
  attacker point a victim's invite email at an attacker-controlled domain.
- `invite_page()`'s OAuth authorize/callback URLs are now built via
  `build_invite_oauth_urls()`, which `quote()`s the invite token path
  parameter before re-embedding it — that token reaches the handler raw and
  unvalidated, so an attacker-chosen token containing `&`/`#`/`/` could
  otherwise desync the query string it ends up nested in.
- `verify_password()` no longer logs the raw exception text on a malformed
  password hash, only the exception type — passlib's message isn't
  guaranteed never to echo back hash fragments.
- `control-plane` and `web-publish` containers now run as non-root.
  `infra/backup` is left as root with an inline justification: its
  `/backups` bind-mount on the prod host is `root:root 0755`, verified
  live — switching to the image's non-root `postgres` user would silently
  break every nightly backup. Fixing that needs the host dir re-chowned by
  someone with prod write access (this repo only has read-only DB access
  to Team Relay prod).
- All 28 mutable GitHub Actions tags pinned to commit SHAs.
- 7-day cooldown added to all three Dependabot update streams.

Commit-by-commit breakdown is in the branch history — each finding class got
its own commit with the reasoning inline.

## Test plan

- [x] `apps/control-plane`: full suite green under Python 3.12 (matches
      `uv python install 3.12` in CI and the Dockerfile's `python:3.12-slim`)
      — 692 passed, 1 skipped
- [x] New unit tests for `get_base_url()` header-trust removal and
      `build_invite_oauth_urls()` token quoting in `test_url_utils.py`
- [x] `control-plane` Docker image built + verified running as uid 999
      non-root with a writable `app/static/uploads`
- [x] `infra/backup` Docker image builds unchanged
- [x] Local semgrep scan (same ruleset as the new CI workflow) on the
      final tree: 0 findings, confirmed via `--disable-nosem` positive
      control that every suppression is genuinely active
- [ ] CI green on this PR, then a full-scan run on `main` post-merge —
      diff-aware PR scans don't prove a push-to-main full scan is clean
