### PR TITLE
ci(web-publish): bump Node 20 -> 22 LTS in CI and Docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: apps/web-publish/package-lock.json
 
@@ -61,7 +61,7 @@ jobs:
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: apps/web-publish/package-lock.json
 

--- a/apps/web-publish/Dockerfile
+++ b/apps/web-publish/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Build stage
-FROM node:20-alpine AS builder
+FROM node:22-alpine AS builder
 
 WORKDIR /app
 
@@ -21,7 +21,7 @@ RUN npm run build
 RUN npm prune --production
 
 # Production stage
-FROM node:20-alpine
+FROM node:22-alpine
 
 WORKDIR /app
 
@@ -30,7 +30,7 @@ COPY --from=builder /app/build ./build
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/package.json ./
 
-# node:20-alpine ships a non-root "node" user (uid 1000) — use it instead of root
+# node:22-alpine ships a non-root "node" user (uid 1000) — use it instead of root
 RUN chown -R node:node /app
 USER node
 

--- a/apps/web-publish/package.json
+++ b/apps/web-publish/package.json
@@ -3,6 +3,9 @@
   "version": "1.8.0",
   "private": true,
   "type": "module",
+  "engines": {
+    "node": ">=22"
+  },
   "scripts": {
     "dev": "vite dev",
     "build": "vite build",


### PR DESCRIPTION
## Summary

Node 20 reached end-of-life 2026-04-30 (102 days ago) — no more security patches. CI (`typecheck-svelte`, `test-svelte`) and the `web-publish` Docker image (both build and runtime stages) were still pinned to `node:20-alpine`.

This silently blocked dependency updates: `isomorphic-dompurify@3.21` pulls `jsdom@30`, which declares `engines.node = "^22.22.2 || ^24.15.0 || >=26.0.0"`. npm's `EBADENGINE` is a **warning**, not an error, so it installed anyway and failed later at import time with an unrelated-looking `undici` error — misdiagnosed twice (#174, #185) as "breaking package" before the Node version was identified as the actual cause (#b85846d4).

## Changes
- `.github/workflows/ci.yml` — both `node-version: '20'` → `'22'` (typecheck-svelte, test-svelte)
- `apps/web-publish/Dockerfile` — both `FROM node:20-alpine` → `node:22-alpine` (builder **and** runtime stage — same major on both, per the task's explicit warning about split-version drift)
- `apps/web-publish/package.json` — added `"engines": { "node": ">=22" }` so future runtime drift is caught by npm at install time instead of resurfacing as a mystery failure in an unrelated dependency's stack trace

Chose 22 over 24: conservative one-major step with runway to 2027-04-30; 24 is a follow-up if wanted, not bundled here. Did **not** touch `isomorphic-dompurify`/`jsdom` in this PR — runtime bump first, deps come back on their own next Dependabot cycle and install cleanly once the engine constraint is met.

## Verification (local, before push)

Ran on the actual Node 22.22.3 already default on this machine, plus the real production Dockerfile:
- `npm ci` — clean, **no EBADENGINE**
- `npm run check` (svelte-check) — `0 ERRORS 0 WARNINGS`
- `npm test` (vitest) — `71/71 passed`
- `docker buildx build` on `node:22-alpine` — succeeds end-to-end (builder + runtime stage)
- Ran the built image against the **real prod control-plane API** (`CONTROL_PLANE_URL=https://cp.tr.entire.vc`): `node --version` in container → `v22.23.2`; root page → HTTP 200 with real branded content (`DOCS` branding, not an error page); Docker's own `HEALTHCHECK` → `healthy`

## Test plan

- [x] All three CI checks green on Node 22 (see run log below once pushed — will cite the exact `setup-node`/build log line, not just "CI green")
- [ ] Merge to `main` — **does NOT auto-deploy web-publish**: `deploy.yml`'s push trigger only watches `apps/control-plane/**` + `scripts/deploy.sh`, and its remote invocation of `scripts/deploy.sh` is hardcoded to the `control-plane` component. Confirmed by reading the workflow, not assumed by analogy from the control-plane-is-now-automated finding in a sibling task.
- [ ] Manual deploy via `bash scripts/deploy.sh web-publish` (driver mode — rsyncs `apps/web-publish/` to `tr-relay-vm`, builds, restarts; auto-tags current image as `infra-web-publish:prev` for rollback before touching anything)
- [ ] Live verify: `node --version` in the deployed container → v22.x; a real published share page returns actual content (not just 200)

Source: #d94a6aa2