### PR TITLE
chore(ci): ignore typescript >=7.0.0 dependabot bumps in apps/web-publish

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,13 @@ updates:
     open-pull-requests-limit: 5
     cooldown:
       default-days: 7
+    ignore:
+      # @sveltejs/kit 2.x declares peerDependencies.typescript = "^5.3.3 || ^6.0.0".
+      # TypeScript 7 is outside that range → npm ci fails on ERESOLVE before typecheck (PR #183).
+      # LIFT when SvelteKit widens the range to 7.x — check with one command:
+      #   npm view @sveltejs/kit peerDependencies.typescript
+      - dependency-name: "typescript"
+        versions: [">=7.0.0"]
 
   # GitHub Actions workflows
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Summary

- @sveltejs/kit 2.x (current latest 2.70.2, verified via `npm view @sveltejs/kit peerDependencies.typescript`) declares `peerDependencies.typescript = "^5.3.3 || ^6.0.0"`. A TS 7.x bump fails `npm ci` on ERESOLVE before any check runs.
- PR #183 (typescript 5.9.3 → 7.0.2) sat red for ~30h before manual close. Without an ignore rule, Dependabot's weekly schedule reopens the same dead-on-arrival PR indefinitely.
- Adds a scoped `ignore: versions: [">=7.0.0"]` rule for `typescript` under the `/apps/web-publish` npm block only — TS 6.x (in SvelteKit's peer range, and thus mergeable) stays unaffected.

## Test plan

- [x] YAML validated with `python3 -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"` — parses cleanly, `ignore` list scoped correctly.
- [x] Confirmed the rule uses `versions: [">=7.0.0"]`, not `update-types: ["version-update:semver-major"]` (which would also block 6.x).
- [ ] Post-merge: check repo Insights → Dependency graph → Dependabot for config parse errors (or lack thereof).
- [ ] Post-merge: `gh pr list --repo entire-vc/evc-team-relay --search "typescript" --state open` → expect empty.

Source: #ae2e9639