### PR TITLE
docs: fix stale relay.$DOMAIN_BASE references and pre-TR-43 Caddy snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ bash ../scripts/pull-published-images.sh
 docker compose up -d
 ```
 
-**Services** (once DNS points `cp`/`relay`/`docs` at your server and Caddy has issued certs):
+**Services** (once DNS points your bare `DOMAIN_BASE`, `cp.DOMAIN_BASE`, and `docs.DOMAIN_BASE` at your server and Caddy has issued certs):
+- Relay Server: `wss://yourdomain.com` (your `DOMAIN_BASE` itself — no `relay.` subdomain)
 - Control Plane API: `https://cp.yourdomain.com`
-- Relay Server: `wss://relay.yourdomain.com`
 - Web Publish: `https://docs.yourdomain.com`
 
 Monitoring (Prometheus + Grafana) is on the internal Docker network only by default — see

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -41,7 +41,7 @@ These create the first admin user when the database is empty.
 |----------|----------|---------|-------------|
 | `SERVER_NAME` | No | `EVC Team Relay` | Display name shown in plugin |
 | `SERVER_ID` | No | (auto) | Unique identifier, defaults to relay key ID |
-| `RELAY_PUBLIC_URL` | No | `wss://relay.${DOMAIN_BASE}` | Public WebSocket URL for relay server |
+| `RELAY_PUBLIC_URL` | No | `wss://${DOMAIN_BASE}/doc/ws` | Public WebSocket URL for relay server |
 
 ## Logging
 
@@ -209,27 +209,43 @@ The `Caddyfile` in the `infra/` directory configures Caddy as a reverse proxy wi
 
 ### WebSocket Token Proxy
 
