### PR TITLE
chore(infra): sync relay-server pin to 0.9.9 (repo copy was three versions stale)

### DIFF
--- a/apps/control-plane/app/services/email_service.py
+++ b/apps/control-plane/app/services/email_service.py
@@ -249,11 +249,12 @@ class EmailService:
             email_type: Email type for logging/metrics
 
         Returns:
-            True if sent successfully
+            True if sent successfully. False if disabled (TR-04, #ac65cfe5)
+            or delivery failed — either way, no email left the building.
         """
         if not self.email_enabled:
             self._log_email(to_email, subject, text_body, email_type)
-            return True
+            return False
 
         msg = self._create_mime_message(to_email, subject, text_body, html_body)
         return self._send_smtp(msg)
@@ -326,18 +327,23 @@ class EmailService:
         Returns:
             True if sent successfully
         """
-        email.attempt_count += 1
-
         if not self.email_enabled:
-            # Just log and mark as sent
+            # TR-04 (#ac65cfe5): a disabled transport is not a delivery
+            # outcome — it must not fabricate SENT (the row would then lie
+            # forever about having reached the recipient) and must not burn
+            # retry budget on an attempt that never touched SMTP. Release
+            # the SENDING claim back to PENDING, untouched attempt_count,
+            # so the next worker cycle — or the moment EMAIL_ENABLED flips
+            # back on — picks it up for a real send.
             self._log_email(email.to_email, email.subject, email.body_text, email.email_type)
-            email.status = EmailStatus.SENT
-            email.sent_at = datetime.now(timezone.utc)
-            email.next_retry_at = None
+            email.status = EmailStatus.PENDING
             email.claimed_at = None
+            email.error_message = "Email delivery disabled (EMAIL_ENABLED=false); not sent"
             db.add(email)
             db.commit()
-            return True
+            return False
+
+        email.attempt_count += 1
 
         msg = self._create_mime_message(
             email.to_email, email.subject, email.body_text, email.body_html

--- a/apps/control-plane/tests/test_email_disabled_no_fake_sent.py
+++ b/apps/control-plane/tests/test_email_disabled_no_fake_sent.py
@@ -1,0 +1,135 @@
+"""Tests for TR-04 (#ac65cfe5): EMAIL_ENABLED=false must not fabricate SENT.
+
+Before this fix, a disabled transport made two independent false claims:
+- `EmailService.send_email()` (the inline path used by password-reset /
+  email-verification) returned `True` without ever touching SMTP.
+- `EmailService.process_queued_email()` (the queue worker path used by
+  invites / member_added / security alerts / lifecycle nudges) marked the
+  row `SENT` with a real `sent_at` timestamp. 1434 rows accumulated this
+  way between 2026-07-10 and 2026-07-21 while `EMAIL_ENABLED=false` on
+  every Team Relay container post-Helsinki-cutover, and the DB had no way
+  to distinguish them from real deliveries.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.db.models import EmailQueue, EmailStatus
+from app.services import email_service
+
+
+def make_email(
+    db: Session,
+    status: EmailStatus = EmailStatus.SENDING,
+    attempt_count: int = 0,
+) -> EmailQueue:
+    email = EmailQueue(
+        to_email="someone@example.com",
+        subject="Test",
+        body_text="body",
+        body_html="<p>body</p>",
+        email_type="invite_notification",
+        status=status,
+        attempt_count=attempt_count,
+    )
+    db.add(email)
+    db.commit()
+    db.refresh(email)
+    return email
+
+
+class TestSendEmailDisabledReturnsFalse:
+    @pytest.mark.asyncio
+    async def test_disabled_transport_returns_false_not_true(self):
+        svc = email_service.EmailService()
+        svc.email_enabled = False
+
+        result = await svc.send_email(
+            "someone@example.com", "Subject", "body", email_type="password_reset"
+        )
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_enabled_but_unconfigured_smtp_also_returns_false(self):
+        """Sanity check the two failure modes stay distinguishable in code
+        even though both currently return False: disabled (config choice)
+        vs. enabled-but-broken (real outage) are different signals for an
+        operator, even if this particular return type can't carry that."""
+        svc = email_service.EmailService()
+        svc.email_enabled = True
+        svc.smtp_host = ""
+
+        result = await svc.send_email(
+            "someone@example.com", "Subject", "body", email_type="password_reset"
+        )
+
+        assert result is False
+
+
+class TestProcessQueuedEmailDisabledDoesNotFakeSent:
+    @pytest.mark.asyncio
+    async def test_disabled_transport_leaves_row_pending_not_sent(self, db_session: Session):
+        svc = email_service.EmailService()
+        svc.email_enabled = False
+        email = make_email(db_session, status=EmailStatus.SENDING, attempt_count=0)
+
+        result = await svc.process_queued_email(db_session, email)
+
+        assert result is False
+        assert email.status == EmailStatus.PENDING
+        assert email.sent_at is None
+        assert email.claimed_at is None
+
+    @pytest.mark.asyncio
+    async def test_disabled_transport_does_not_consume_retry_budget(self, db_session: Session):
+        """A disabled transport is not a delivery attempt — attempt_count
+        must stay untouched so a later real send starts with its full
+        retry budget instead of arriving pre-exhausted."""
+        svc = email_service.EmailService()
+        svc.email_enabled = False
+        email = make_email(db_session, status=EmailStatus.SENDING, attempt_count=2)
+
+        await svc.process_queued_email(db_session, email)
+
+        assert email.attempt_count == 2
+
+    @pytest.mark.asyncio
+    async def test_disabled_transport_error_message_names_the_real_reason(
+        self, db_session: Session
+    ):
+        svc = email_service.EmailService()
+        svc.email_enabled = False
+        email = make_email(db_session, status=EmailStatus.SENDING, attempt_count=0)
+
+        await svc.process_queued_email(db_session, email)
+
+        assert email.error_message is not None
+        assert "disabled" in email.error_message.lower()
+
+    @pytest.mark.asyncio
+    async def test_re_enabling_lets_a_previously_skipped_row_actually_send(
+        self, db_session: Session
+    ):
+        """End-to-end of the bug's own lifecycle: skipped while disabled,
+        then a real send succeeds once the flag flips — the row must not
+        have been left in a state (SENT, or budget-exhausted FAILED) that
+        blocks the real attempt from ever happening."""
+        svc = email_service.EmailService()
+        svc.email_enabled = False
+        email = make_email(db_session, status=EmailStatus.SENDING, attempt_count=0)
+        await svc.process_queued_email(db_session, email)
+        assert email.status == EmailStatus.PENDING
+
+        svc.email_enabled = True
+        svc._send_smtp = lambda msg: True  # noqa: SLF001 — stub the real SMTP call
+        email.status = EmailStatus.SENDING  # simulate the next claim cycle
+
+        result = await svc.process_queued_email(db_session, email)
+
+        assert result is True
+        assert email.status == EmailStatus.SENT
+        assert email.sent_at is not None
+        assert email.attempt_count == 1

--- a/apps/control-plane/tests/test_email_queue_claim.py
+++ b/apps/control-plane/tests/test_email_queue_claim.py
@@ -136,12 +136,34 @@ class TestProcessQueuedEmailReleasesClaim:
         email = _make_email(
             db_session, status=EmailStatus.SENDING, claimed_at=datetime.now(timezone.utc)
         )
-        email_service.email_enabled = False  # log-and-mark-sent path
+        email_service.email_enabled = True
+        email_service._send_smtp = lambda msg: True  # type: ignore[method-assign]
 
         result = await email_service.process_queued_email(db_session, email)
 
         assert result is True
         assert email.status == EmailStatus.SENT
+        assert email.claimed_at is None
+
+    @pytest.mark.asyncio
+    async def test_disabled_transport_clears_claim_without_marking_sent(
+        self, db_session: Session, email_service: EmailService
+    ):
+        """TR-04 (#ac65cfe5): a disabled transport used to take this exact
+        branch and fabricate SENT — the row released its claim but the DB
+        recorded a delivery that never happened. Disabled now releases the
+        claim back to PENDING instead, so the row is retried for real once
+        EMAIL_ENABLED flips back on."""
+        email = _make_email(
+            db_session, status=EmailStatus.SENDING, claimed_at=datetime.now(timezone.utc)
+        )
+        email_service.email_enabled = False
+
+        result = await email_service.process_queued_email(db_session, email)
+
+        assert result is False
+        assert email.status == EmailStatus.PENDING
+        assert email.sent_at is None
         assert email.claimed_at is None
 
     @pytest.mark.asyncio

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -239,7 +239,7 @@ services:
         condition: service_completed_successfully
 
   relay-server:
-    image: ghcr.io/entire-vc/evc-relay-server:0.9.7
+    image: ghcr.io/entire-vc/evc-relay-server:0.9.9
     depends_on:
       minio:
         condition: service_healthy


### PR DESCRIPTION
## Что

Прод на `tr-relay-vm` переведён на `ghcr.io/entire-vc/evc-relay-server:0.9.9` (сборка с `rustls-webpki` 0.103.4 → 0.103.14). В `infra/docker-compose.yml` пин оставался на **0.9.7** — три версии назад.

## Почему это не косметика

Боевой compose живёт на хосте в `/opt/relay/docker-compose.yml`. `scripts/deploy.sh` его **никогда не перезаписывает** — он rsync'ит только `apps/<component>/` и падает, если compose на хосте отсутствует (`[ -f docker-compose.yml ] || die`). То есть копия в репо — документация, а не источник правды, и она молча разъехалась.

Разъезд рабочий, а не теоретический: любой, кто скопирует `infra/docker-compose.yml` на хост, откатит релей с 0.9.9 на 0.9.7 — мимо security-фикса, без ошибки и без заметного сигнала. Привожу обе стороны к одному значению.

## Проверка

```
tr-relay-vm: relay-relay-server-1  ghcr.io/entire-vc/evc-relay-server:0.9.9  Up (healthy)
curl -sI https://tr.entire.vc/ → relay-server-version: 0.9.9
```
