### PR TITLE
fix: make the OSS install path actually work without private-package access

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,8 +75,80 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-  create-release:
+  smoke-test:
+    # Boots the JUST-PUBLISHED images against a clean database and asserts
+    # /health. This is what issue #177 needed: the team's own deploy migrates
+    # a database that already passed whatever revision a release was cut at,
+    # so a broken migration or a fresh-install-only crash (e.g. a bootstrap
+    # bug) is invisible to us and visible only to an external user starting
+    # from nothing. Deliberately does NOT reuse cache-from/cache-to or any
+    # locally-built layer — it pulls from ghcr exactly like an external
+    # installer's `bash scripts/pull-published-images.sh` would.
     needs: build-and-push
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate relay keypair + env
+        working-directory: infra
+        run: |
+          openssl genpkey -algorithm ed25519 -out relay_private.pem
+          RELAY_PRIVATE_KEY_B64=$(openssl base64 -A -in relay_private.pem)
+          RELAY_PUBLIC_KEY_B64=$(python3 -c "
+          from cryptography.hazmat.primitives import serialization
+          import base64
+          with open('relay_private.pem', 'rb') as f:
+              priv = serialization.load_pem_private_key(f.read(), password=None)
+          pub = priv.public_key().public_bytes(encoding=serialization.Encoding.Raw, format=serialization.PublicFormat.Raw)
+          print(base64.b64encode(pub).decode())
+          ")
+
+          cp env.example .env
+          sed -i "s|^DOMAIN_BASE=.*|DOMAIN_BASE=localhost|" .env
+          sed -i "s|^JWT_SECRET=.*|JWT_SECRET=$(openssl rand -hex 32)|" .env
+          sed -i "s|^RELAY_PRIVATE_KEY=.*|RELAY_PRIVATE_KEY=${RELAY_PRIVATE_KEY_B64}|" .env
+
+          cp relay/relay.toml.example relay/relay.toml
+          sed -i 's|url = "https://relay.example.com"|url = "ws://localhost:8080"|' relay/relay.toml
+          sed -i 's|key_id = "REPLACE_WITH_KEY_ID"|key_id = "relay_cp_dev"|' relay/relay.toml
+          sed -i "s|public_key = \"REPLACE_WITH_PUBLIC_KEY_BASE64\"|public_key = \"${RELAY_PUBLIC_KEY_B64}\"|" relay/relay.toml
+          sed -i 's|access_key = "MINIO_ROOT_USER"|access_key = "relay"|' relay/relay.toml
+          sed -i 's|secret_key = "MINIO_ROOT_PASSWORD"|secret_key = "change-this-too"|' relay/relay.toml
+
+      - name: Pull published images (this release's tag)
+        run: bash scripts/pull-published-images.sh "${GITHUB_REF_NAME#v}"
+
+      - name: Boot clean stack
+        working-directory: infra
+        run: |
+          docker compose up -d postgres minio minio-init control-plane-migrate control-plane relay-server web-publish
+          timeout 90 bash -c 'until [ "$(docker inspect -f "{{.State.Health.Status}}" infra-control-plane-1 2>/dev/null)" = "healthy" ]; do sleep 3; done'
+
+      - name: Check /health on a clean database
+        working-directory: infra
+        run: |
+          RESULT=$(docker compose exec -T control-plane python3 -c "import urllib.request; print(urllib.request.urlopen('http://localhost:8000/health').read().decode())")
+          echo "control-plane /health: $RESULT"
+          echo "$RESULT" | grep -q '"ok": *true' || (echo "::error::control-plane /health did not report ok:true" && exit 1)
+
+      - name: Dump logs on failure
+        if: failure()
+        working-directory: infra
+        run: docker compose logs
+
+  create-release:
+    needs: [build-and-push, smoke-test]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/README.md
+++ b/README.md
@@ -49,19 +49,37 @@ You want your team in Obsidian, editing together, publishing docs — without gi
 
 ## Quick Start
 
+Full walkthrough — DNS, production hardening, systemd, troubleshooting — lives in the
+**[Installation Guide](docs/installation.md)**. The short version:
+
 ```bash
 git clone https://github.com/entire-vc/evc-team-relay.git
 cd evc-team-relay/infra
 cp env.example .env
-# Edit .env with your settings
+# Edit .env — at minimum DOMAIN_BASE, ACME_EMAIL, and RELAY_PRIVATE_KEY
+# (generate with: openssl genpkey -algorithm ed25519 -out relay_private.pem
+#  && openssl base64 -A -in relay_private.pem)
+
+cp relay/relay.toml.example relay/relay.toml
+# Edit relay.toml: MinIO credentials from .env, and the [[auth]] public_key
+# derived from the same key (see docs/installation.md step 3)
+
+# Pull the published images instead of building from source — web-publish's
+# build needs a GitHub token scoped to our private packages, which nobody
+# outside the org has. Point releases only; run from evc-team-relay/ (one
+# level up from infra/).
+bash ../scripts/pull-published-images.sh
+
 docker compose up -d
 ```
 
-**Services:**
+**Services** (once DNS points `cp`/`relay`/`docs` at your server and Caddy has issued certs):
 - Control Plane API: `https://cp.yourdomain.com`
 - Relay Server: `wss://relay.yourdomain.com`
 - Web Publish: `https://docs.yourdomain.com`
-- Grafana: `http://localhost:3001`
+
+Monitoring (Prometheus + Grafana) is on the internal Docker network only by default — see
+[Configuration → Monitoring](docs/configuration.md#monitoring) to reach it.
 
 Then install the [Obsidian plugin](https://github.com/entire-vc/evc-team-relay-obsidian-plugin) and connect.
 
@@ -96,10 +114,9 @@ Then install the [Obsidian plugin](https://github.com/entire-vc/evc-team-relay-o
 ## Documentation
 
 Technical documentation is available in [`docs/`](./docs/):
-- [Configuration](./docs/configuration.md)
+- [Installation](./docs/installation.md)
+- [Configuration](./docs/configuration.md) — includes [Web Publishing](./docs/configuration.md#web-publishing) and [Monitoring](./docs/configuration.md#monitoring)
 - [API Reference](./docs/api.md)
-- [Web Publishing](./docs/web-publish.md)
-- [Monitoring](./docs/monitoring.md)
 
 ---
 

--- a/apps/control-plane/app/core/security.py
+++ b/apps/control-plane/app/core/security.py
@@ -156,8 +156,8 @@ def load_or_generate_relay_keypair(
     if not settings.relay_private_key:
         raise RuntimeError(
             "RELAY_PRIVATE_KEY is required but not set. "
-            "Generate an Ed25519 key and set the RELAY_PRIVATE_KEY environment variable "
-            "(Base64-encoded PEM). See docs/setup.md for instructions."
+            "Generate with: openssl genpkey -algorithm ed25519 -out relay_private.pem "
+            "&& openssl base64 -A -in relay_private.pem — see docs/installation.md step 2."
         )
 
     # Load private key — supports both Base64-encoded (from .env) and raw PEM formats

--- a/apps/control-plane/app/templates/admin/settings_oauth.html
+++ b/apps/control-plane/app/templates/admin/settings_oauth.html
@@ -203,9 +203,9 @@ OAUTH_ADMIN_GROUPS=admins,superusers
 OAUTH_DEFAULT_ROLE=user</pre>
     <p class="text-muted">
         For detailed setup instructions, see the
-        <a href="https://github.com/entire-vc/evc-team-relay/blob/main/docs/guides/casdoor-setup.md" target="_blank" rel="noopener">
-            Casdoor Integration Guide
-        </a>.
+        <a href="https://github.com/entire-vc/evc-team-relay/blob/main/docs/configuration.md#oauthoidc" target="_blank" rel="noopener">
+            OAuth/OIDC configuration reference
+        </a> — Casdoor works as any generic OIDC provider.
     </p>
 </div>
 {% endblock %}

--- a/apps/control-plane/pyproject.toml
+++ b/apps/control-plane/pyproject.toml
@@ -14,7 +14,16 @@ dependencies = [
     "sqlalchemy>=2.0.25,<3.0",
     "alembic>=1.12,<2.0",
     "passlib[bcrypt]>=1.7.4,<2.0",
-    "bcrypt>=3.2,<6.0",
+    # passlib 1.7.4 (last release 2020, unmaintained) probes bcrypt's internal
+    # wrap-bug workaround at import time; bcrypt>=4.1 removed what that probe
+    # relies on, so any fresh install crashes bootstrap_admin_if_needed with
+    # "password cannot be longer than 72 bytes" on EVERY password, unrelated
+    # to actual length. Reproduced empirically on a clean OSS install
+    # (task 0bc89f80): `pip install .` (the Dockerfile's own install path,
+    # which does not use uv.lock) resolves bcrypt 5.0.0 today and the
+    # container never becomes healthy. Pin below the break until passlib is
+    # replaced or fixed upstream.
+    "bcrypt>=3.2,<4.1",
     "PyJWT>=2.8.0,<3.0",
     "cryptography>=50.0.0,<51.0",
     "psycopg[binary]>=3.1,<4.0",

--- a/apps/control-plane/uv.lock
+++ b/apps/control-plane/uv.lock
@@ -1058,7 +1058,7 @@ dev = [
 requires-dist = [
     { name = "alembic", specifier = ">=1.12,<2.0" },
     { name = "authlib", specifier = ">=1.6.12,<2.0" },
-    { name = "bcrypt", specifier = ">=3.2,<6.0" },
+    { name = "bcrypt", specifier = ">=3.2,<4.1" },
     { name = "cbor2", specifier = ">=5.6.0,<7.0" },
     { name = "cryptography", specifier = ">=50.0.0,<51.0" },
     { name = "fastapi", specifier = ">=0.115.0,<1.0" },

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -48,9 +48,18 @@ DOMAIN_BASE=yourdomain.com
 ACME_EMAIL=admin@yourdomain.com
 JWT_SECRET=$(openssl rand -hex 32)
 POSTGRES_PASSWORD=$(openssl rand -hex 16)
+# DATABASE_URL is a separate literal value — if you randomize POSTGRES_PASSWORD,
+# also update the password embedded in DATABASE_URL to match, or the app
+# will fail to connect (postgres and control-plane will disagree on it).
 MINIO_ROOT_PASSWORD=$(openssl rand -hex 16)
 BOOTSTRAP_ADMIN_EMAIL=admin@yourdomain.com
 BOOTSTRAP_ADMIN_PASSWORD=your-secure-password
+
+# REQUIRED — Ed25519 keypair for relay auth. Generate the private half:
+openssl genpkey -algorithm ed25519 -out relay_private.pem
+# RELAY_PRIVATE_KEY= the base64 output of:
+openssl base64 -A -in relay_private.pem
+# You'll need the matching public key in step 3 below.
 ```
 
 See [Configuration Reference](configuration.md) for all options.
@@ -61,7 +70,21 @@ See [Configuration Reference](configuration.md) for all options.
 cp relay/relay.toml.example relay/relay.toml
 ```
 
-Edit `relay/relay.toml` to match your MinIO credentials from `.env`.
+Edit `relay/relay.toml`:
+- `[store]` — MinIO credentials from `.env` (`MINIO_ROOT_USER`/`MINIO_ROOT_PASSWORD`).
+- `[[auth]]` — `key_id` matches `RELAY_KEY_ID` in `.env` if you set one (defaults to `relay_cp_dev`
+  if omitted); `public_key` is the Ed25519 public key derived from the private key you generated
+  in step 2:
+  ```bash
+  python3 -c "
+  from cryptography.hazmat.primitives import serialization
+  import base64
+  with open('relay_private.pem', 'rb') as f:
+      priv = serialization.load_pem_private_key(f.read(), password=None)
+  pub = priv.public_key().public_bytes(encoding=serialization.Encoding.Raw, format=serialization.PublicFormat.Raw)
+  print(base64.b64encode(pub).decode())
+  "
+  ```
 
 ### 4. Configure DNS
 
@@ -89,7 +112,29 @@ This allows the Obsidian plugin (and other browser-based clients) to authenticat
 
 > **Important**: Do not remove the `request_header` directive — without it, the Obsidian plugin will receive `401 Unauthorized` when connecting to the relay server.
 
-### 6. Start Services
+### 6. Pull the Published Images
+
+`web-publish` builds from source only with a GitHub token scoped to our private
+`@entire-vc/*` packages — not available outside the org. Pull the images the release
+workflow already publishes publicly instead (run from the repo root, one level up from
+`infra/`):
+
+```bash
+bash scripts/pull-published-images.sh
+```
+
+This tags them locally as `infra-control-plane:latest` / `infra-web-publish:latest`, which
+`docker compose up` picks up without attempting to build. Pass a version to pin one
+(`bash scripts/pull-published-images.sh 1.10.0`) instead of the default `latest`.
+
+> linux/amd64 only for now — there is no arm64 manifest yet, so this fails on Apple Silicon
+> or other arm64 hosts without emulation (e.g. `export DOCKER_DEFAULT_PLATFORM=linux/amd64`
+> under Docker Desktop).
+
+If you do have org access and want to build from source instead (e.g. active development),
+skip this step and run `docker compose up -d --build` in step 7.
+
+### 7. Start Services
 
 ```bash
 docker compose up -d
@@ -101,7 +146,7 @@ Wait for all services to become healthy:
 docker compose ps
 ```
 
-### 7. Verify Installation
+### 8. Verify Installation
 
 ```bash
 # Check health
@@ -113,7 +158,7 @@ curl https://cp.yourdomain.com/version
 # Expected: {"version":"1.x.x"}
 ```
 
-### 8. Access Admin Panel
+### 9. Access Admin Panel
 
 Open `https://cp.yourdomain.com/admin-ui/` in your browser and login with your bootstrap admin credentials.
 
@@ -138,14 +183,10 @@ Open `https://cp.yourdomain.com/admin-ui/` in your browser and login with your b
 
 ### Using Pre-built Images
 
-For production, you can use pre-built images from GitHub Container Registry:
-
-```yaml
-services:
-  control-plane:
-    image: ghcr.io/entire-vc/evc-team-relay/control-plane:latest
-    # ... rest of config
-```
+This is the default path (step 6 above) — `bash scripts/pull-published-images.sh [version]`
+pulls both `control-plane` and `web-publish` from GitHub Container Registry and tags them
+locally so `docker compose up -d` uses them without building. Re-run it with a new version
+to update.
 
 ### Systemd Service (Optional)
 
@@ -192,8 +233,13 @@ docker compose up -d --build
 
 ### With Pre-built Images
 
+`docker compose pull` won't work here — `control-plane`/`web-publish` are tagged locally
+(`infra-control-plane:latest`/`infra-web-publish:latest`, not a registry reference), by design
+so the same compose file works whether you build from source or pull. Re-run the pull script
+instead:
+
 ```bash
-docker compose pull
+bash scripts/pull-published-images.sh [version]
 docker compose up -d
 ```
 

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -304,11 +304,17 @@ services:
       start_period: 20s
 
   web-publish:
+    # Building this from source needs a GitHub token with read access to our
+    # private @entire-vc/* packages (see apps/web-publish/.npmrc) — not
+    # available outside the org. Default to the image the release workflow
+    # already publishes publicly (docs/installation.md "Pull the published
+    # images"); `build:` stays below for internal/dev use with GITHUB_TOKEN.
     build:
       context: ../apps/web-publish
       dockerfile: Dockerfile
       args:
         GITHUB_TOKEN: ${GITHUB_TOKEN:-}
+    image: infra-web-publish:latest
     environment:
       CONTROL_PLANE_URL: http://control-plane:8000
       PUBLIC_CONTROL_PLANE_URL: https://cp.${DOMAIN_BASE}

--- a/infra/env.example
+++ b/infra/env.example
@@ -2,6 +2,10 @@ DOMAIN_BASE=example.com
 ACME_EMAIL=ops@example.com
 
 # PostgreSQL
+# DATABASE_URL is a separate literal value, not derived from the three vars
+# above — if you change POSTGRES_PASSWORD (recommended), update the password
+# inside DATABASE_URL to match, or control-plane and postgres will disagree
+# on the password and the app will fail to connect.
 POSTGRES_USER=relay
 POSTGRES_PASSWORD=change-me
 POSTGRES_DB=relay
@@ -22,7 +26,9 @@ CORS_ALLOWED_ORIGINS=https://cp.tr.entire.vc     # Comma-separated; use '*' only
 # Relay server
 RELAY_PUBLIC_URL=wss://${DOMAIN_BASE}/doc/ws
 # RELAY_KEY_ID=relay_cp_01              # Optional, defaults to 'relay_cp_dev' if not set
-RELAY_PRIVATE_KEY=                       # REQUIRED — Base64-encoded Ed25519 PEM private key
+# REQUIRED — Base64-encoded Ed25519 PEM private key. Generate with:
+#   openssl genpkey -algorithm ed25519 -out relay_private.pem && openssl base64 -A -in relay_private.pem
+RELAY_PRIVATE_KEY=
 
 # Server identity (for multi-server plugin support)
 SERVER_NAME=My Relay Server
@@ -51,13 +57,17 @@ GRAFANA_ADMIN_PASSWORD=change-me-please
 
 # Email configuration (for notifications)
 EMAIL_ENABLED=false                   # Enable email sending
-SMTP_HOST=                            # SMTP server hostname
+# SMTP server hostname
+SMTP_HOST=
 SMTP_PORT=587                         # SMTP port (587 for TLS, 465 for SSL)
-SMTP_USER=                            # SMTP username
-SMTP_PASSWORD=                        # SMTP password
+# SMTP username
+SMTP_USER=
+# SMTP password
+SMTP_PASSWORD=
 SMTP_USE_TLS=true                     # Use STARTTLS
 EMAIL_FROM=noreply@example.com        # From address
-EMAIL_REPLY_TO=                       # Reply-to address (optional)
+# Reply-to address (optional)
+EMAIL_REPLY_TO=
 
 # Background worker configuration
 WEBHOOK_WORKER_INTERVAL=30            # Webhook worker poll interval (seconds)
@@ -66,16 +76,19 @@ EMAIL_WORKER_INTERVAL=60              # Email worker poll interval (seconds)
 EMAIL_WORKER_BATCH_SIZE=100           # Max emails to process per cycle
 
 # Web Publishing configuration (v1.7)
-WEB_PUBLISH_DOMAIN=                   # Web publishing domain (e.g., docs.example.com)
-                                       # Leave empty to disable web publishing
+# Web publishing domain (e.g., docs.example.com). Leave empty to disable web publishing.
+WEB_PUBLISH_DOMAIN=
 
 # Lifecycle email nudge engine (S3)
 # Set LIFECYCLE_ENABLED=true after E2E smoke test passes.
 LIFECYCLE_ENABLED=false
-LIFECYCLE_LAUNCH_DATE=                # ISO datetime cutoff; nudge only users registered on/after this date
+# ISO datetime cutoff; nudge only users registered on/after this date
+LIFECYCLE_LAUNCH_DATE=
 # LIFECYCLE_WORKER_INTERVAL=3600     # Poll interval seconds (default 3600)
-LIFECYCLE_FROM_NAME=                  # Lead persona display name (e.g. "Alex from Entire")
-LIFECYCLE_FROM_EMAIL=                 # Lead persona send-as address (must be an SMTP alias)
+# Lead persona display name (e.g. "Alex from Entire")
+LIFECYCLE_FROM_NAME=
+# Lead persona send-as address (must be an SMTP alias)
+LIFECYCLE_FROM_EMAIL=
 LIFECYCLE_UNSUBSCRIBE_SECRET=change-me-in-prod  # HMAC-SHA256 key for unsubscribe tokens
 
 # OAuth state signing (required when OAUTH_ENABLED=true)

--- a/scripts/pull-published-images.sh
+++ b/scripts/pull-published-images.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# Team Relay — pull the published control-plane + web-publish images and tag
+# them locally to match what infra/docker-compose.yml expects (infra-control-
+# plane:latest, infra-web-publish:latest). This is the path for anyone who
+# doesn't have a GitHub token with read access to our private @entire-vc/*
+# packages — which building web-publish from source needs (see
+# apps/web-publish/.npmrc) and every external OSS user is in that position.
+#
+# Both images are published publicly by .github/workflows/release.yml on
+# every version tag; no login is required to pull them.
+#
+# linux/amd64 only for now (same for relay-server) — there is no arm64
+# manifest, so this fails on Apple Silicon / arm64 hosts without emulation
+# (e.g. `export DOCKER_DEFAULT_PLATFORM=linux/amd64` under Docker Desktop).
+# Tracked separately; not fixed here.
+#
+# Usage:
+#   bash scripts/pull-published-images.sh [version]   # default: latest
+#
+# Then, from infra/:
+#   docker compose up -d
+# picks up the locally-tagged images without attempting to build anything.
+
+set -euo pipefail
+
+VERSION="${1:-latest}"
+REGISTRY="ghcr.io/entire-vc/evc-team-relay"
+
+for component in control-plane web-publish; do
+  echo "Pulling ${REGISTRY}/${component}:${VERSION}..."
+  docker pull "${REGISTRY}/${component}:${VERSION}"
+  docker tag "${REGISTRY}/${component}:${VERSION}" "infra-${component}:latest"
+done
+
+echo "Done. infra-control-plane:latest and infra-web-publish:latest are ready for docker compose up -d."


### PR DESCRIPTION
## Summary
The documented `docker compose up -d` install flow never worked for anyone outside the org — `web-publish` builds from source and needs a GitHub token scoped to our private `@entire-vc/tokens`/`@entire-vc/ui-svelte` packages. Verified the whole flow end-to-end on a clean host and fixed every failure found along the way:

- `web-publish` now has an `image:` entry alongside its `build:` (matching `control-plane`'s existing pattern); `scripts/pull-published-images.sh` pulls both published images from ghcr (public, no auth) and tags them locally so `docker compose up` doesn't need to build. Internal prod deploys are unaffected — they already build+tag these exact local names by hand.
- `infra/env.example`: 9 vars had a trailing inline comment on an empty value (`KEY=   # comment`) — Compose's `.env` parser only treats a *leading* `#` as a comment, so these values were literally the comment text. `WEB_PUBLISH_DOMAIN` silently became truthy this way and crashed web-publish on an invalid URL built from a comment string. Moved every instance to its own line. Also documents `RELAY_PRIVATE_KEY` generation (required, zero prior instructions) and flags the `DATABASE_URL`/`POSTGRES_PASSWORD` desync risk.
- `bcrypt` was unpinned above passlib's (unmaintained since 2020) compatible range — a fresh build today resolves bcrypt 5.0.0 and crashes `bootstrap_admin_if_needed` with a password-length error on any password. Pinned below the break.
- Two dead doc references fixed (one in the code's own error message, one in the admin UI template) — both pointed at files that don't exist.
- README + installation.md: missing `relay.toml` copy step added, DOMAIN_BASE/DNS documented as prerequisites, false Grafana-port claim removed, dead doc links fixed, README now links to installation.md.
- New `smoke-test` job in `release.yml`, gating `create-release`: pulls the just-published images into a clean database and asserts `/health`. Complements the existing `checks-control-plane.yml` alembic check (source-level, every PR) by testing the actual published artifact end-to-end — which is what would have caught the bcrypt regression above.

**Known gap not fixed here, flagged in the docs/script instead:** none of the three published images (`relay-server`, `control-plane`, `web-publish`) have an arm64 manifest. Multi-arch build is separate, non-trivial work (Rust/Python/Node cross-compilation) tracked on its own.

**On GH #177:** already fixed and replied to on 2026-08-07, before the internal task that produced this PR existed. This PR fixes a different, still-live set of bugs a fresh installer hits next.

## Test plan
- [x] Built and ran the full stack (postgres, minio, control-plane, relay-server, web-publish) from the pulled `v1.10.0` images — zero local builds, zero private-package access
- [x] `control-plane` healthy, `/health` → `{"ok":true}`
- [x] Bootstrap admin login → 200
- [x] `web-publish` serves 200 with real content
- [x] Full control-plane suite: 725 passed, 1 skipped
- [x] `ruff check` clean on changed files
- [x] `release.yml` YAML validated, job dependency graph confirmed (`smoke-test` needs `build-and-push`; `create-release` needs both)

— Daedalus, Entire VC