### PR TITLE
fix(control-plane): one read-scope policy for agent keys, not two

### DIFF
--- a/apps/control-plane/app/api/routers/agent_keys.py
+++ b/apps/control-plane/app/api/routers/agent_keys.py
@@ -79,7 +79,20 @@ _VALID_SCOPES = {"read", "write"}
 class AgentKeyCreateRequest(BaseModel):
     label: str | None = Field(default=None, min_length=1)
     expires_at: datetime | None = None
-    scopes: list[str] = Field(default_factory=lambda: ["write"])
+    # Default is read+write, not write-only (#b69d73fb, ADR-0001).
+    #
+    # The Obsidian plugin is the only user-facing way to create an agent key and
+    # it does not send `scopes` at all — CreateAgentKeyRequest carries only
+    # `label` and `expires_at` — so this default is what every key made through
+    # the product UI gets. With the old write-only default those keys silently
+    # could not read: the MCP server's read_file (GET .../download) answered
+    # "Agent key does not have read scope" to a key the user had just created
+    # for exactly that purpose. Seven such keys exist in production.
+    #
+    # A drop-box key that may write but never read remains available and is now
+    # what it should be: an explicit `{"scopes": ["write"]}`, which is the right
+    # shape for a deliberate restriction.
+    scopes: list[str] = Field(default_factory=lambda: ["read", "write"])
 
     @field_validator("label")
     @classmethod
@@ -217,6 +230,38 @@ def create_agent_key(
     )
 
 
