### PR TITLE
fix(control-plane): route upload_mesh_artifact's scope check through agent_key_scopes

### DIFF
--- a/apps/control-plane/app/api/routers/web.py
+++ b/apps/control-plane/app/api/routers/web.py
@@ -1255,7 +1255,6 @@ async def upload_mesh_artifact(
 
     share_identifier: folder UUID (private/sync shares) or web_slug (web-published shares only).
     """
-    import hashlib
     import uuid as _uuid_mod
 
     settings = get_settings()
@@ -1286,42 +1285,16 @@ async def upload_mesh_artifact(
             detail="Upload only supported for folder shares",
         )
 
-    # Agent-key auth (B1)
-    raw_key = request.headers.get("X-Agent-Key")
-    if not raw_key:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED, detail="X-Agent-Key header required"
-        )
-
-    key_hash = hashlib.sha256(raw_key.encode()).hexdigest()
-    key_stmt = select(models.ShareAgentKey).where(models.ShareAgentKey.key_hash == key_hash)
-    agent_key = db.execute(key_stmt).scalar_one_or_none()
-
-    if agent_key is None:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid agent key")
-
-    if agent_key.share_id != share.id:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN, detail="Agent key not valid for this share"
-        )
-
-    if agent_key.revoked_at is not None:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN, detail="Agent key has been revoked"
-        )
-
-    if agent_key.expires_at is not None:
-        from datetime import timezone as _tz
-
-        expires_at = agent_key.expires_at
-        if expires_at.tzinfo is None:
-            expires_at = expires_at.replace(tzinfo=_tz.utc)
-        if expires_at < security.utcnow():
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN, detail="Agent key has expired"
-            )
-
-    if "write" not in set(agent_key.scopes.split(",")):
+    # Agent-key auth (B1). Identity/standing via the shared resolver (same cycle
+    # every X-Agent-Key call site needs); scope via the shared literal policy
+    # (ADR-0001) — this route previously carried its own inline copy of both,
+    # which is how a fourth, undetected scope-check divergence became possible
+    # after #b69d73fb consolidated the other three (task #3870a0f1). Deliberately
+    # NOT routed through the full `_auth_agent_key()` wrapper: that also enforces
+    # `agent_key_creator_authorized`, a check this route has never applied, and
+    # this is a scope-consolidation refactor, not a change to who can upload.
+    agent_key = _resolve_share_agent_key(share, request, db)
+    if not agent_key_scopes.satisfies(agent_key_scopes.parse_scopes(agent_key.scopes), "write"):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN, detail="Agent key does not have write scope"
         )
@@ -1468,16 +1441,19 @@ def _resolve_share_for_agent(share_identifier: str, db: Session) -> models.Share
     return share
 
 
-def _auth_agent_key(
-    share: models.Share, request: Request, db: Session, required_scope: str | None = None
+def _resolve_share_agent_key(
+    share: models.Share, request: Request, db: Session
 ) -> models.ShareAgentKey:
-    """Validate X-Agent-Key header against the given share.
+    """Look up and validate the X-Agent-Key header against the given share.
 
-    Returns the ShareAgentKey row on success; raises HTTPException on failure.
-    If required_scope is given, the key must have that scope (e.g. "read" or "write").
+    Covers only identity/standing (hash lookup, share match, revoked, expired) —
+    NOT scope. Every X-Agent-Key call site needs this same cycle; previously
+    ``upload_mesh_artifact`` carried its own copy (task #3870a0f1), which is how
+    a fourth, undetected scope-check divergence became possible after #b69d73fb
+    consolidated the other three. Scope policy stays out of this helper on
+    purpose — callers apply ``agent_key_scopes`` themselves, since what "the
+    right scope" means differs per route (see ADR-0001).
     """
-    import hashlib
-
     raw_key = request.headers.get("X-Agent-Key")
     if not raw_key:
         raise HTTPException(
@@ -1500,8 +1476,6 @@ def _auth_agent_key(
             status_code=status.HTTP_403_FORBIDDEN, detail="Agent key has been revoked"
         )
     if agent_key.expires_at is not None:
-        from datetime import timezone as _tz
-
         exp = agent_key.expires_at
         if exp.tzinfo is None:
             exp = exp.replace(tzinfo=_tz.utc)
@@ -1509,6 +1483,18 @@ def _auth_agent_key(
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN, detail="Agent key has expired"
             )
+    return agent_key
+
+
+def _auth_agent_key(
+    share: models.Share, request: Request, db: Session, required_scope: str | None = None
+) -> models.ShareAgentKey:
+    """Validate X-Agent-Key header against the given share.
+
+    Returns the ShareAgentKey row on success; raises HTTPException on failure.
+    If required_scope is given, the key must have that scope (e.g. "read" or "write").
+    """
+    agent_key = _resolve_share_agent_key(share, request, db)
     # Third helper, same policy object (ADR-0001). Only ever called with
     # required_scope="write" today; routed through the shared check so a future
     # read-requiring caller cannot silently reintroduce a fourth answer.

--- a/apps/control-plane/docs/adrs/0001-unified-agent-key-read-scope-policy.md
+++ b/apps/control-plane/docs/adrs/0001-unified-agent-key-read-scope-policy.md
@@ -9,8 +9,12 @@ found by Daedalus while independently checking the API answer given in
 ## Decision
 
 **A scope is satisfied only by itself. `write` does not imply `read`.** This holds on every route
-that serves share content to an agent key. The policy lives in one place —
-`app/core/agent_key_scopes.py` — and all three auth helpers in `web.py` call it.
+that serves share content to an agent key, and on `POST /v1/web/shares/{id}/upload`'s own `write`
+requirement. The policy lives in one place — `app/core/agent_key_scopes.py` — and every scope check
+in `web.py` calls it: the three auth helpers, plus `upload_mesh_artifact`'s own scope check (folded
+in by task [#3870a0f1](http://mesh.entire.host/t/3870a0f1-08d7-41c2-8c6b-5a733f0f1e72) — that route
+had carried an untouched inline copy since before this ADR, found during cross-verify on this very
+PR, which is exactly the class of defect *One policy, one module* below exists to prevent).
 
 Two coupled changes ship with it:
 
@@ -138,6 +142,14 @@ for a full observation window. Reverting is a config change, not a redeploy.
 ## Consequences
 
 - One policy, one module. A fourth helper cannot quietly invent a fifth answer.
+- Key identity/standing (hash lookup, share match, revoked, expired) is also shared now, via
+  `_resolve_share_agent_key()` — `_auth_agent_key()` and `upload_mesh_artifact` both call it, instead
+  of each carrying its own copy of that cycle. Scope policy deliberately stays **out** of that
+  helper: `upload_mesh_artifact` checks `agent_key_scopes.satisfies(..., "write")` directly and does
+  **not** go through the full `_auth_agent_key()` wrapper, because that wrapper also enforces
+  `agent_key_creator_authorized` — a check this route has never applied. Routing it through the
+  wrapper would be a second, uninvited change riding on a scope-consolidation task; if creator
+  authorization should apply to uploads too, that is its own decision, not a side effect of this one.
 - Agent-key reads are now measurable. "Is anything reading with a write-only key?" became
   answerable at all — previously the data could not represent it.
 - `PATCH .../agent-keys/{key_id}` is a new authorization surface. It is owner/admin-only, matching
@@ -156,3 +168,10 @@ of read routes: for any given key they must all return the same verdict.
 Each test was mutation-checked against the source: reverting the lenient helper, leaking grace into
 the strict helper, dropping the `last_used_at` stamp, and restoring the old creation default each
 turn the intended tests red.
+
+`upload_mesh_artifact`'s own scope check is covered in `tests/test_mesh_upload.py`
+(`TestAgentKeyReadScope`): a route-level test parametrized over the grace flag confirms a write-only
+key still succeeds and a read-only key still gets 403 either way, and a mutation-style test patches
+`agent_key_scopes.satisfies` to force `False` and confirms the route actually calls it — mutation-
+checked the other way too (reverted to the old inline `"write" not in set(...)` copy, confirmed that
+test goes red, restored).

--- a/apps/control-plane/tests/test_mesh_upload.py
+++ b/apps/control-plane/tests/test_mesh_upload.py
@@ -614,6 +614,77 @@ class TestAgentKeyReadScope:
             )
         assert resp.status_code == 403, resp.text
 
+    @pytest.mark.parametrize("grace", ["true", "false"])
+    def test_upload_verdict_unaffected_by_grace_flag(
+        self,
+        client: TestClient,
+        test_user: models.User,
+        db_session: Session,
+        web_enabled,
+        monkeypatch,
+        grace,
+    ):
+        """Task #3870a0f1 — upload_mesh_artifact requires a literal `write` scope
+
+        via the shared agent_key_scopes module (not an inline copy). Grace
+        (AGENT_KEY_LENIENT_READ_GRACE) only ever widens a `required == "read"`
+        check (see agent_key_scopes.would_be_denied_without_grace) — it must
+        have zero effect on this route's `required == "write"` verdict, in
+        either direction, on or off.
+        """
+        monkeypatch.setenv("AGENT_KEY_LENIENT_READ_GRACE", grace)
+        from app.core.config import get_settings
+
+        get_settings.cache_clear()
+        try:
+            share = make_folder_share(db_session, test_user, slug=f"grace-{grace}-upload")
+            write_key, _ = make_agent_key(db_session, share, scopes="write")
+            read_key, _ = make_agent_key(db_session, share, scopes="read")
+
+            with minio_patch():
+                write_resp = client.post(
+                    f"/v1/web/shares/grace-{grace}-upload/upload?path=file.md",
+                    content=b"data",
+                    headers={"X-Agent-Key": write_key, "Content-Type": "text/plain"},
+                )
+            assert write_resp.status_code == 200, write_resp.text
+
+            with minio_patch():
+                read_resp = client.post(
+                    f"/v1/web/shares/grace-{grace}-upload/upload?path=other.md",
+                    content=b"data",
+                    headers={"X-Agent-Key": read_key, "Content-Type": "text/plain"},
+                )
+            assert read_resp.status_code == 403, read_resp.text
+        finally:
+            get_settings.cache_clear()
+
+    def test_upload_route_actually_calls_the_shared_scope_module(
+        self, client: TestClient, test_user: models.User, db_session: Session, web_enabled
+    ):
+        """Mutation-style proof, not just an inline reading of the diff: force
+
+        agent_key_scopes.satisfies() to always return False and confirm a
+        write-only key that would otherwise succeed now gets 403. If this
+        route still carried its own inline `"write" not in set(...)` copy
+        (the pre-#3870a0f1 shape), patching the module would have no effect
+        and this test would fail to fail — i.e. it would pass for the wrong
+        reason. Restored via monkeypatch's own teardown.
+        """
+        from app.core import agent_key_scopes
+
+        share = make_folder_share(db_session, test_user, slug="mutation-upload")
+        write_key, _ = make_agent_key(db_session, share, scopes="write")
+
+        with patch.object(agent_key_scopes, "satisfies", return_value=False):
+            with minio_patch():
+                resp = client.post(
+                    "/v1/web/shares/mutation-upload/upload?path=file.md",
+                    content=b"data",
+                    headers={"X-Agent-Key": write_key, "Content-Type": "text/plain"},
+                )
+        assert resp.status_code == 403, resp.text
+
     def test_wrong_share_key_returns_403_on_files_index(
         self, client: TestClient, test_user: models.User, db_session: Session, web_enabled
     ):


### PR DESCRIPTION
## Summary
- `upload_mesh_artifact` carried its own inline copy of the agent-key validation cycle and write-scope check, entirely outside `app/core/agent_key_scopes.py` — the module ADR-0001 (PR #195) built specifically so this couldn't happen unnoticed. Found during cross-review on that PR. Not a regression (the route already required a literal `write` scope and grace never applies to a write requirement), but the ADR's completeness claim was false.
- Extracted the shared identity/standing cycle (hash lookup, share match, revoked, expired) into `_resolve_share_agent_key()`, reused by both `_auth_agent_key()` and `upload_mesh_artifact`.
- Scope policy stays route-specific on purpose: upload checks `agent_key_scopes.satisfies(..., "write")` directly rather than going through the full `_auth_agent_key()` wrapper, which also enforces `agent_key_creator_authorized` — a check this route has never applied. This is a scope-consolidation refactor, not a change to who can upload.
- ADR-0001 updated to reflect all four scope-check sites are now consolidated, and to document why upload deliberately doesn't route through the full wrapper.

## Test plan
- [x] `grep -n 'scopes.split' apps/control-plane/app/api/routers/web.py` — no matches (no inline scope checks remain outside the module)
- [x] Route-level test parametrized over `AGENT_KEY_LENIENT_READ_GRACE` — write-only key still succeeds, read-only key still gets 403, either way (grace has no effect on a `write` requirement)
- [x] Mutation-style test: patches `agent_key_scopes.satisfies` to force `False`, confirms the route actually calls it — verified the test goes red under the pre-fix inline-check shape, then restored
- [x] Full suite: 725 passed, 1 skipped locally

— Daedalus, Entire VC