-The relay server authenticates WebSocket connections using CWT (CBOR Web Token) tokens passed via the `Authorization: Bearer` header. However, the browser WebSocket API (`new WebSocket(url)`) does not support custom headers.
-
-To bridge this gap, Caddy extracts the `?token=` query parameter and sets it as the `Authorization` header:
+Relay server (`{$DOMAIN_BASE}` — there is no separate `relay.` subdomain) authenticates
+WebSocket connections using CWT (CBOR Web Token) tokens. For plain HTTP endpoints, since the
+browser WebSocket API (`new WebSocket(url)`) does not support custom headers, Caddy extracts
+the `?token=` query parameter and rewrites it as an `Authorization: Bearer` header. The
+WebSocket-upgrade paths are explicitly excluded from that rewrite: relay-server's own
+WS-upgrade handlers only ever read the token from the query string, never from a header
+(see [#137](https://github.com/entire-vc/evc-team-relay/pull/137)), so rewriting it there
+strips the one thing the handler checks and replaces it with the one thing it never reads:
 
 ```caddy
-relay.{$DOMAIN_BASE} {
-  @token_in_query query token=*
-  request_header @token_in_query Authorization "Bearer {query.token}"
-  reverse_proxy relay-server:8080
+{$DOMAIN_BASE} {
+  @token_in_query {
+    query token=*
+    not path /doc/ws/* /d/*/ws/*
+  }
+  handle @token_in_query {
+    route {
+      request_header Authorization "Bearer {query.token}"
+      uri query -token
+      reverse_proxy relay-server:8080
+    }
+  }
+  handle {
+    reverse_proxy relay-server:8080
+  }
 }
 ```
 
 **How it works:**
 
-1. The Obsidian plugin connects to `wss://relay.yourdomain.com/doc/ws/{docId}?token=<CWT>`
-2. Caddy sees the `?token=` query parameter and sets `Authorization: Bearer <CWT>` header
-3. The relay server receives the `Authorization` header and validates the CWT token
+1. The Obsidian plugin connects to `wss://yourdomain.com/doc/ws/{docId}?token=<CWT>`
+2. The path matches `/doc/ws/*`, so the `@token_in_query` matcher above excludes it — Caddy proxies the request through unchanged, query string intact
+3. relay-server's own verifier reads `?token=` directly and validates the CWT
 
-Both methods are supported simultaneously:
-- **`?token=` query parameter** — used by browser-based clients (Obsidian plugin)
-- **`Authorization: Bearer` header** — used by server-side clients and scripts
+For non-WS HTTP endpoints, both methods are supported:
+- **`?token=` query parameter** — rewritten to a header by Caddy, for browser-based clients that can't set one
+- **`Authorization: Bearer` header** — set directly by server-side clients and scripts
 
 ### CWT Token Format
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -88,29 +88,46 @@ Edit `relay/relay.toml`:
 
 ### 4. Configure DNS
 
+`DOMAIN_BASE` itself is the relay server's domain — there is no separate `relay.` subdomain.
 Point these DNS records to your server IP:
 
 | Record | Type | Value |
 |--------|------|-------|
+| `yourdomain.com` (i.e. your `DOMAIN_BASE`) | A | Your server IP |
 | `cp.yourdomain.com` | A | Your server IP |
-| `relay.yourdomain.com` | A | Your server IP |
 | `docs.yourdomain.com` | A | Your server IP (optional, for web publishing) |
 
 ### 5. Review Caddy Configuration
 
-The default `Caddyfile` handles TLS termination, routing, and **WebSocket token proxying**. The relay server expects authentication via the `Authorization` header, but browser WebSocket API cannot set custom headers. Caddy bridges this gap by extracting `?token=` from the query string and setting it as an `Authorization: Bearer` header:
+The default `Caddyfile` handles TLS termination and routing. For plain HTTP endpoints it also
+does **WebSocket token proxying**: since the browser WebSocket API cannot set custom headers,
+Caddy extracts `?token=` from the query string and sets it as an `Authorization: Bearer` header
+— but the relay server's WebSocket-upgrade handlers only ever read the token from the query
+string, never from a header, so that rewrite must skip the WS paths or it strips the one thing
+the handler checks:
 
 ```caddy
-relay.{$DOMAIN_BASE} {
-  @token_in_query query token=*
-  request_header @token_in_query Authorization "Bearer {query.token}"
-  reverse_proxy relay-server:8080
+{$DOMAIN_BASE} {
+  @token_in_query {
+    query token=*
+    not path /doc/ws/* /d/*/ws/*
+  }
+  handle @token_in_query {
+    route {
+      request_header Authorization "Bearer {query.token}"
+      uri query -token
+      reverse_proxy relay-server:8080
+    }
+  }
+  handle {
+    reverse_proxy relay-server:8080
+  }
 }
 ```
 
-This allows the Obsidian plugin (and other browser-based clients) to authenticate using `wss://relay.yourdomain.com/doc/ws/{docId}?token=CWT_TOKEN`.
+This allows the Obsidian plugin (and other browser-based clients) to authenticate using `wss://yourdomain.com/doc/ws/{docId}?token=CWT_TOKEN` — the WS upgrade carries the token straight through to relay-server's own query-param verifier, unmodified.
 
-> **Important**: Do not remove the `request_header` directive — without it, the Obsidian plugin will receive `401 Unauthorized` when connecting to the relay server.
+> **Important**: Do not add the `Authorization` rewrite back to the `/doc/ws/*` and `/d/*/ws/*` paths — it was there originally and caused every WebSocket connection to fail auth with `missing_token` (see [#137](https://github.com/entire-vc/evc-team-relay/pull/137) for the incident this config now avoids).
 
 ### 6. Pull the Published Images
 


### PR DESCRIPTION
## Summary
Found while independently verifying the #198 outsider-install fix end-to-end (clean clone, no private-package access, pulled published images). Three docs describe a `relay.` subdomain and a Caddy `@token_in_query` matcher without the WS-path exclusion — neither matches reality:

- `infra/Caddyfile` and `infra/env.example`'s `RELAY_PUBLIC_URL` default both route relay-server off the bare `DOMAIN_BASE`, with no `relay.` prefix. README's Services list, installation.md's DNS table, and configuration.md's WebSocket section all said `relay.yourdomain.com` instead.
- installation.md and configuration.md both showed the Caddyfile snippet *before* #137 (the WS-token-stripping fix that resolved `missing_token` auth failures) — including installation.md's `> **Important**: Do not remove the request_header directive`, which is the exact opposite of what #137 needed to do for the WS-upgrade paths. A self-hoster copying this snippet verbatim would reintroduce that bug.

Fixed all three files to match `infra/Caddyfile` as it actually ships, and reworded the "Important" note to explain why the WS paths are excluded rather than warn against excluding them.

## Test plan
- [x] `grep -rn "relay\.yourdomain\|relay\.\${DOMAIN\|relay\.{DOMAIN" docs/ README.md infra/` — zero remaining matches
- [x] Diffed the new Caddyfile snippets in both docs against the live `infra/Caddyfile` — identical
- [x] Docs-only change, no code/config touched

— Daedalus, Entire VC