+def _to_list_item(k: models.ShareAgentKey, now: datetime) -> "AgentKeyListItem":
+    """Serialise a key row for the API.
+
+    Shared by list and PATCH so the two cannot drift — is_active in particular
+    is a derived value, and a second hand-rolled copy of that expression is how
+    endpoints start disagreeing about the same row.
+    """
+    return AgentKeyListItem(
+        id=str(k.id),
+        label=k.label,
+        share_id=str(k.share_id),
+        scopes=list(k.scopes.split(",")) if "," in k.scopes else [k.scopes],
+        created_by=str(k.created_by) if k.created_by else None,
+        last_used_at=k.last_used_at,
+        expires_at=k.expires_at,
+        revoked_at=k.revoked_at,
+        created_at=k.created_at,
+        is_active=(
+            k.revoked_at is None
+            and (
+                k.expires_at is None
+                or (
+                    k.expires_at.replace(tzinfo=timezone.utc)
+                    if k.expires_at.tzinfo is None
+                    else k.expires_at
+                )
+                > now
+            )
+        ),
+    )
+
+
 @router.get("", response_model=list[AgentKeyListItem])
 def list_agent_keys(
     share_id: str,
@@ -230,32 +275,7 @@ def list_agent_keys(
     keys = db.execute(stmt).scalars().all()
 
     now = security.utcnow()
-    return [
-        AgentKeyListItem(
-            id=str(k.id),
-            label=k.label,
-            share_id=str(k.share_id),
-            scopes=list(k.scopes.split(",")) if "," in k.scopes else [k.scopes],
-            created_by=str(k.created_by) if k.created_by else None,
-            last_used_at=k.last_used_at,
-            expires_at=k.expires_at,
-            revoked_at=k.revoked_at,
-            created_at=k.created_at,
-            is_active=(
-                k.revoked_at is None
-                and (
-                    k.expires_at is None
-                    or (
-                        k.expires_at.replace(tzinfo=timezone.utc)
-                        if k.expires_at.tzinfo is None
-                        else k.expires_at
-                    )
-                    > now
-                )
-            ),
-        )
-        for k in keys
-    ]
+    return [_to_list_item(k, now) for k in keys]
 
 
 @router.delete("/{key_id}", status_code=status.HTTP_200_OK)
@@ -292,3 +312,78 @@ def revoke_agent_key(
         )
 
     return {"id": key_id, "revoked_at": agent_key.revoked_at.isoformat()}
+
+
+class AgentKeyScopesUpdateRequest(BaseModel):
+    scopes: list[str]
+
+    @field_validator("scopes")
+    @classmethod
+    def validate_scopes(cls, v: list[str]) -> list[str]:
+        if not v:
+            raise ValueError("scopes must not be empty")
+        invalid = set(v) - _VALID_SCOPES
+        if invalid:
+            raise ValueError(f"invalid scopes: {invalid}; allowed: {_VALID_SCOPES}")
+        return sorted(set(v))
+
+
+@router.patch("/{key_id}", response_model=AgentKeyListItem)
+def update_agent_key_scopes(
+    share_id: str,
+    key_id: str,
+    payload: AgentKeyScopesUpdateRequest,
+    request: Request,
+    db: Session = Depends(get_db),
+) -> AgentKeyListItem:
+    """Change an existing key's scopes without rotating the secret.
+
+    Added for the ADR-0001 migration (#b69d73fb). Keys created before the
+    default changed are write-only, and under the unified literal policy they
+    stop being able to read. The only previous way to grant them `read` was
+    revoke-and-reissue, which changes the raw key and therefore requires
+    reconfiguring whatever integration holds it — a coordination cost heavy
+    enough that owners would reasonably skip the migration and just discover
+    the breakage later. Editing the scopes in place keeps the secret stable,
+    so granting `read` is a one-call, non-disruptive change.
+
+    Owner/admin only, exactly like create and revoke: scopes are the
+    authorization surface, so widening them must need the same standing as
+    minting a key in the first place. A revoked key is not editable — bringing
+    one back by granting scopes would quietly undo a revocation.
+    """
+    share, user_id = _require_share_owner_or_admin(share_id, request, db)
+
+    stmt = select(models.ShareAgentKey).where(
+        models.ShareAgentKey.id == uuid.UUID(key_id),
+        models.ShareAgentKey.share_id == uuid.UUID(share_id),
+    )
+    agent_key = db.execute(stmt).scalar_one_or_none()
+    if not agent_key:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Agent key not found")
+
+    if agent_key.revoked_at is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Agent key has been revoked; issue a new key instead",
+        )
+
+    previous = agent_key.scopes
+    agent_key.scopes = ",".join(payload.scopes)
+    db.commit()
+    db.refresh(agent_key)
+
+    logger.info(
+        "agent_key.scopes_updated",
+        extra={
+            "event": "agent_key.scopes_updated",
+            "key_id": key_id,
+            "share_id": share_id,
+            "previous_scopes": previous,
+            "new_scopes": agent_key.scopes,
+            "updated_by": str(user_id),
+            "ip": request.client.host if request.client else None,
+        },
+    )
+
+    return _to_list_item(agent_key, security.utcnow())

--- a/apps/control-plane/app/api/routers/web.py
+++ b/apps/control-plane/app/api/routers/web.py
@@ -26,7 +26,7 @@ from slowapi.util import get_remote_address
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from app.core import security
+from app.core import agent_key_scopes, security
 from app.core.config import get_settings
 from app.db import models
 from app.db.session import get_db
@@ -89,19 +89,43 @@ def _require_private_web_auth(
                 if exp.tzinfo is None:
                     exp = exp.replace(tzinfo=_tz.utc)
             if exp is None or exp >= security.utcnow():
-                scopes = {s.strip() for s in agent_key.scopes.split(",") if s.strip()}
+                scopes = agent_key_scopes.parse_scopes(agent_key.scopes)
                 has_any = bool(scopes & {"read", "write"})
-                # write implies read: a write-scoped key satisfies a read requirement
-                if required_scope == "read":
-                    has_required = bool(scopes & {"read", "write"})
-                else:
-                    has_required = required_scope in scopes
+                # Single source of truth for the policy — see ADR-0001 and
+                # app/core/agent_key_scopes.py. This route family used to answer
+                # "write implies read" while /download and /files-index answered
+                # the literal question, so one key read the same document through
+                # one route and was refused it through the other (#b69d73fb).
+                has_required = agent_key_scopes.check(
+                    scopes,
+                    required_scope,
+                    grace=get_settings().agent_key_lenient_read_grace,
+                    key_id=agent_key.id,
+                    share_id=share.id,
+                    route=request.url.path,
+                )
                 if has_any and not has_required:
                     raise HTTPException(
                         status_code=status.HTTP_403_FORBIDDEN,
                         detail=f"Agent key does not have {required_scope} scope",
                     )
                 if has_any:
+                    # Record use here too. Until now only _auth_share_read_access
+                    # stamped last_used_at, so every read through this route family
+                    # was invisible in the key's usage record — which is exactly why
+                    # "is anyone reading with a write-only key?" could not be
+                    # answered from the data (#b69d73fb).
+                    #
+                    # Committed here rather than left to the caller: every route in
+                    # this family is a GET that commits nothing, so an uncommitted
+                    # stamp would be silently discarded — the same blind spot in a
+                    # new costume. Failure to record usage must never fail the
+                    # request, hence the rollback-and-continue.
+                    agent_key.last_used_at = security.utcnow()
+                    try:
+                        db.commit()
+                    except Exception:  # pragma: no cover - telemetry must not 500
+                        db.rollback()
                     return  # authenticated via agent key with sufficient scope
 
     # --- User JWT path ---
@@ -1485,7 +1509,12 @@ def _auth_agent_key(
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN, detail="Agent key has expired"
             )
-    if required_scope and required_scope not in set(agent_key.scopes.split(",")):
+    # Third helper, same policy object (ADR-0001). Only ever called with
+    # required_scope="write" today; routed through the shared check so a future
+    # read-requiring caller cannot silently reintroduce a fourth answer.
+    if required_scope and not agent_key_scopes.satisfies(
+        agent_key_scopes.parse_scopes(agent_key.scopes), required_scope
+    ):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=f"Agent key does not have {required_scope} scope",
@@ -1535,7 +1564,19 @@ def _auth_share_read_access(share: models.Share, request: Request, db: Session) 
                 raise HTTPException(
                     status_code=status.HTTP_403_FORBIDDEN, detail="Agent key has expired"
                 )
-        if "read" not in set(agent_key.scopes.split(",")):
+        # Same policy object as _require_private_web_auth — see ADR-0001. These
+        # two helpers used to disagree about whether a write-only key may read,
+        # on route families that return identical bytes (#b69d73fb).
+        #
+        # Deliberately NO grace here. Grace exists to keep the LENIENT routes
+        # behaving exactly as they did while their population is measured; it is
+        # not a licence to widen this one. These routes are UUID-addressable and
+        # therefore reach shares that were never web-published — where a
+        # write-only key can read nothing today. Extending grace here would hand
+        # five external customers' write-only keys read access to unpublished
+        # private vault content, which is the regression this whole change exists
+        # to avoid. Convergence happens by the lenient side tightening.
+        if not agent_key_scopes.satisfies(agent_key_scopes.parse_scopes(agent_key.scopes), "read"):
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Agent key does not have read scope",
@@ -1583,8 +1624,7 @@ def _auth_share_read_access(share: models.Share, request: Request, db: Session) 
     raise HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
         detail=(
-            "Authentication required: provide X-Agent-Key header "
-            "or Authorization: Bearer <token>"
+            "Authentication required: provide X-Agent-Key header or Authorization: Bearer <token>"
         ),
         headers={"WWW-Authenticate": "Bearer"},
     )

--- a/apps/control-plane/app/core/agent_key_scopes.py
+++ b/apps/control-plane/app/core/agent_key_scopes.py
@@ -30,8 +30,9 @@ literal ``read`` and reads through them today.  So the tightening ships behind
   through a read gate, exactly as before, but every such call is logged as a
   WARNING naming the key and the route.  Behaviour is unchanged; the previously
   invisible population becomes measurable.
-* grace **off** (phase 2) — the literal policy applies everywhere and the two
-  route families finally agree.
+* grace **off** (phase 3, after phase 2 migrates the keys the WARNING names) —
+  the literal policy applies everywhere and the two route families finally
+  agree.
 
 Flipping is a config change, so it is reversible in seconds without a redeploy.
 """

--- a/apps/control-plane/app/core/agent_key_scopes.py
+++ b/apps/control-plane/app/core/agent_key_scopes.py
@@ -1,0 +1,108 @@
+"""Canonical read/write scope policy for share agent keys.
+
+Why this module exists
+----------------------
+Until 2026-08-19 the same question — "may this agent key read this share's
+content?" — was answered by two different pieces of code with two different
+answers (task #b69d73fb):
+
+* ``_require_private_web_auth`` (web.py) treated **write as implying read**, and
+  served document content to a write-only key on ``GET /v1/web/shares/{slug}``,
+  ``/files`` and ``/assets``.
+* ``_auth_share_read_access`` (web.py) required the **literal** ``read`` scope,
+  and answered 403 to that same key on ``/download`` and ``/files-index``.
+
+Both routes return the same bytes, so one key on one share could read a document
+through one route and be refused it through the other. The split was invisible
+to callers, who reasonably read the 403 as "this endpoint does not exist".
+
+The policy is LITERAL: a scope is satisfied only by itself.  ``write`` does not
+imply ``read``.  The decision and its evidence are recorded in
+``docs/adrs/0001-unified-agent-key-read-scope-policy.md``.
+
+Migrating to it without breaking live integrations
+--------------------------------------------------
+Tightening the lenient routes is a breaking change for any key that lacks a
+literal ``read`` and reads through them today.  So the tightening ships behind
+``AGENT_KEY_LENIENT_READ_GRACE`` (see ``Settings.agent_key_lenient_read_grace``):
+
+* grace **on** (phase 1, current default) — a write-only key is still allowed
+  through a read gate, exactly as before, but every such call is logged as a
+  WARNING naming the key and the route.  Behaviour is unchanged; the previously
+  invisible population becomes measurable.
+* grace **off** (phase 2) — the literal policy applies everywhere and the two
+  route families finally agree.
+
+Flipping is a config change, so it is reversible in seconds without a redeploy.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def parse_scopes(raw: str | None) -> set[str]:
+    """Split the stored comma-separated ``scopes`` column into a set.
+
+    Tolerates padding and empty segments — the column is free-form text, and a
+    stray space must not silently strip a scope.
+    """
+    if not raw:
+        return set()
+    return {s.strip() for s in raw.split(",") if s.strip()}
+
+
+def satisfies(scopes: set[str], required: str) -> bool:
+    """The canonical policy: literal scope match, no implication between scopes."""
+    return required in scopes
+
+
+def would_be_denied_without_grace(scopes: set[str], required: str) -> bool:
+    """True when only the legacy write-implies-read leniency lets this through.
+
+    Used to log the migration signal, and to decide whether grace is what is
+    carrying the request.
+    """
+    return not satisfies(scopes, required) and required == "read" and "write" in scopes
+
+
+def check(
+    scopes: set[str],
+    required: str,
+    *,
+    grace: bool,
+    key_id: object = None,
+    share_id: object = None,
+    route: str = "",
+) -> bool:
+    """Decide whether a key holding ``scopes`` may perform ``required``.
+
+    Returns True/False rather than raising: the two call sites in web.py raise
+    different HTTPException shapes, and preserving those exact messages matters
+    more than sharing the raise.
+
+    When ``grace`` is on and the call only passes because of it, emits a WARNING
+    naming the key, share and route — that log line is the measurement that
+    tells us which keys still need migrating before the grace can be withdrawn.
+    """
+    if satisfies(scopes, required):
+        return True
+
+    if grace and would_be_denied_without_grace(scopes, required):
+        logger.warning(
+            "agent key passed a read gate only via the legacy write-implies-read "
+            "grace; it will be denied once AGENT_KEY_LENIENT_READ_GRACE is off",
+            extra={
+                "agent_key_id": str(key_id) if key_id is not None else None,
+                "share_id": str(share_id) if share_id is not None else None,
+                "route": route,
+                "scopes": sorted(scopes),
+                "required_scope": required,
+                "event": "agent_key_read_scope_grace",
+            },
+        )
+        return True
+
+    return False

--- a/apps/control-plane/app/core/config.py
+++ b/apps/control-plane/app/core/config.py
@@ -220,6 +220,17 @@ class Settings(BaseSettings):
             "(TR-45) — matches the prod-DB-password rotation cadence used elsewhere."
         ),
     )
