### PR TITLE
fix(control-plane): CWT tokens now carry kid+aud+configurable iss

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,13 @@ JWT_SECRET=replace-me
 BOOTSTRAP_ADMIN_EMAIL=admin@example.com
 BOOTSTRAP_ADMIN_PASSWORD=super-secret-pass
 RELAY_PUBLIC_URL=wss://relay.${DOMAIN_BASE}
+# RELAY_AUDIENCE=https://${DOMAIN_BASE}  # Optional — must equal relay.toml's [server].url
+                                          # exactly. Defaults to https://{RELAY_PUBLIC_URL's
+                                          # host}, which matches relay.toml.example's default.
+                                          # Set explicitly only if your [server].url differs.
+# RELAY_TOKEN_ISSUER=relay-server        # Optional — must be in relay-server's issuer
+                                          # allowlist (relay-server, auth.system3.dev,
+                                          # auth.system3.md as of image 0.9.9). Leave default.
 
 # Server identity (for multi-server plugin support)
 SERVER_NAME=My Relay Server

--- a/apps/control-plane/app/core/config.py
+++ b/apps/control-plane/app/core/config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from functools import lru_cache
+from urllib.parse import urlsplit
 
 from pydantic import AnyUrl, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -73,6 +74,44 @@ class Settings(BaseSettings):
         default=None, description="Ed25519 private key in PEM format for signing relay tokens"
     )
     relay_key_id: str = Field(default="relay_cp_dev", description="Key ID for JWT kid header")
+    relay_audience: str | None = Field(
+        default=None,
+        description=(
+            "Expected 'aud' claim relay-server validates CWT tokens against — must equal "
+            "[server].url in relay.toml exactly (e.g. https://tr.entire.vc). NOT the same "
+            "value as relay_public_url: that one is the client-facing WebSocket URL and "
+            "typically carries a wss:// scheme and a /doc/ws path, which the aud claim must "
+            "NOT include. If unset, derived from relay_public_url's host as "
+            "'https://{host}' (see Settings.effective_relay_audience) — correct for the "
+            "standard deploy where relay.toml's [server].url is 'https://{DOMAIN_BASE}'. "
+            "Set explicitly if your relay.toml uses a different [server].url."
+        ),
+    )
+    relay_token_issuer: str = Field(
+        default="relay-server",
+        description=(
+            "'iss' claim on issued CWT tokens. relay-server (ghcr.io/entire-vc/"
+            "evc-relay-server, crates/y-sweet-core/src/auth.rs VALID_ISSUERS) only accepts "
+            "'relay-server', 'auth.system3.dev', or 'auth.system3.md' as of image 0.9.9 — "
+            "the semantically accurate 'relay-control-plane' is NOT in that allowlist. Keep "
+            "the default until relay-server's allowlist is extended; do not hardcode "
+            "'relay-control-plane' in code."
+        ),
+    )
+
+    @property
+    def effective_relay_audience(self) -> str:
+        """The 'aud' claim to embed in issued CWT tokens.
+
+        Explicit relay_audience wins. Otherwise derived from relay_public_url's
+        host, dropping the scheme/path/query relay_public_url carries for WS
+        clients (e.g. 'wss://tr.entire.vc/doc/ws' -> 'https://tr.entire.vc') —
+        matching the standard relay.toml [server].url convention.
+        """
+        if self.relay_audience:
+            return self.relay_audience
+        host = urlsplit(str(self.relay_public_url)).netloc
+        return f"https://{host}"
 
     bootstrap_admin_email: str | None = Field(default=None)
     bootstrap_admin_password: str | None = Field(default=None)

