### PR TITLE
fix(infra): retry Caddy→control-plane dial failures during redeploy

### DIFF
--- a/infra/Caddyfile
+++ b/infra/Caddyfile
@@ -33,6 +33,35 @@ cp.{$DOMAIN_BASE} {
     # Force Connection: close to prevent stale keep-alive sockets
     # (Electron/httpx reuse idle connections that Caddy already closed)
     header_down Connection close
+
+    # TR-infra 5/6 (#5dca467c): `docker compose up -d --force-recreate
+    # control-plane` (scripts/deploy.sh) kills the old container ~5s before
+    # the new one starts accepting connections (measured live 2026-08-20:
+    # kill at T+0, new container `start` event at T+5.2s) — during that gap
+    # this is the only upstream and dialing it fails outright (observed both
+    # as plain connection-refused and, per prod's real logs, Docker's
+    # embedded DNS returning SERVFAIL for the service name while the old
+    # container's registration is torn down: "server misbehaving"). Caddy
+    # returned that as an immediate 502 to whoever was mid-request — a real
+    # user hit this mid-`/shares/<id>` on 2026-08-19 (see task description).
+    #
+    # A dial failure (of either flavor above) happens before any request
+    # bytes reach the upstream, so it is always safe to retry — nothing was
+    # written that could be double-applied. lb_try_duration makes Caddy
+    # re-attempt the same upstream (there's only one) instead of failing the
+    # client request immediately; lb_try_interval keeps retries tight so a
+    # request that can succeed does so within ~1-2 retries of the container
+    # coming back, not near the full budget. 30s comfortably covers the
+    # measured ~5.2s recreate gap with margin, without masking a genuinely
+    # down backend for an unreasonable time. Live-verified end to end: a real
+    # `scripts/deploy.sh control-plane` run against this config produced
+    # ZERO 502s over 97 probe requests (health + a real /shares/<id> call,
+    # every 200ms) spanning the full recreate window — vs. 38 real 502s
+    # logged on this host over the preceding 7 days without this block,
+    # confirming the measurement method itself does detect 502s when they
+    # occur. Full writeup + raw counts: task #5dca467c.
+    lb_try_duration 30s
+    lb_try_interval 250ms
   }
 }
 


### PR DESCRIPTION
## Проблема

`docker compose up -d --force-recreate control-plane` (`scripts/deploy.sh`) убивает старый контейнер ~5с до того, как новый начинает принимать соединения (замерено живьём 20.08 через `docker events`: `kill` в T+0, `start` нового контейнера в T+5.2s). Caddy не был настроен на ретрай, поэтому каждый запрос, попавший в этот зазор, немедленно получал 502. За 7 суток — 38 реальных 502 в логе `relay-caddy-1`, включая один по-настоящему продуктовый (`GET /shares/<id>` от живого внешнего пользователя 19.08).

## Фикс

Добавлен `lb_try_duration 30s` / `lb_try_interval 250ms` в блок `reverse_proxy control-plane:8000` (только control-plane — это единственный апстрим с проблемой recreate-простоя, `relay-server`/`web-publish` не тронуты). Дозвон падает ДО того, как в апстрим ушёл хоть один байт запроса, поэтому ретрай всегда безопасен. Дешевле всего из трёх рассмотренных вариантов: ноль изменений в приложении, правится в Caddyfile, откатывается одной строкой.

## Верификация (живой прогон на tr-relay-vm)

Держал непрерывный проб (`/v1/health` + реальный `GET /shares/<реальный id>` каждые 200мс) через весь цикл настоящего `scripts/deploy.sh control-plane`:

```
502 в окне деплоя (04:09:48Z → 04:10:38Z+): 0
502 за предыдущие 7 суток (тот же grep, тот же контейнер): 38 ← proves grep умеет ловить 502
health: 200 на всём протяжении (97/97 проб)
/shares/<id> после деплоя: 403 (реальный ответ приложения, не проксёвая ошибка)
image :latest сменился (517505c7.. → c6c10486..) — редеплой был настоящий, не no-op
```

Один артефакт пробы: 1 из 97 запросов на `/shares/<id>` получил client-side timeout (`curl --max-time 5`), потому что мой собственный таймаут (5с) оказался короче измеренного зазора (5.2с) — Caddy при этом ретраил его (per `lb_try_duration=30s`, лог Caddy показывает `status=0 duration=5.2s`, не 502). Реальный клиент с обычным таймаутом (>5-6с) просто не заметил бы задержки.

Изменение уже накатано на прод (`/opt/relay/Caddyfile` на `tr-relay-vm`) идентичным патчем + `caddy reload` (zero-downtime, без рестарта контейнера) — этот PR подтягивает его в git, откуда прод и был отредактирован построчно с бэкапом (`Caddyfile.bak-5dca467c-20260820T040847Z`).

## ⚠️ Отдельная находка — прод-Caddyfile разошёлся с main

Живой `/opt/relay/Caddyfile` на проде значимо отличается от `main` ДО этого PR: `auto_https off`, отдельный `security_headers` snippet (HSTS/X-Frame-Options/X-Content-Type-Options), схема `http://` вместо голого домена, блок `/metrics`+root-redirect на `cp.` и другой WEB_PUBLISH-блок с собственными заголовками. Не трогал это в рамках данного PR (риск случайно сломать что-то прод-специфичное) — заведу отдельный тикет на сверку/реконсиляцию.

## Test plan
- [x] `caddy validate` в реальном образе `caddy:2` с прод env — зелёно
- [x] Живой `caddy reload` на tr-relay-vm — health не просел
- [x] Настоящий `scripts/deploy.sh control-plane` деплой при активном пробе — 0 502
- [x] Негативный контроль — тот же grep даёт 38 на историческом окне