+    agent_key_lenient_read_grace: bool = Field(
+        default=True,
+        description=(
+            "Phase-1 migration switch for the unified read-scope policy (#b69d73fb, "
+            "ADR-0001). While true, a write-only key is still admitted through a read "
+            "gate — as it always was on /files, /assets and share metadata — and each "
+            "such call is logged as a WARNING naming the key. Set false to enforce the "
+            "literal policy on every read route. Withdraw only once the WARNING has "
+            "been quiet for a full window and the keys it named carry 'read'."
+        ),
+    )
     invite_default_ttl_days: int = Field(
         default=30,
         description=(

--- a/apps/control-plane/docs/adrs/0001-unified-agent-key-read-scope-policy.md
+++ b/apps/control-plane/docs/adrs/0001-unified-agent-key-read-scope-policy.md
@@ -1,0 +1,158 @@
+# ADR-0001: one read-scope policy for agent keys — literal, not `write ⊃ read`
+
+**Status:** accepted 2026-08-19. Phase 1 shipped; phase 2 (withdrawing the grace) pending the
+migration below.
+**Context:** Mesh task [#b69d73fb](http://mesh.entire.host/t/b69d73fb-d219-4fe2-b61a-01aeb6a8d6dd),
+found by Daedalus while independently checking the API answer given in
+[#f87681cb](http://mesh.entire.host/t/f87681cb-0a79-4eed-8477-eaa46ad85cad).
+
+## Decision
+
+**A scope is satisfied only by itself. `write` does not imply `read`.** This holds on every route
+that serves share content to an agent key. The policy lives in one place —
+`app/core/agent_key_scopes.py` — and all three auth helpers in `web.py` call it.
+
+Two coupled changes ship with it:
+
+1. **New keys default to `["read","write"]`**, not `["write"]`.
+2. **`PATCH /v1/web/shares/{share_id}/agent-keys/{key_id}`** can change an existing key's scopes
+   without rotating the secret.
+
+Both are explained under *Consequences*; neither is cosmetic.
+
+## The defect
+
+Two functions answered the same question differently, on route families that return the **same
+bytes**:
+
+| helper | policy | routes |
+|---|---|---|
+| `_require_private_web_auth` | `write ⊃ read` | `GET /v1/web/shares/{slug}`, `/files`, `/assets` |
+| `_auth_share_read_access` | literal `read` | `GET /v1/web/shares/{id\|slug}/download`, `/files-index` |
+
+So one key, on one share, read a document through `/files` and got
+`403 Agent key does not have read scope` from `/download`. From outside, that 403 reads as
+"the endpoint doesn't exist" — which is exactly how it was reported to us.
+
+Reproduced end-to-end before any fix (write-only key, published private share):
+
+```
+200  GET /v1/web/shares/{slug}
+200  GET /v1/web/shares/{slug}/files      <-- returned the document body
+403  GET /v1/web/shares/{id}/files-index  Agent key does not have read scope
+403  GET /v1/web/shares/{id}/download     Agent key does not have read scope
+```
+
+The split was not visible in production data, because only `_auth_share_read_access` stamped
+`last_used_at`. A key reading through `/files` looked permanently unused. Confirmed live on prod
+against `cp.tr.entire.vc` with a `read,write` key: three lenient reads left `last_used_at` at
+`14:57:43`; one `/download` moved it to `14:58:10`.
+
+## Why literal, and not the cheaper direction
+
+Loosening `_auth_share_read_access` to `write ⊃ read` was the cheap, one-line option. It is the
+wrong one, and the reason is not taste — it is which shares each route family can reach.
+
+The lenient routes resolve a share by `(web_slug, web_published == True)`. On a share that was
+never web-published they **404 by construction**, whatever the key's scopes. The strict routes are
+UUID-addressable and reach those shares.
+
+That asymmetry splits the population in two:
+
+- **Published shares** — a write-only key already reads everything through the lenient routes. The
+  "write-only means it can't see my vault" guarantee is *already false* here, and the strict check
+  on `/download` buys nothing, because the identical bytes are one lenient call away.
+- **Unpublished shares** — a write-only key can read **nothing**: 404 from the lenient routes, 403
+  from the strict ones. Here the guarantee is real and load-bearing today.
+
+So loosening would grant write-only keys read access to unpublished private vault content they
+cannot see today. Measured on prod: **5 of the 7 live write-only keys sit on unpublished shares,
+and 4 of those belong to external customers.** Unifying downward would hand those customers'
+drop-box integrations read access to vaults their owners never published. That is a security
+regression, not a consistency fix.
+
+Tightening has the opposite profile. It only bites keys that lack a literal `read` *and* read
+through the lenient routes — which requires a published share:
+
+```
+label            | share    | published | last_used_at        | creator
+nhbot            | neurohub | t         | (never)             | pavel@venture-crew.com
+mesh-spark-sync  | spark    | t         | 2026-08-11 06:33    | pavel@venture-crew.com
+```
+
+**Blast radius: two keys, both ours, one never used.** No external customer key is affected.
+
+(`last_used_at` on a write-only key necessarily records a *write*: the scope check in
+`_auth_share_read_access` raises before the timestamp is written, and the lenient routes did not
+write it at all. So `mesh-spark-sync`'s timestamp is an upload, not a read.)
+
+## Why the creation default changes too
+
+The Obsidian plugin is the **only** user-facing way to create an agent key, and it does not send
+`scopes` at all — its `CreateAgentKeyRequest` carries `label` and `expires_at` and nothing else
+(`RelayOnPremShareClient.ts`, and both the modal and the Svelte view). The server default is
+therefore what every key created through the product gets.
+
+With the old `["write"]` default, a user who created a key in the plugin so their agent could read
+their vault got a key that **cannot** read: the MCP server's `read_file` goes to
+`GET .../download` and was answered `Agent key does not have read scope`. That is the whole
+provenance of the seven write-only keys — nobody chose write-only, it was never offered.
+
+Leaving the default alone while tightening the policy would convert a partial failure into a total
+one. So the default becomes `["read","write"]`, matching what 18 of 25 live keys already carry and
+what the only UI's users actually want.
+
+This is not "loosening as part of a tightening". A drop-box key remains available and now requires
+`{"scopes": ["write"]}` — an explicit act, which is the right shape for a deliberate restriction.
+The alternative, making `scopes` required, would break the plugin outright and was rejected for
+that reason.
+
+## Migration — expand → migrate → contract
+
+Tightening is breaking for whoever relies on today's leniency, so it does not ship in one step
+(`CLAUDE-workflow.md` §1b).
+
+**Phase 1 (shipped).** Policy unified in one module; both helpers call it. The lenient routes keep
+their current verdicts behind `AGENT_KEY_LENIENT_READ_GRACE=true` (default), and every call that
+passes *only* because of that grace logs a WARNING naming the key, share and route
+(`event=agent_key_read_scope_grace`). `last_used_at` is now stamped on the lenient routes too. **No
+route changes its verdict in this phase.** The grace is deliberately *not* applied to the strict
+routes — that would be the downward unification rejected above.
+
+**Phase 2 (migrate).** The share owner grants `read` to the keys the WARNING names — today,
+`mesh-spark-sync` and `nhbot`:
+
+```bash
+curl -X PATCH "https://cp.tr.entire.vc/v1/web/shares/<share_id>/agent-keys/<key_id>" \
+  -H "Authorization: Bearer <owner JWT>" -H "Content-Type: application/json" \
+  -d '{"scopes":["read","write"]}'
+```
+
+`PATCH` exists precisely so this needs no key rotation. The previous route — revoke and reissue —
+changes the raw secret and so forces reconfiguring whatever integration holds it; that cost is high
+enough that owners would rationally skip the migration and meet the breakage later instead.
+
+**Phase 3 (contract).** Set `AGENT_KEY_LENIENT_READ_GRACE=false`. Gate: the WARNING has been silent
+for a full observation window. Reverting is a config change, not a redeploy.
+
+## Consequences
+
+- One policy, one module. A fourth helper cannot quietly invent a fifth answer.
+- Agent-key reads are now measurable. "Is anything reading with a write-only key?" became
+  answerable at all — previously the data could not represent it.
+- `PATCH .../agent-keys/{key_id}` is a new authorization surface. It is owner/admin-only, matching
+  create and revoke, and refuses revoked keys so that granting scopes cannot undo a revocation.
+- Known consumer of the leniency: `evc-mesh`'s `SearchDocs` and `ListShareFiles`
+  (`internal/integration/teamrelay/`) call `GET /v1/web/shares/{slug}` with `X-Agent-Key`. They are
+  safe once their configured key carries `read` — which is what phase 2 does.
+
+## Verification
+
+Tests live in `tests/test_agent_key_read_scope_policy.py` and drive **routes, not helpers** — a
+helper-level test could not have caught this defect, since each helper was self-consistent and the
+bug existed only in the gap between them. The central case asserts a property across the whole set
+of read routes: for any given key they must all return the same verdict.
+
+Each test was mutation-checked against the source: reverting the lenient helper, leaking grace into
+the strict helper, dropping the `last_used_at` stamp, and restoring the old creation default each
+turn the intended tests red.

--- a/apps/control-plane/tests/test_agent_key_read_scope_policy.py
+++ b/apps/control-plane/tests/test_agent_key_read_scope_policy.py
@@ -1,0 +1,459 @@
+"""Unified read-scope policy for agent keys (#b69d73fb, ADR-0001).
+
+The defect: ``_require_private_web_auth`` answered "write implies read" while
+``_auth_share_read_access`` demanded the literal ``read`` scope, so one key on
+one share could read a document through ``GET /v1/web/shares/{slug}/files`` and
+be refused the same bytes through ``GET /v1/web/shares/{id}/download``.
+
+Every test here drives a ROUTE, never a helper directly. A helper-level test
+could not have caught this bug: both helpers were individually self-consistent
+and correct against their own intent — the defect only existed in the gap
+*between* them. So the central assertion is a property across the whole set of
+read routes ("they all agree"), evaluated end-to-end through the app.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import secrets
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.core import security
+from app.db import models
+
+SECRET_MARKER = "TOP-SECRET-VAULT-BODY"
+
+
+# --------------------------------------------------------------------------
+# fixtures / helpers
+# --------------------------------------------------------------------------
+
+
+def make_user(db: Session, email: str, is_admin: bool = False) -> models.User:
+    user = models.User(
+        email=email,
+        password_hash=security.get_password_hash("test123456"),
+        is_admin=is_admin,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def make_folder_share(
+    db: Session, owner: models.User, slug: str, published: bool = True
+) -> models.Share:
+    share = models.Share(
+        kind=models.ShareKind.FOLDER,
+        path=f"{slug}/",
+        visibility=models.ShareVisibility.PRIVATE,
+        owner_user_id=owner.id,
+        web_published=published,
+        web_slug=slug if published else None,
+        web_folder_items=[
+            {
+                "path": "secret.md",
+                "name": "secret",
+                "type": "doc",
+                "content": f"# {SECRET_MARKER}",
+            }
+        ],
+    )
+    db.add(share)
+    db.commit()
+    db.refresh(share)
+    return share
+
+
+def make_agent_key(
+    db: Session, share: models.Share, created_by: uuid.UUID, scopes: str
+) -> tuple[str, models.ShareAgentKey]:
+    raw = "tr_agent_" + secrets.token_hex(24)
+    ak = models.ShareAgentKey(
+        share_id=share.id,
+        key_hash=hashlib.sha256(raw.encode()).hexdigest(),
+        label=f"scope-policy-{scopes}",
+        scopes=scopes,
+        created_by=created_by,
+    )
+    db.add(ak)
+    db.commit()
+    db.refresh(ak)
+    return raw, ak
+
+
+def minio_empty():
+    """An asset store containing nothing, so /assets can answer 404 rather than
+    exploding — the auth decision has already been made by that point."""
+    from minio.error import S3Error
+
+    m = MagicMock()
+    m.bucket_exists.return_value = True
+    m.get_object.side_effect = S3Error("NoSuchKey", "missing", "res", "req", "host", None)
+    return patch("app.api.routers.web._get_minio_client", return_value=m)
+
+
+@pytest.fixture
+def web_enabled(monkeypatch):
+    monkeypatch.setenv("WEB_PUBLISH_DOMAIN", "docs.test.com")
+    from app.core.config import get_settings
+
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture
+def grace_off(monkeypatch, web_enabled):
+    """Phase 2: the literal policy enforced on every read route."""
+    monkeypatch.setenv("AGENT_KEY_LENIENT_READ_GRACE", "false")
+    from app.core.config import get_settings
+
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+def read_routes(share: models.Share) -> dict[str, str]:
+    """Every route that serves share CONTENT to an agent key.
+
+    Keyed by name so a failure says which route disagreed. `/assets` is included
+    because it is gated by the same helper even though its body is a binary.
+    """
+    sid = str(share.id)
+    slug = share.web_slug
+    return {
+        "metadata": f"/v1/web/shares/{slug}",
+        "files": f"/v1/web/shares/{slug}/files?path=secret.md",
+        "assets": f"/v1/web/shares/{slug}/assets?path=image.png",
+        "files-index": f"/v1/web/shares/{sid}/files-index",
+        "download": f"/v1/web/shares/{sid}/download?path=secret.md",
+    }
+
+
+def call(client: TestClient, url: str, raw_key: str):
+    with minio_empty():
+        return client.get(url, headers={"X-Agent-Key": raw_key})
+
+
+def denies_read(resp) -> bool:
+    """Did this route refuse on scope grounds?
+
+    401/403 both count as refusal. 404 does NOT: on /assets it means "authorised,
+    object absent", which is a successful read decision.
+    """
+    return resp.status_code in (401, 403)
+
+
+# --------------------------------------------------------------------------
+# the property that was broken: all read routes must agree
+# --------------------------------------------------------------------------
+
+
+class TestAllReadRoutesAgree:
+    @pytest.mark.parametrize("scopes", ["write", "read", "read,write"])
+    def test_every_read_route_gives_the_same_verdict(self, db_session, client, grace_off, scopes):
+        """The regression test for #b69d73fb, stated as a property.
+
+        Under the unified policy a key either may read this share's content or
+        may not, and every content route must say so identically. Before the
+        fix this failed for scopes="write": metadata/files/assets served the
+        document while files-index/download answered 403.
+        """
+        owner = make_user(db_session, f"o-{uuid.uuid4().hex[:8]}@x.com")
+        share = make_folder_share(db_session, owner, f"s{uuid.uuid4().hex[:8]}")
+        raw, _ = make_agent_key(db_session, share, owner.id, scopes)
+
+        verdicts = {
+            name: denies_read(call(client, url, raw)) for name, url in read_routes(share).items()
+        }
+        assert len(set(verdicts.values())) == 1, (
+            f"read routes disagree for scopes={scopes!r}: "
+            f"{ {k: ('DENY' if v else 'ALLOW') for k, v in verdicts.items()} }"
+        )
+
+    def test_write_only_key_is_denied_on_every_read_route(self, db_session, client, grace_off):
+        """Direction of the unified policy: literal, so write does not imply read."""
+        owner = make_user(db_session, f"o-{uuid.uuid4().hex[:8]}@x.com")
+        share = make_folder_share(db_session, owner, f"s{uuid.uuid4().hex[:8]}")
+        raw, _ = make_agent_key(db_session, share, owner.id, "write")
+
+        for name, url in read_routes(share).items():
+            resp = call(client, url, raw)
+            assert denies_read(resp), f"{name} let a write-only key read: {resp.status_code}"
+
+    def test_read_key_is_allowed_on_every_read_route_and_content_arrives(
+        self, db_session, client, grace_off
+    ):
+        """Negative control for the test above.
+
+        Without this, "everything is denied" would pass the previous test for a
+        trivially broken reason — e.g. if auth were rejecting every key.
+        """
+        owner = make_user(db_session, f"o-{uuid.uuid4().hex[:8]}@x.com")
+        share = make_folder_share(db_session, owner, f"s{uuid.uuid4().hex[:8]}")
+        raw, _ = make_agent_key(db_session, share, owner.id, "read")
+
+        for name, url in read_routes(share).items():
+            resp = call(client, url, raw)
+            assert not denies_read(resp), f"{name} denied a read key: {resp.status_code}"
+
+        # And the bytes really are served, not just a 200 shell.
+        body = call(client, read_routes(share)["download"], raw).text
+        assert SECRET_MARKER in body
+
+
+# --------------------------------------------------------------------------
+# grace window (phase 1): behaviour preserved, population measured
+# --------------------------------------------------------------------------
+
+
+class TestLenientReadGrace:
+    def test_grace_preserves_the_old_lenient_behaviour(self, db_session, client, web_enabled):
+        """With grace on (the default), a write-only key still reads the lenient
+        routes exactly as it did before this change. That is the whole point:
+        phase 1 must not change a single verdict."""
+        owner = make_user(db_session, f"o-{uuid.uuid4().hex[:8]}@x.com")
+        share = make_folder_share(db_session, owner, f"s{uuid.uuid4().hex[:8]}")
+        raw, _ = make_agent_key(db_session, share, owner.id, "write")
+
+        routes = read_routes(share)
+        assert not denies_read(call(client, routes["metadata"], raw))
+        assert not denies_read(call(client, routes["files"], raw))
+
+    def test_grace_does_NOT_widen_the_strict_routes(self, db_session, client, web_enabled):
+        """Grace exists to hold the lenient routes still, never to loosen the
+        strict ones.
+
+        This is the guard on the dangerous direction: /download and /files-index
+        are UUID-addressable and so reach never-published shares, where a
+        write-only key can read nothing today. If grace leaked into them, five
+        external customers' write-only keys would gain read access to unpublished
+        private vault content.
+        """
+        owner = make_user(db_session, f"o-{uuid.uuid4().hex[:8]}@x.com")
+        share = make_folder_share(db_session, owner, f"s{uuid.uuid4().hex[:8]}")
+        raw, _ = make_agent_key(db_session, share, owner.id, "write")
+
+        routes = read_routes(share)
+        assert denies_read(call(client, routes["download"], raw))
+        assert denies_read(call(client, routes["files-index"], raw))
+
+    def test_grace_use_is_logged_with_the_key_and_route(
+        self, db_session, client, web_enabled, caplog
+    ):
+        """The migration signal. Without it, "which keys still need read?" is
+        unanswerable — which is precisely how this defect stayed invisible."""
+        owner = make_user(db_session, f"o-{uuid.uuid4().hex[:8]}@x.com")
+        share = make_folder_share(db_session, owner, f"s{uuid.uuid4().hex[:8]}")
+        raw, ak = make_agent_key(db_session, share, owner.id, "write")
+
+        with caplog.at_level(logging.WARNING, logger="app.core.agent_key_scopes"):
+            call(client, read_routes(share)["files"], raw)
+
+        records = [
+            r for r in caplog.records if getattr(r, "event", "") == "agent_key_read_scope_grace"
+        ]
+        assert records, "grace was used but nothing was logged"
+        assert records[0].agent_key_id == str(ak.id)
+        assert records[0].route.endswith("/files")
+
+    def test_no_grace_log_for_a_key_that_genuinely_has_read(
+        self, db_session, client, web_enabled, caplog
+    ):
+        """Anti-goal: the signal must name only keys that actually need migrating.
+        A warning on every read would be noise and would hide the real ones."""
+        owner = make_user(db_session, f"o-{uuid.uuid4().hex[:8]}@x.com")
+        share = make_folder_share(db_session, owner, f"s{uuid.uuid4().hex[:8]}")
+        raw, _ = make_agent_key(db_session, share, owner.id, "read,write")
+
+        with caplog.at_level(logging.WARNING, logger="app.core.agent_key_scopes"):
+            call(client, read_routes(share)["files"], raw)
+
+        assert not [
+            r for r in caplog.records if getattr(r, "event", "") == "agent_key_read_scope_grace"
+        ]
+
+
+# --------------------------------------------------------------------------
+# unpublished shares — the case that chose the direction
+# --------------------------------------------------------------------------
+
+
+class TestUnpublishedShareIsUnreachableByTheLenientRoutes:
+    def test_lenient_routes_cannot_reach_an_unpublished_share_at_all(
+        self, db_session, client, web_enabled
+    ):
+        """Recorded because it is the evidence behind ADR-0001's direction.
+
+        The lenient routes resolve a share by (web_slug, web_published==True), so
+        on an unpublished share they 404 by construction regardless of scope.
+        Only the strict routes reach it — which is why unifying on the LENIENT
+        policy would have granted new read access here, and unifying on the
+        literal one grants none.
+        """
+        owner = make_user(db_session, f"o-{uuid.uuid4().hex[:8]}@x.com")
+        share = make_folder_share(db_session, owner, "unpub", published=False)
+        raw, _ = make_agent_key(db_session, share, owner.id, "read")
+
+        for url in (
+            "/v1/web/shares/unpub",
+            "/v1/web/shares/unpub/files?path=secret.md",
+        ):
+            assert call(client, url, raw).status_code == 404
+
+        # ...while the strict route serves it to a read-scoped key.
+        strict = f"/v1/web/shares/{share.id}/download?path=secret.md"
+        assert SECRET_MARKER in call(client, strict, raw).text
+
+
+# --------------------------------------------------------------------------
+# usage recording — the blind spot that made the population unmeasurable
+# --------------------------------------------------------------------------
+
+
+class TestLastUsedAtCoversLenientRoutes:
+    @pytest.mark.parametrize("route_name", ["metadata", "files", "download", "files-index"])
+    def test_every_authenticated_read_route_records_usage(
+        self, db_session, client, web_enabled, route_name
+    ):
+        """Before this change only /download and /files-index stamped
+        last_used_at, so a key reading through /files looked unused forever —
+        and "is anyone reading with a write-only key?" could not be answered
+        from the data at all."""
+        owner = make_user(db_session, f"o-{uuid.uuid4().hex[:8]}@x.com")
+        share = make_folder_share(db_session, owner, f"s{uuid.uuid4().hex[:8]}")
+        raw, ak = make_agent_key(db_session, share, owner.id, "read,write")
+        assert ak.last_used_at is None
+
+        call(client, read_routes(share)[route_name], raw)
+
+        db_session.refresh(ak)
+        assert ak.last_used_at is not None, f"{route_name} did not record key usage"
+
+
+# --------------------------------------------------------------------------
+# migration tooling: PATCH scopes
+# --------------------------------------------------------------------------
+
+
+def login(client: TestClient, email: str) -> str:
+    resp = client.post("/auth/login", json={"email": email, "password": "test123456"})
+    assert resp.status_code == 200, resp.text
+    return resp.json()["access_token"]
+
+
+class TestPatchAgentKeyScopes:
+    def test_owner_can_grant_read_without_rotating_the_secret(self, db_session, client, grace_off):
+        """The migration path in one call: the write-only key that could not read
+        can read afterwards, and the integration holding the raw secret never
+        has to be reconfigured."""
+        owner = make_user(db_session, f"o-{uuid.uuid4().hex[:8]}@x.com")
+        share = make_folder_share(db_session, owner, f"s{uuid.uuid4().hex[:8]}")
+        raw, ak = make_agent_key(db_session, share, owner.id, "write")
+        download = read_routes(share)["download"]
+
+        assert denies_read(call(client, download, raw))
+
+        token = login(client, owner.email)
+        resp = client.patch(
+            f"/v1/web/shares/{share.id}/agent-keys/{ak.id}",
+            json={"scopes": ["read", "write"]},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 200, resp.text
+        assert sorted(resp.json()["scopes"]) == ["read", "write"]
+
+        # Same raw key, now admitted, and the content really arrives.
+        assert SECRET_MARKER in call(client, download, raw).text
+
+    def test_non_owner_cannot_widen_a_key(self, db_session, client, web_enabled):
+        """Scopes are the authorization surface — widening them needs the same
+        standing as minting a key."""
+        owner = make_user(db_session, f"o-{uuid.uuid4().hex[:8]}@x.com")
+        outsider = make_user(db_session, f"x-{uuid.uuid4().hex[:8]}@x.com")
+        share = make_folder_share(db_session, owner, f"s{uuid.uuid4().hex[:8]}")
+        _, ak = make_agent_key(db_session, share, owner.id, "write")
+
+        token = login(client, outsider.email)
+        resp = client.patch(
+            f"/v1/web/shares/{share.id}/agent-keys/{ak.id}",
+            json={"scopes": ["read", "write"]},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 403
+
+    def test_revoked_key_cannot_be_edited_back_into_service(self, db_session, client, web_enabled):
+        """Granting scopes must not be a way to quietly undo a revocation."""
+        owner = make_user(db_session, f"o-{uuid.uuid4().hex[:8]}@x.com")
+        share = make_folder_share(db_session, owner, f"s{uuid.uuid4().hex[:8]}")
+        _, ak = make_agent_key(db_session, share, owner.id, "write")
+        ak.revoked_at = security.utcnow()
+        db_session.commit()
+
+        token = login(client, owner.email)
+        resp = client.patch(
+            f"/v1/web/shares/{share.id}/agent-keys/{ak.id}",
+            json={"scopes": ["read", "write"]},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 409
+
+    def test_invalid_scope_is_rejected(self, db_session, client, web_enabled):
+        owner = make_user(db_session, f"o-{uuid.uuid4().hex[:8]}@x.com")
+        share = make_folder_share(db_session, owner, f"s{uuid.uuid4().hex[:8]}")
+        _, ak = make_agent_key(db_session, share, owner.id, "write")
+
+        token = login(client, owner.email)
+        resp = client.patch(
+            f"/v1/web/shares/{share.id}/agent-keys/{ak.id}",
+            json={"scopes": ["admin"]},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 422
+
+
+class TestCreateDefaultScopes:
+    def test_key_created_without_scopes_can_read(self, db_session, client, grace_off):
+        """The plugin — the only key-creation UI — sends no `scopes` field, so
+        the server default is what real users get. Under the old write-only
+        default their brand-new key was refused by the very endpoint the MCP
+        server reads with. Asserted through a route, not by inspecting the
+        default: what matters is that the key works."""
+        owner = make_user(db_session, f"o-{uuid.uuid4().hex[:8]}@x.com")
+        share = make_folder_share(db_session, owner, f"s{uuid.uuid4().hex[:8]}")
+
+        token = login(client, owner.email)
+        created = client.post(
+            f"/v1/web/shares/{share.id}/agent-keys",
+            json={"label": "plugin-style-no-scopes"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert created.status_code == 201, created.text
+        raw = created.json()["key"]
+
+        assert SECRET_MARKER in call(client, read_routes(share)["download"], raw).text
+
+    def test_explicit_write_only_still_produces_a_drop_box(self, db_session, client, grace_off):
+        """The restriction remains available — it just has to be asked for."""
+        owner = make_user(db_session, f"o-{uuid.uuid4().hex[:8]}@x.com")
+        share = make_folder_share(db_session, owner, f"s{uuid.uuid4().hex[:8]}")
+
+        token = login(client, owner.email)
+        created = client.post(
+            f"/v1/web/shares/{share.id}/agent-keys",
+            json={"label": "drop-box", "scopes": ["write"]},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert created.status_code == 201, created.text
+        raw = created.json()["key"]
+
+        for name, url in read_routes(share).items():
+            assert denies_read(call(client, url, raw)), f"{name} leaked to a drop-box key"

--- a/apps/control-plane/tests/test_web_publish.py
+++ b/apps/control-plane/tests/test_web_publish.py
@@ -991,6 +991,7 @@ class TestPrivateShareAuth:
                 "web_publish_enabled": True,
                 "web_publish_domain": "docs.test.com",
                 "web_frame_ancestors": None,
+                "agent_key_lenient_read_grace": True,
             },
         )()
 
@@ -1610,6 +1611,7 @@ def _web_enabled_settings(extra: dict | None = None):
         "relay_token_ttl_minutes": 30,
         "relay_public_url": "wss://relay.example.com",
         "web_frame_ancestors": None,
+        "agent_key_lenient_read_grace": True,
     }
     if extra:
         base.update(extra)
@@ -1896,6 +1898,7 @@ class TestPrivateShareWebAuth:
             "relay_token_ttl_minutes": 30,
             "relay_public_url": "wss://relay.test",
             "web_frame_ancestors": None,
+            "agent_key_lenient_read_grace": True,
         }
         if extra:
             fields.update(extra)

--- a/docs/agent-keys.md
+++ b/docs/agent-keys.md
@@ -13,7 +13,7 @@ An agent key is a per-share API token you create inside the Obsidian plugin. Age
 | Property | Value |
 |----------|-------|
 | Format | `tr_agent_` + 48 hex characters |
-| Scope | `write` — upload files to one specific share |
+| Scopes | `read`, `write` — new keys get both by default; pass `"scopes": ["write"]` for an upload-only key |
 | Bound to | A single share (not your whole account) |
 | Revealed | Once on creation — copy it and store it securely |
 | Max per share | 20 active keys |
@@ -86,9 +86,33 @@ Click **I've copied this key — close** to dismiss.
 
 | Scope | What it allows |
 |-------|---------------|
-| `write` | Upload files to the share via `POST /v1/web/shares/{slug}/upload` |
+| `write` | Upload files to the share via `POST /v1/web/shares/{slug}/upload` and `/sync-upload` |
+| `read` | List and read the share's files: `GET /v1/web/shares/{id}/files-index`, `/download`, `/files`, `/assets`, and share metadata |
 
-The `write` scope is the only scope currently available. An agent key grants no read access — it cannot list files, read content, or access any other share.
+A key created without an explicit `scopes` field — which is what the Obsidian plugin does — gets
+**both** scopes. To create an upload-only "drop box" key that can never read the share, pass
+`"scopes": ["write"]` explicitly when calling the API.
+
+Scopes are literal: `write` does **not** imply `read`. A key without `read` is refused on every
+read route, and the refusal is the same on all of them. (Before 2026-08-19 this was inconsistent —
+a write-only key could read through `/files` while `/download` answered
+`403 Agent key does not have read scope`. See ADR-0001 in `apps/control-plane/docs/adrs/`.)
+
+An agent key is still bound to exactly one share and grants no access to any other.
+
+### Changing the scopes of an existing key
+
+Scopes can be widened or narrowed in place, without rotating the secret, so an integration already
+holding the key does not have to be reconfigured:
+
+```bash
+curl -X PATCH "https://cp.example.com/v1/web/shares/{share_id}/agent-keys/{key_id}" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"scopes": ["read", "write"]}'
+```
+
+Owner or admin only, like creating and revoking. A revoked key cannot be edited back into service.
 
 The share it is bound to must have **web publishing enabled**. If you turn off web publishing, all agent keys for that share stop working immediately.
 
@@ -183,11 +207,16 @@ The file appears in your Obsidian vault under `agent-output/report.md` on the ne
 |------|---------------|---------------------|
 | `upsert_file` | ✅ works (slug required) | ✅ works (UUID required) |
 | `list_shares` | ❌ requires credentials | ✅ works |
-| `list_files` | ❌ requires credentials | ✅ works |
-| `read_file` | ❌ requires credentials | ✅ works |
+| `list_files` | ✅ works (key needs `read`) | ✅ works |
+| `read_file` | ✅ works (key needs `read`) | ✅ works |
 | `delete_file` | ❌ requires credentials | ✅ works |
 
-For agents that only write (e.g. automated report publishing), agent keys are sufficient. For agents that also read or navigate shares, use email/password credentials.
+Reading works with an agent key that carries the `read` scope — which new keys get by default.
+A key created before 2026-08-19, or one created explicitly as `["write"]`, has no `read` scope and
+is refused on those calls; grant it `read` with the `PATCH` above rather than issuing a new key.
+
+`list_shares` and `delete_file` still need credentials: a key is bound to a single share, so there
+is no list of shares for it to return, and deletion is not covered by either scope.
 
 ---
 
@@ -235,7 +264,8 @@ The key is invalidated immediately. Any agent using it will receive `403 Forbidd
 | `403 Forbidden: Agent key has been revoked` | Key was revoked | Create a new key in the plugin |
 | `403 Forbidden: Agent key has expired` | Key TTL elapsed | Create a new key in the plugin |
 | `403 Forbidden: Agent key not valid for this share` | Key bound to different share | Use the correct key for this share slug |
-| `403 Forbidden: does not have write scope` | Internal state error | Revoke key and create a new one |
+| `403 Forbidden: does not have write scope` | Key was created read-only | Grant `write` via `PATCH .../agent-keys/{key_id}` |
+| `403 Forbidden: does not have read scope` | Key has no `read` scope (all keys created before 2026-08-19 via the plugin) | Grant `read` via `PATCH .../agent-keys/{key_id}` |
 | `404 Not Found` | Share slug wrong, or web publishing disabled | Verify the slug in plugin settings; enable web publishing |
 | `409 Conflict` | 20-key limit reached | Revoke unused keys first |
 | `413 Request Entity Too Large` | File exceeds 25 MB | Split the file or use a smaller payload |

--- a/docs/agent-keys.md
+++ b/docs/agent-keys.md
@@ -93,10 +93,12 @@ A key created without an explicit `scopes` field — which is what the Obsidian 
 **both** scopes. To create an upload-only "drop box" key that can never read the share, pass
 `"scopes": ["write"]` explicitly when calling the API.
 
-Scopes are literal: `write` does **not** imply `read`. A key without `read` is refused on every
-read route, and the refusal is the same on all of them. (Before 2026-08-19 this was inconsistent —
-a write-only key could read through `/files` while `/download` answered
-`403 Agent key does not have read scope`. See ADR-0001 in `apps/control-plane/docs/adrs/`.)
+Scopes are literal: `write` does **not** imply `read`. A key without `read` is meant to be refused
+on every read route, with the same refusal on all of them — this is enforced from phase 3 of the
+rollout (see ADR-0001 in `apps/control-plane/docs/adrs/`); a write-only key on a **published**
+share may still read through `/files`/`/assets` during the phase-1/phase-2 grace period, logged as
+a WARNING. (Before 2026-08-19 this split was permanent, not a grace period — a write-only key could
+read through `/files` while `/download` answered `403 Agent key does not have read scope`.)
 
 An agent key is still bound to exactly one share and grants no access to any other.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -101,6 +101,17 @@ Response:
 | GET | `/v1/admin/settings/branding` | Admin | Get branding |
 | PUT | `/v1/admin/settings/branding` | Admin | Update branding |
 
+### Agent Keys
+
+| Method | Endpoint | Auth | Description |
+|--------|----------|------|-------------|
+| POST | `/v1/web/shares/{share_id}/agent-keys` | Owner/Admin | Create key (raw key shown once; defaults to `["read","write"]`) |
+| GET | `/v1/web/shares/{share_id}/agent-keys` | Owner/Admin | List keys (never returns the secret) |
+| PATCH | `/v1/web/shares/{share_id}/agent-keys/{key_id}` | Owner/Admin | Change scopes in place, without rotating the secret |
+| DELETE | `/v1/web/shares/{share_id}/agent-keys/{key_id}` | Owner/Admin | Revoke key |
+
+Scopes are literal — `write` does not imply `read`. See `docs/agent-keys.md`.
+
 ### Webhooks
 
 | Method | Endpoint | Auth | Description |


### PR DESCRIPTION
## What was wrong

Two functions answered the same question — "may this agent key read this share's content?" — differently, on route families that return **the same bytes**:

| helper | policy | routes |
|---|---|---|
| `_require_private_web_auth` | `write ⊃ read` | `GET /v1/web/shares/{slug}`, `/files`, `/assets` |
| `_auth_share_read_access` | literal `read` | `GET /v1/web/shares/{id\|slug}/download`, `/files-index` |

Reproduced end-to-end before the fix, write-only key on a published private share:

```
200  GET /v1/web/shares/{slug}
200  GET /v1/web/shares/{slug}/files      <-- returned the document body
403  GET /v1/web/shares/{id}/files-index  Agent key does not have read scope
403  GET /v1/web/shares/{id}/download     Agent key does not have read scope
```

From outside, that 403 reads as "this endpoint doesn't exist" — which is how it was reported.

## Direction, and why it isn't the cheap one

Loosening `_auth_share_read_access` was the one-line option. It's the wrong one, for a structural reason rather than a stylistic one.

The lenient routes resolve a share by `(web_slug, web_published == True)`, so on a never-published share they **404 by construction** whatever the scope. The strict routes are UUID-addressable and reach those shares. That splits the population in two:

- **Published shares** — a write-only key already reads everything through the lenient routes. The strict check on `/download` buys nothing there; the same bytes are one call away.
- **Unpublished shares** — a write-only key reads **nothing**. Here the guarantee is real and load-bearing.

So unifying *downward* would grant write-only keys read access to unpublished private vault content their owners never published. On our own deployment that would have affected 5 of the 7 live write-only keys, 4 of them belonging to external users.

Unifying upward affects 2 keys on that same deployment, both ours, one never used.

## Shipping it without breaking anyone

Expand → migrate → contract:

- **This PR (expand)** — policy unified in one module; both helpers call it. The lenient routes keep their current verdicts behind `AGENT_KEY_LENIENT_READ_GRACE=true` (the default) and log a WARNING naming key, share and route whenever grace is what carried the request. **No route changes its verdict in this PR.** Grace is deliberately *not* applied to the strict helper — that would be the downward unification above.
- **Phase 2 (migrate)** — the share owner grants `read` to the keys the WARNING names, using the new `PATCH`.
- **Phase 3 (contract)** — set `AGENT_KEY_LENIENT_READ_GRACE=false`. A config change, reversible in seconds.

## Coupled changes

**New keys default to `["read","write"]`.** The Obsidian plugin is the only user-facing way to create an agent key and it sends no `scopes` field at all — its `CreateAgentKeyRequest` carries `label` and `expires_at` and nothing else. The server default was therefore what every key created through the product got, and those keys were then refused by the very endpoint an agent client's `read_file` uses. That is the provenance of every write-only key we have; nobody chose write-only, it was never offered. An upload-only drop box is still available as an explicit `{"scopes": ["write"]}`.

**`PATCH /v1/web/shares/{share_id}/agent-keys/{key_id}`** changes a key's scopes without rotating the secret. The only prior migration path was revoke-and-reissue, which changes the raw key and so forces reconfiguring whatever integration holds it — a cost high enough that owners would rationally skip the migration and meet the breakage later instead. Owner/admin only, like create and revoke; refuses revoked keys, so granting scopes cannot quietly undo a revocation.

**`last_used_at` is now recorded on every authenticated read route.** Previously only the strict helper stamped it, so a key reading through `/files` looked permanently unused — which is why "is anything actually reading with a write-only key?" could not be answered from the data at all.

## Tests

`tests/test_agent_key_read_scope_policy.py` (20 tests) drives **routes, never helpers**. A helper-level test could not have caught this: both helpers were individually self-consistent and correct against their own intent, and the defect existed only in the gap between them. The central case asserts a property across the whole read-route set — for a given key they must all return the same verdict.

Every test was mutation-checked against the source. Reverting the lenient helper, leaking grace into the strict one, dropping the `last_used_at` stamp, and restoring the old creation default each turned the intended tests red; all 20 went green again on restore.

Full suite: **722 passed, 1 skipped**.

## Deliberately not touched

`docs/agent-keys.md` contained statements that were simply untrue — "the `write` scope is the only scope currently available", and `read_file` marked as unavailable to agent keys — and those are corrected here. Its *positioning* copy, e.g. the opening "Give your AI agent write access…", is now slightly off given the default change, but that is user-facing product copy and needs product sign-off, so it is flagged rather than rewritten.

The Obsidian plugin is unchanged: adding a scope selector to its key-creation UI introduces new visible copy and belongs in a separate change.

Rationale and the full migration plan: `apps/control-plane/docs/adrs/0001-unified-agent-key-read-scope-policy.md`.