--- a/apps/control-plane/app/core/security.py
+++ b/apps/control-plane/app/core/security.py
@@ -247,7 +247,8 @@ def create_relay_token_cwt(
     Token structure:
     - CWT tag 61 wrapper
     - COSE_Sign1 with Ed25519 signature (EdDSA algorithm)
-    - Claims: iss, iat, exp, scope (-80201), share (-80203)
+    - Protected header: alg (1) + kid (4, bstr)
+    - Claims: iss, iat, exp, aud, scope (-80201), share (-80203)
     - Scope format: "doc:{doc_id}:rw" or "doc:{doc_id}:r"
 
     Security notes (H6, re-verified TR-22 2026-07-21 against our own fork —
@@ -267,16 +268,32 @@ def create_relay_token_cwt(
     - Because there is no jti/revocation-list, remove_member cannot invalidate a
       token already handed to the ex-member — settings.relay_token_ttl_minutes (see
       config.py) is the only lever bounding that exposure window (TR-22, #f63a2bea).
-    - aud is omitted: y-sweet rejects tokens with the aud claim.
+    - kid/aud/iss (2026-08-20, #f975dd60): the previous version of this docstring said
+      "aud is omitted: y-sweet rejects tokens with the aud claim" and omitted kid from
+      the protected header entirely. That was true of upstream y-sweet; it has been
+      false since 2025-10, when we moved to our own fork (evc-relay-server), which
+      REQUIRES kid + aud, and validates iss against a fixed allowlist when present.
+      Result: every CWT issued since the CWT migration (bec43fb, 2026-02-06) failed
+      relay-server's auth check — collab was fully broken in prod for ~6 months,
+      silently, because the missing-kid failure path (auth.rs find_verifying_key)
+      never logs. Root-caused + reproduced live in #f3cb5365; do not reintroduce any
+      of these three omissions.
 
     Args:
         private_key: Ed25519 private key object
-        key_id: Key identifier for COSE header (kid)
+        key_id: Key identifier for COSE header (kid) — REQUIRED for relay-server to find
+            the right verification key; must match a [[auth]] key_id in relay.toml.
         doc_id: Document ID for relay access
         mode: Access mode ("read" or "write")
         expires_minutes: Token TTL in minutes
-        audience: Relay server URL (reserved, not added to claims — y-sweet rejects aud)
-        issuer: Token issuer (default: "relay-control-plane")
+        audience: Expected audience — MUST equal relay.toml's [server].url exactly
+            (see Settings.effective_relay_audience). Required: relay-server rejects
+            tokens with no aud claim (MissingAudience) once it knows to expect one.
+        issuer: Token issuer. Must be one of relay-server's VALID_ISSUERS allowlist
+            ("relay-server", "auth.system3.dev", "auth.system3.md" as of image 0.9.9) —
+            see Settings.relay_token_issuer. Default kept at "relay-control-plane" for
+            call-site backward-compat, but callers going through token_service.py
+            override this via settings.relay_token_issuer.
         share_id: Share UUID the token was issued against (added as CWT_CLAIM_SHARE)
 
     Returns:
@@ -295,6 +312,10 @@ def create_relay_token_cwt(
         CWT_CLAIM_SCOPE: scope,
     }
 
+    # relay-server (evc-relay-server fork) requires aud — see docstring above.
+    if audience:
+        claims[CWT_CLAIM_AUD] = audience
+
     # Bind token to the issuing share — confused-deputy mitigation (H6).
     # Full enforcement requires relay-server (System3) to validate this claim.
     if share_id:
@@ -304,9 +325,12 @@ def create_relay_token_cwt(
     claims_cbor = cbor2.dumps(claims)
 
     # Create COSE_Sign1 message
-    # Protected header: algorithm (EdDSA = -8) only
-    # Note: y-sweet does NOT include kid in protected header
-    protected = {1: -8}  # alg: EdDSA
+    # Protected header: algorithm (EdDSA = -8) + key ID (COSE param 4, bstr).
+    # relay-server's find_verifying_key (auth.rs) reads kid to pick which
+    # relay.toml [[auth]] entry to verify against; without it, tokens only work
+    # by accident (fallback loop over keys_without_id) or not at all if the
+    # matching key has a key_id configured, as prod does (KeyMismatch, silently).
+    protected = {1: -8, 4: key_id.encode("utf-8")}  # alg: EdDSA, kid: bstr
 
     # Encode protected header
     protected_cbor = cbor2.dumps(protected)

--- a/apps/control-plane/app/services/token_service.py
+++ b/apps/control-plane/app/services/token_service.py
@@ -125,7 +125,6 @@ def issue_relay_token(
     # parse_claims_map + auth.rs) — separate task from TR-22, file if not already open.
     private_key = request.app.state.relay_private_key
     key_id = request.app.state.relay_key_id
-    relay_url = str(settings.relay_public_url).rstrip("/")
 
     token = security.create_relay_token_cwt(
         private_key=private_key,
@@ -133,7 +132,8 @@ def issue_relay_token(
         doc_id=payload.doc_id,
         mode=payload.mode.value,
         expires_minutes=settings.relay_token_ttl_minutes,
-        audience=relay_url,
+        audience=settings.effective_relay_audience,
+        issuer=settings.relay_token_issuer,
         share_id=str(share.id),
     )
 

--- a/apps/control-plane/tests/test_config_relay_audience.py
+++ b/apps/control-plane/tests/test_config_relay_audience.py
@@ -1,0 +1,41 @@
+"""Tests for Settings.effective_relay_audience (#f975dd60).
+
+Level 1: Unit tests — pure config derivation, no external dependencies.
+"""
+
+from __future__ import annotations
+
+from app.core.config import Settings
+
+
+class TestEffectiveRelayAudience:
+    def test_explicit_relay_audience_wins(self):
+        settings = Settings(
+            relay_public_url="wss://tr.entire.vc/doc/ws",
+            relay_audience="https://custom.example.com",
+        )
+        assert settings.effective_relay_audience == "https://custom.example.com"
+
+    def test_derived_from_relay_public_url_when_unset(self):
+        """Default case: strip scheme/path from relay_public_url, force https.
+
+        This must NOT just reuse relay_public_url verbatim — that carries the
+        wss:// scheme and /doc/ws path clients use, which relay.toml's
+        [server].url (the value relay-server compares aud against) does not.
+        """
+        settings = Settings(relay_public_url="wss://tr.entire.vc/doc/ws", relay_audience=None)
+        assert settings.effective_relay_audience == "https://tr.entire.vc"
+
+    def test_derived_default_has_no_path_or_query(self):
+        settings = Settings(
+            relay_public_url="wss://relay.example.com/doc/ws?foo=bar", relay_audience=None
+        )
+        assert settings.effective_relay_audience == "https://relay.example.com"
+
+    def test_default_token_issuer_is_relay_server(self):
+        """Must default to a value in relay-server's VALID_ISSUERS allowlist
+        (auth.rs) for the currently-deployed image — NOT 'relay-control-plane',
+        which is not accepted by evc-relay-server:0.9.9.
+        """
+        settings = Settings()
+        assert settings.relay_token_issuer == "relay-server"

--- a/apps/control-plane/tests/test_cwt_tokens.py
+++ b/apps/control-plane/tests/test_cwt_tokens.py
@@ -154,26 +154,40 @@ class TestCWTTokenStructure:
         assert isinstance(inner, cbor2.CBORTag)
         assert inner.tag == COSE_SIGN1_TAG  # 18
 
-    def test_protected_header_only_alg_eddsa(self):
-        """Protected header must be {1: -8} (alg: EdDSA) — NO kid."""
+    def test_protected_header_has_alg_and_kid(self):
+        """Protected header must be {1: -8 (alg: EdDSA), 4: kid (bstr)}.
+
+        #f975dd60: reverses the old "NO kid" assumption, which was correct for
+        upstream y-sweet but wrong for our evc-relay-server fork — see the
+        docstring on create_relay_token_cwt. Without kid, relay-server's
+        find_verifying_key (auth.rs) silently returns KeyMismatch whenever the
+        matching key has a key_id configured, as prod's relay.toml does.
+        """
         private_key, _ = _make_keypair()
         token = create_relay_token_cwt(private_key, "k1", "doc-123", "write", 60)
 
         protected_cbor, _, _, _ = _decode_cwt_raw(token)
         protected = cbor2.loads(protected_cbor)
 
-        assert protected == {1: -8}, f"Expected {{1: -8}}, got {protected}"
+        assert protected == {1: -8, 4: b"k1"}, f"Expected alg+kid, got {protected}"
 
-    def test_no_kid_in_protected_header(self):
-        """y-sweet rejects tokens with kid in protected header."""
+    def test_kid_is_bytes_matching_key_id(self):
+        """kid (COSE param 4) must be a bstr equal to key_id.encode('utf-8').
+
+        relay-server's extract_cwt_key_id (auth.rs) requires param 4 to decode
+        as a Bytes value, then UTF-8-decodes it to compare against relay.toml's
+        configured key_id string — a text-type kid would not match.
+        """
         private_key, _ = _make_keypair()
         token = create_relay_token_cwt(private_key, "some_kid", "doc-123", "write", 60)
 
         protected_cbor, _, _, _ = _decode_cwt_raw(token)
         protected = cbor2.loads(protected_cbor)
 
-        assert 4 not in protected, "kid (label 4) must NOT be in protected header"
-        assert len(protected) == 1, f"Only alg expected, got {protected}"
+        assert 4 in protected, "kid (label 4) must be present in protected header"
+        assert isinstance(protected[4], bytes), "kid must be CBOR bstr, not text"
+        assert protected[4] == b"some_kid"
+        assert len(protected) == 2, f"Expected exactly alg+kid, got {protected}"
 
     def test_unprotected_header_is_empty(self):
         private_key, _ = _make_keypair()
@@ -246,13 +260,27 @@ class TestCWTClaims:
             delta = claims[CWT_CLAIM_EXP] - claims[CWT_CLAIM_IAT]
             assert abs(delta - ttl * 60) <= 5, f"TTL {ttl} min gave delta={delta}s"
 
-    def test_no_aud_claim(self):
-        """aud (3) must NOT be present — y-sweet rejects it."""
+    def test_aud_claim_present_when_audience_given(self):
+        """aud (3) must be present and equal to `audience` when provided.
+
+        #f975dd60: reverses the old "y-sweet rejects aud" assumption — our
+        evc-relay-server fork requires aud and rejects tokens missing it
+        (MissingAudience) once verification is invoked with an expected
+        audience, which token_service.py always does in production.
+        """
         private_key, _ = _make_keypair()
-        # Even when audience is passed, it should NOT appear in claims
         token = create_relay_token_cwt(
-            private_key, "k1", "doc-123", "write", 60, audience="wss://relay.test"
+            private_key, "k1", "doc-123", "write", 60, audience="https://tr.entire.vc"
         )
+
+        _, claims, _, _ = _decode_cwt_raw(token)
+        assert CWT_CLAIM_AUD in claims, f"aud claim missing: {claims}"
+        assert claims[CWT_CLAIM_AUD] == "https://tr.entire.vc"
+
+    def test_no_aud_claim_when_audience_omitted(self):
+        """aud must be absent when audience is not passed (backward-compat callers)."""
+        private_key, _ = _make_keypair()
+        token = create_relay_token_cwt(private_key, "k1", "doc-123", "write", 60)
 
         _, claims, _, _ = _decode_cwt_raw(token)
         assert CWT_CLAIM_AUD not in claims, f"aud claim found: {claims}"

--- a/apps/control-plane/tests/test_relay_token_endpoint.py
+++ b/apps/control-plane/tests/test_relay_token_endpoint.py
@@ -157,14 +157,22 @@ class TestRelayTokenHappyPath:
         data = resp.json()
         claims = decode_cwt_claims(data["token"])
 
-        assert claims["iss"] == "relay-control-plane"
+        # #f975dd60: our evc-relay-server fork requires iss in its VALID_ISSUERS
+        # allowlist and requires aud — "relay-control-plane" + no-aud (the old
+        # expectations here) is exactly the pair of defects that left collab
+        # broken in prod for 6 months. See Settings.relay_token_issuer /
+        # effective_relay_audience.
+        assert claims["iss"] == "relay-server"
         assert claims["scope"] == f"doc:{share_id}:rw"
         assert "iat" in claims
         # H6: exp is now required for TTL enforcement
         assert "exp" in claims, "exp missing — H6 security regression"
         assert claims["exp"] > claims["iat"]
-        # aud must NOT appear — y-sweet rejects it
-        assert "aud" not in claims
+        # aud MUST appear — relay-server rejects tokens missing it. Derived from
+        # RELAY_PUBLIC_URL=wss://relay.test (conftest.py) -> https://relay.test.
+        assert claims.get("aud") == "https://relay.test", (
+            "aud missing or wrong — relay-server requires it (#f975dd60)"
+        )
 
     def test_read_mode_scope(self, client: TestClient):
         admin_token = login(client, "bootstrap@example.com", "super-secret")

--- a/apps/control-plane/tests/test_relay_token_endpoint.py
+++ b/apps/control-plane/tests/test_relay_token_endpoint.py
@@ -170,9 +170,9 @@ class TestRelayTokenHappyPath:
         assert claims["exp"] > claims["iat"]
         # aud MUST appear — relay-server rejects tokens missing it. Derived from
         # RELAY_PUBLIC_URL=wss://relay.test (conftest.py) -> https://relay.test.
-        assert claims.get("aud") == "https://relay.test", (
-            "aud missing or wrong — relay-server requires it (#f975dd60)"
-        )
+        assert (
+            claims.get("aud") == "https://relay.test"
+        ), "aud missing or wrong — relay-server requires it (#f975dd60)"
 
     def test_read_mode_scope(self, client: TestClient):
         admin_token = login(client, "bootstrap@example.com", "super-secret")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -41,7 +41,10 @@ These create the first admin user when the database is empty.
 |----------|----------|---------|-------------|
 | `SERVER_NAME` | No | `EVC Team Relay` | Display name shown in plugin |
 | `SERVER_ID` | No | (auto) | Unique identifier, defaults to relay key ID |
-| `RELAY_PUBLIC_URL` | No | `wss://${DOMAIN_BASE}/doc/ws` | Public WebSocket URL for relay server |
+| `RELAY_PUBLIC_URL` | No | `wss://${DOMAIN_BASE}/doc/ws` | Public WebSocket URL for relay server (client-facing) |
+| `RELAY_KEY_ID` | No | `relay_cp_dev` | COSE `kid` embedded in issued tokens; must match a `[[auth]] key_id` in `relay.toml` |
+| `RELAY_AUDIENCE` | No | derived from `RELAY_PUBLIC_URL`'s host as `https://{host}` | `aud` claim on issued tokens — must equal `relay.toml`'s `[server].url` exactly. Distinct from `RELAY_PUBLIC_URL`: that one is the wss:// client URL with a `/doc/ws` path, this must be a bare https:// origin with no path. Set explicitly only if your `[server].url` uses a different host than `RELAY_PUBLIC_URL`. |
+| `RELAY_TOKEN_ISSUER` | No | `relay-server` | `iss` claim on issued tokens. Must be one of relay-server's accepted issuers (`relay-server`, `auth.system3.dev`, `auth.system3.md` as of image `0.9.9`) — leave at the default unless you know your relay-server image accepts a different value. |
 
 ## Logging
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -71,6 +71,12 @@ cp relay/relay.toml.example relay/relay.toml
 ```
 
 Edit `relay/relay.toml`:
+- `[server].url` — **must equal `RELAY_AUDIENCE` in `.env` exactly** (or, if you left
+  `RELAY_AUDIENCE` unset, must equal `https://${DOMAIN_BASE}` — the default control-plane
+  derives from `RELAY_PUBLIC_URL`'s host). A mismatch here fails silently: tokens are issued
+  and signed correctly but every WebSocket connection is rejected with no useful log line.
+  Remember there is no separate `relay.` subdomain (step 4 below) — this is
+  `https://yourdomain.com`, not `https://relay.yourdomain.com`.
 - `[store]` — MinIO credentials from `.env` (`MINIO_ROOT_USER`/`MINIO_ROOT_PASSWORD`).
 - `[[auth]]` — `key_id` matches `RELAY_KEY_ID` in `.env` if you set one (defaults to `relay_cp_dev`
   if omitted); `public_key` is the Ed25519 public key derived from the private key you generated

--- a/infra/env.example
+++ b/infra/env.example
@@ -29,6 +29,16 @@ RELAY_PUBLIC_URL=wss://${DOMAIN_BASE}/doc/ws
 # REQUIRED — Base64-encoded Ed25519 PEM private key. Generate with:
 #   openssl genpkey -algorithm ed25519 -out relay_private.pem && openssl base64 -A -in relay_private.pem
 RELAY_PRIVATE_KEY=
+# RELAY_AUDIENCE=https://${DOMAIN_BASE}  # Optional — must equal relay.toml's [server].url
+                                          # exactly (NOT the same as RELAY_PUBLIC_URL — that's
+                                          # the wss:// client URL, this must be a bare https://
+                                          # origin with no path). Defaults to https://{the host
+                                          # in RELAY_PUBLIC_URL}, correct for the standard deploy
+                                          # above. Set explicitly only if your relay.toml's
+                                          # [server].url uses a different host.
+# RELAY_TOKEN_ISSUER=relay-server        # Optional — must be in relay-server's issuer
+                                          # allowlist (relay-server, auth.system3.dev,
+                                          # auth.system3.md as of image 0.9.9). Leave default.
 
 # Server identity (for multi-server plugin support)
 SERVER_NAME=My Relay Server

--- a/infra/relay/relay.toml.example
+++ b/infra/relay/relay.toml.example
@@ -1,6 +1,11 @@
 [server]
-# Public URL used by clients; DOMAIN_BASE is interpolated during deploy
-url = "https://relay.example.com"
+# MUST equal RELAY_AUDIENCE in .env exactly (control-plane's aud claim is checked
+# against this string byte-for-byte). DOMAIN_BASE is your base domain, e.g.
+# example.com — installation.md step 4: there is no separate relay. subdomain,
+# so this is https://{DOMAIN_BASE}, NOT https://relay.{DOMAIN_BASE}. If you
+# leave RELAY_AUDIENCE unset, the control-plane derives the same value from
+# RELAY_PUBLIC_URL's host — see docs/configuration.md.
+url = "https://example.com"
 host = "0.0.0.0"
 port = 8080
 


### PR DESCRIPTION
## Summary

- `create_relay_token_cwt` issues CWT tokens our own `evc-relay-server` fork cannot authenticate — no `kid` in the COSE protected header, no `aud` claim despite accepting an `audience` param, and an `iss` value (`relay-control-plane`) outside relay-server's `VALID_ISSUERS` allowlist. Every token issued since the CWT migration (`bec43fb`, 2026-02-06) has failed relay-server auth. Collaborative editing has been fully broken in prod for ~6 months — silently, because the missing-`kid` failure path never logs.
- Adds `RELAY_AUDIENCE` (defaults to `relay_public_url`'s host, since `relay_public_url` itself is the wrong value for `aud`) and `RELAY_TOKEN_ISSUER` (defaults to `relay-server`, in the allowlist) settings; `token_service.py` now uses both.
- Fix works against the **already-deployed** `ghcr.io/entire-vc/evc-relay-server:0.9.9` image — no new relay-server release needed.
- Rewrites the CWT tests that had codified the wrong (pre-fork) behavior as correct, adds coverage for the new config derivation, fixes `infra/relay/relay.toml.example`'s `[server].url` (disagreed with our own `DOMAIN_BASE` convention), and documents the new env vars.

## Test plan

- [x] CWT/relay-token-endpoint/config test suites — 66/66 green
- [x] Full control-plane suite — 730 passed, 1 skipped, 0 failed
- [ ] Live WS-upgrade probe against prod post-deploy (HTTP 101)
- [ ] relay-server connection metric appears and increments; auth-error metric stops growing
- [ ] Real two-vault Obsidian collab scenario

🔒 Held pending independent sign-off (P0/auth/prod-impacting).