### PR TITLE
docs: SUPPORT.md и рабочий канал для отчётов об уязвимостях

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/entire-vc/evc-team-relay/security/advisories/new
+    about: Private disclosure. Please do not open a public issue for a security problem.
+  - name: Email us
+    url: https://github.com/entire-vc/evc-team-relay/blob/main/SUPPORT.md
+    about: Account questions, or anything you would rather not describe in public. Addresses and response times are here.
+  - name: Ask a question
+    url: https://github.com/entire-vc/evc-team-relay/discussions
+    about: Open-ended questions and ideas that are not yet a bug report.

--- a/README.md
+++ b/README.md
@@ -121,7 +121,8 @@ Technical documentation is available in [`docs/`](./docs/):
 
 - 🌐 [entire.vc](https://entire.vc)
 - 💬 [Discussions](https://github.com/entire-vc/.github/discussions)
-- 📧 in@entire.vc
+- 📧 <support@entire.vc>
+- 🛟 [Where to get help and what to expect](https://github.com/entire-vc/evc-team-relay/blob/main/SUPPORT.md)
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,7 +15,12 @@ We take security seriously. If you discover a security vulnerability, please rep
 
 **Do NOT create a public GitHub issue for security vulnerabilities.**
 
-Instead, please email: **security@entire.vc**
+Use GitHub's private vulnerability reporting:
+**[Report a vulnerability](https://github.com/entire-vc/evc-team-relay/security/advisories/new)**
+
+The report is visible only to the maintainers of this repository until we publish an advisory. If
+you cannot use GitHub, email <support@entire.vc> with `SECURITY` in the subject and we will move the
+conversation somewhere private; do not put vulnerability details in a public issue in the meantime.
 
 Include:
 - Description of the vulnerability

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,53 @@
+# Support
+
+Thanks for using EVC Team Relay. This page is the whole map: where to go, and what happens after you write.
+
+## Where to go
+
+| What you have | Where to put it | First response |
+|---|---|---|
+| A bug | [Open an issue](https://github.com/entire-vc/evc-team-relay/issues/new/choose) | 2 business days |
+| A feature idea | [Open an issue](https://github.com/entire-vc/evc-team-relay/issues/new/choose) | 2 business days |
+| A setup or usage question | [Open an issue](https://github.com/entire-vc/evc-team-relay/issues/new/choose), or email <support@entire.vc> | 2 business days |
+| Anything about your account, your data, or a problem you would rather not describe in public | Email <support@entire.vc> | 2 business days |
+| A security vulnerability | **Not a public issue.** [Report it privately](https://github.com/entire-vc/evc-team-relay/security/advisories/new) | 48 hours |
+| An open-ended discussion | [Discussions](https://github.com/entire-vc/evc-team-relay/discussions) | 2 business days |
+
+Public issues are the fastest route for anything that is not private — other people hit the same
+problems, and a fix in the open helps them too.
+
+## Reporting a bug
+
+The issue templates ask for the list below. If you email instead, please include the same things:
+
+- **Versions** — the plugin, server, or package version, and the Obsidian version if a plugin is involved.
+- **Deployment** — hosted by us, or self-hosted.
+- **What you expected, and what happened instead.**
+- **Steps to reproduce**, numbered.
+- **Logs**, if you can get them. In Obsidian: `Ctrl`/`Cmd` + `Shift` + `I` opens Developer Tools; the
+  Console tab holds the plugin log. For a self-hosted server: `docker logs <container>`.
+
+Please redact tokens, keys, and document contents before pasting. We do not need them to diagnose
+a problem, and an issue is public forever.
+
+A report that arrives with versions and reproduction steps is often fixed in the same exchange.
+Without them, our first reply is just a request for them, which costs you a round trip.
+
+## What these response times mean
+
+They are commitments for a **first human response** — someone reading your report and telling you
+what happens next. They are not fix deadlines; how long a fix takes depends on what broke.
+
+Business days are Monday to Friday. If we are going to miss one of these, we would rather say so in
+the thread than go quiet.
+
+## What is not handled here
+
+This repository holds the control plane, web publishing, and deployment infrastructure. Some things
+live elsewhere:
+
+- **The Obsidian plugin** — [evc-team-relay-obsidian-plugin](https://github.com/entire-vc/evc-team-relay-obsidian-plugin).
+- **The relay server (the Rust sync core)** — [evc-relay-server](https://github.com/entire-vc/evc-relay-server).
+- **The MCP server** — [evc-team-relay-mcp](https://github.com/entire-vc/evc-team-relay-mcp).
+
+If you are not sure which one broke, open the issue here. Routing it is our job, not yours.


### PR DESCRIPTION
## Почему

Задача: поддержка как процесс. У продукта не было ни одного места, где посторонний человек за минуту находит, куда написать и когда ждать ответа.

Контрольные письма на все опубликованные адреса:

| адрес | результат |
|---|---|
| `support@entire.vc` | ✅ доставляется (плюс реальное письмо клиента от 10.08 — доказательство внешнего пути) |
| `in@entire.vc` | ✅ доставляется |
| `team.relay@entire.vc` (точка) | ✅ доставляется |
| `team-relay@entire.vc` (дефис) | ❌ `550 5.1.3 Address not found` |
| `hello@entire.vc` | ❌ `550 5.1.3 Address not found` |
| `security@entire.vc` | ❌ `550 5.1.3 Address not found` |

Публичный адрес поддержки сведён к одному — **`support@entire.vc`**.

## Про `security@entire.vc`

`SECURITY.md` инструктировал: «Do NOT create a public GitHub issue… email **security@entire.vc**» и обещал ответ за 48 часов. **Этого адреса не существует** — письма отбиваются с `Address not found`. То есть любой отчёт об уязвимости, отправленный по нашей же опубликованной процедуре, отвергался на входе, а отправитель не мог отличить это от «нас игнорируют».

Канал переведён на **GitHub private vulnerability reporting** — он включён в этом репозитории и работает уже сейчас, не завися от того, когда заведут почтовый ящик. Запасной путь — `support@entire.vc` (проверенный, живой).

## Что в PR

- `SUPPORT.md`: куда писать, срок первого ответа, что приложить к отчёту о баге, и просьба не вставлять токены и содержимое заметок.
- `.github/ISSUE_TEMPLATE/config.yml`: в выборе issue появились ссылки на приватный репорт уязвимостей и на SUPPORT.md. `blank_issues_enabled: true` оставлен намеренно — задача снизить барьер, а не поднять.

Сроки в SUPPORT.md (2 рабочих дня на первый ответ, 48 часов на security) выбраны консервативно — мы их уже фактически перевыполняем. Если Bill захочет другие цифры, это правка одной строки.