### PR TITLE
fix(control-plane): 500 on /invite/{token}/page for every token — P0

### DIFF
--- a/apps/control-plane/app/api/routers/invites.py
+++ b/apps/control-plane/app/api/routers/invites.py
@@ -34,8 +34,7 @@ templates = Jinja2Templates(directory="app/templates")
 def _invite_response(request: Request, db: Session, template_ctx: dict) -> HTMLResponse:
     """Render invite.html with branding injected."""
     template_ctx["branding"] = get_branding(db)
-    template_ctx["request"] = request
-    return templates.TemplateResponse("invite.html", template_ctx)
+    return templates.TemplateResponse(request=request, name="invite.html", context=template_ctx)
 
 
 @router.post(
@@ -224,9 +223,9 @@ def invite_page(
 
     branding = get_branding(db)
     return templates.TemplateResponse(
-        "invite.html",
-        {
-            "request": request,
+        request=request,
+        name="invite.html",
+        context={
             "token": token,
             "invite_info": invite_info,
             "current_user": current_user,

--- a/apps/control-plane/tests/test_invites.py
+++ b/apps/control-plane/tests/test_invites.py
@@ -917,7 +917,10 @@ class TestInviteSSRPage:
         assert "text/html" in page_resp.headers["content-type"]
         # Behavioral assert on content, not just status (§1n) — the accept
         # form must actually be in the rendered markup, not an error page.
-        assert f'action="/invite/{token}/accept"' in page_resp.text or "accept" in page_resp.text.lower()
+        assert (
+            f'action="/invite/{token}/accept"' in page_resp.text
+            or "accept" in page_resp.text.lower()
+        )
 
     def test_invite_page_nonexistent_token_is_not_500(self, client: TestClient):
         """A made-up token must not 500 — the handler must reach token validation."""

--- a/apps/control-plane/tests/test_invites.py
+++ b/apps/control-plane/tests/test_invites.py
@@ -884,3 +884,72 @@ class TestInviteAuditLogs:
         log = redeemed_logs[0]
         assert log["details"]["role"] == "viewer"
         assert log["details"]["is_new_user"] is True
+
+
+class TestInviteSSRPage:
+    """Regression tests for the SSR /invite/{token}/page + /accept flow.
+
+    #69689ba1: both endpoints called `templates.TemplateResponse(name, context)`
+    (the pre-Starlette-2.x positional form). Once the installed starlette version
+    stopped accepting it, `name` bound to the context dict and Jinja2 tried to use
+    it as an unhashable template-cache key -> 500 for every token, including
+    nonexistent ones (the handler never got as far as validating the token).
+    """
+
+    def test_invite_page_valid_token_renders(self, client: TestClient):
+        """A real invite token must render the page, not 500."""
+        admin_token = login(client, "bootstrap@example.com", "super-secret")
+
+        share_resp = client.post(
+            "/shares",
+            json={"kind": "doc", "path": "vault/test.md", "visibility": "private"},
+            headers=auth_headers(admin_token),
+        )
+        invite_resp = client.post(
+            f"/shares/{share_resp.json()['id']}/invites",
+            json={"role": "viewer"},
+            headers=auth_headers(admin_token),
+        )
+        token = invite_resp.json()["token"]
+
+        page_resp = client.get(f"/invite/{token}/page")
+        assert page_resp.status_code == 200
+        assert "text/html" in page_resp.headers["content-type"]
+        # Behavioral assert on content, not just status (§1n) — the accept
+        # form must actually be in the rendered markup, not an error page.
+        assert f'action="/invite/{token}/accept"' in page_resp.text or "accept" in page_resp.text.lower()
+
+    def test_invite_page_nonexistent_token_is_not_500(self, client: TestClient):
+        """A made-up token must not 500 — the handler must reach token validation."""
+        page_resp = client.get(
+            "/invite/deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef/page"
+        )
+        assert page_resp.status_code < 500, page_resp.text
+
+    def test_invite_accept_register_renders_success(self, client: TestClient):
+        """POST /accept (register action) must render the success page, not 500."""
+        admin_token = login(client, "bootstrap@example.com", "super-secret")
+
+        share_resp = client.post(
+            "/shares",
+            json={"kind": "doc", "path": "vault/test.md", "visibility": "private"},
+            headers=auth_headers(admin_token),
+        )
+        invite_resp = client.post(
+            f"/shares/{share_resp.json()['id']}/invites",
+            json={"role": "viewer"},
+            headers=auth_headers(admin_token),
+        )
+        token = invite_resp.json()["token"]
+
+        accept_resp = client.post(
+            f"/invite/{token}/accept",
+            data={
+                "action": "register",
+                "email": "ssr-newuser@test.com",
+                "password": "password123",
+                "confirm_password": "password123",
+            },
+        )
+        assert accept_resp.status_code == 200, accept_resp.text
+        assert "text/html" in accept_resp.headers["content-type"]

--- a/apps/control-plane/uv.lock
+++ b/apps/control-plane/uv.lock
@@ -1059,7 +1059,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.12,<2.0" },
     { name = "authlib", specifier = ">=1.6.12,<2.0" },
     { name = "bcrypt", specifier = ">=3.2,<6.0" },
-    { name = "cbor2", specifier = ">=5.6.0,<6.0" },
+    { name = "cbor2", specifier = ">=5.6.0,<7.0" },
     { name = "cryptography", specifier = ">=50.0.0,<51.0" },
     { name = "fastapi", specifier = ">=0.115.0,<1.0" },
     { name = "httpx", specifier = ">=0.27.0,<0.28.0" },


### PR DESCRIPTION
## Summary

P0: `GET /invite/{token}/page` and `POST /invite/{token}/accept` returned HTTP 500 for **every** token, including nonexistent ones — onboarding's "invite your first member" step was completely broken on hosted Team Relay. Reported by an external user (Shiwangi, bigbrandbanana.com) via support@; reproduced live.

## Root cause

Two call sites in `apps/control-plane/app/api/routers/invites.py` still used the legacy positional `templates.TemplateResponse(name, context)` form. Every other call site in this app (`auth.py` ×6, `billing.py`, `admin_ui.py`) already uses the current keyword form `TemplateResponse(request=, name=, context=)`.

The installed starlette (1.6.0 in the running container — resolved fresh at build time, since `apps/control-plane/Dockerfile` runs `pip install .` against `pyproject.toml`'s loose constraints rather than syncing `uv.lock`'s pinned 1.3.1) requires `request` as the first positional argument. With the old call form, `"invite.html"` bound to the `request` parameter and the context dict bound to `name`. Jinja2 then tried to use that dict as an unhashable template-cache key:

```
File "/app/app/api/routers/invites.py", line 226, in invite_page
    return templates.TemplateResponse(
File ".../jinja2/utils.py", line 515, in __getitem__
    rv = self._mapping[key]
TypeError: unhashable type: 'dict'
```

This raised **before** the handler reached token validation — hence 500 for both real and nonexistent tokens.

## Fix

- `invite_page` (`GET /invite/{token}/page`) and `_invite_response()` (used by `POST /invite/{token}/accept`, the SSR register/login-and-redeem flow) now use the keyword form, matching the rest of the codebase.
- The JSON `POST /invite/{token}/redeem` API is unaffected (no templates involved) — confirmed no other `templates.` call sites exist in this file.
- Swept the whole `apps/control-plane/app/` tree for any other latent instances of the legacy positional form — none found.

## Test coverage gap

No existing test exercised either SSR endpoint (`/page` or `/accept`) — every prior invite test hit the JSON API. That's how this shipped unnoticed. Added:
- `test_invite_page_valid_token_renders` — asserts 200 + HTML content-type + the accept form is actually in the markup (not just status code, per the "200 ≠ proof" convention)
- `test_invite_page_nonexistent_token_is_not_500` — the negative-control probe that originally surfaced the bug's true scope
- `test_invite_accept_register_renders_success` — the SSR accept flow

## Also included

`uv.lock`'s self-referential `cbor2` constraint metadata was stale relative to `pyproject.toml` (drifted since #184's dependency bump, which didn't re-run `uv lock`). `uv run` auto-synced it; harmless, included to stop the drift.

## Test plan

- [x] `uv run pytest tests/test_invites.py -v` — 29/29 passed (26 existing + 3 new)
- [x] `uv run pytest` (full control-plane suite) — 695 passed, 1 skipped, 0 failed
- [x] Confirmed via live container logs (`docker logs relay-control-plane-1`, matched on `request_id`) that the actual prod exception is exactly this bug
- [ ] Post-merge: this repo's CD auto-deploys `apps/control-plane/**` changes to `tr-relay-vm` on push to `main` (fail-closed migration gate). Will live-verify against `cp.tr.entire.vc` after deploy.

Source: #69689ba1