### PR TITLE
fix(infra): ship security headers and a body-size guard in the reference Caddyfile

### DIFF
--- a/infra/Caddyfile
+++ b/infra/Caddyfile
@@ -1,5 +1,43 @@
+# Team Relay ingress config.
+#
+# This file targets the DEFAULT deployment: this host owns its public IP and
+# terminates TLS itself, so Caddy manages certificates automatically for the
+# domains below.
+#
+# ── Running behind a TLS-terminating reverse proxy / CDN ────────────────────
+# If something in front of this host already terminates TLS and forwards plain
+# HTTP (a cloud LB, a shared edge Caddy/nginx, Cloudflare in "flexible" mode),
+# THREE changes are required — and the first one is not optional:
+#
+#   1. Prefix every site address below with `http://`
+#      (`http://cp.{$DOMAIN_BASE} {`, `http://{$DOMAIN_BASE} {`, ...).
+#      Without the scheme Caddy binds the site to :443 and tries to obtain a
+#      certificate; a proxy that only forwards to :80 then matches no site and
+#      the domain answers with an empty 200. This exact omission took our
+#      control-plane domain down for hours.
+#   2. Optionally add `auto_https off` to the global block above as a guard, so
+#      a site block added later WITHOUT the `http://` prefix cannot silently
+#      re-introduce (1).
+#   3. Make sure the proxy in front sets HSTS, or keep `import security_headers`
+#      here — headers set on a plain-HTTP hop still reach the client through
+#      the proxy, which is why they are imported per-site below.
+#
+# Do NOT apply these on a normal public-IP install: `http://` there means the
+# service is served over plaintext with no certificate at all.
 {
   email {$ACME_EMAIL}
+}
+
+(security_headers) {
+  header Strict-Transport-Security "max-age=31536000; includeSubDomains"
+  header X-Content-Type-Options "nosniff"
+}
+
+# Kept separate from security_headers on purpose: the web-publish host below
+# must stay embeddable in an iframe, so it imports security_headers WITHOUT
+# this one. Merging the two would silently break embedding.
+(no_framing) {
+  header X-Frame-Options "DENY"
 }
 
 (access_log_redacted) {
@@ -25,9 +63,28 @@
 }
 
 cp.{$DOMAIN_BASE} {
+  import security_headers
+  import no_framing
   import access_log_redacted
+
+  # TR-47: /metrics must never be reachable on the public edge — it is the
+  # unauthenticated Prometheus scrape surface (route templates + counters,
+  # confirmed no PII, but still should never be public). Internal scraping
+  # goes through a separate firewall-locked metrics-proxy on :9300
+  # (docker-compose.override.yml), unaffected by this block.
   handle /metrics* {
     respond 404
+  }
+
+  # Cheap guard against oversized bodies. Deliberately far looser than any
+  # real endpoint needs: the only upload route (branding logo/favicon) caps
+  # itself at 1MB in the application, and the largest body observed on our
+  # own prod over 30 days was ~190KB across 112k requests, with zero 413s.
+  # Note this is a read-time guard: Caddy answers 413 when the upstream reads
+  # past the limit, so an upstream that ignores the body still sees the
+  # request. Verified: 11MB -> 413, 1MB -> 200.
+  request_body {
+    max_size 10MB
   }
   reverse_proxy control-plane:8000 {
     # Force Connection: close to prevent stale keep-alive sockets
@@ -66,7 +123,10 @@ cp.{$DOMAIN_BASE} {
 }
 
 {$DOMAIN_BASE} {
+  import security_headers
+  import no_framing
   import access_log_redacted
+
   # Browser WebSocket API cannot set custom headers, so this rule extracts
   # ?token= and sets it as an Authorization header instead, for plain HTTP
   # endpoints that need it that way.
@@ -105,7 +165,15 @@ cp.{$DOMAIN_BASE} {
 # Set WEB_PUBLISH_DOMAIN in .env to enable (e.g., docs.example.com)
 # Default 'web-publish.disabled' is a placeholder that won't match real requests
 {$WEB_PUBLISH_DOMAIN:web-publish.disabled} {
+  # security_headers WITHOUT no_framing: published docs are meant to be
+  # embeddable, so X-Frame-Options must not be sent here. Framing is
+  # constrained by the app's own CSP `frame-ancestors` instead, which —
+  # unlike X-Frame-Options — can allow a specific origin.
+  import security_headers
   import access_log_redacted
+  request_body {
+    max_size 10MB
+  }
   reverse_proxy web-publish:3000
 }
 


### PR DESCRIPTION
Разбор расхождения между `infra/Caddyfile` в репозитории и тем, что реально крутится на нашем хосте (замечено при работе над PR #203).

Файл в репозитории — стартовая точка для любого нового окружения, и он разошёлся. **Развёрнутый как есть на чистом хосте, он не отдаёт ни одного security-заголовка**: `header`-директив в нём ровно ноль. Проверено, что заголовки на наших хостах ставит именно этот Caddy, а не что-то перед ним — запрос напрямую в VM мимо edge отдаёт HSTS + nosniff + `X-Frame-Options`.

## Что добавлено

Всё проверено на живом Caddy с фиктивными апстримами, не на глаз:

| Добавлено | Проба |
|---|---|
| `(security_headers)` — HSTS + `X-Content-Type-Options`, импортируется по сайтам | cp/relay отдают 3 заголовка, web-publish — 2 |
| `(no_framing)` — `X-Frame-Options`, **отдельным** сниппетом | web-publish импортирует `security_headers` БЕЗ него и остаётся встраиваемым в iframe; слияние сниппетов сломало бы встраивание молча |
| `request_body max_size 10MB` на control-plane и web-publish | 11 МБ → **413**, 1 МБ → **200** |
| Комментарий-обоснование TR-47 к `/metrics` 404 (жил только в развёрнутой копии) | `/metrics` → 404 с `server: Caddy`, `/v1/health` → ответ апстрима ⇒ правило не проглатывает соседние маршруты |

Лимит тела намеренно много свободнее реальной нужды: единственный upload-маршрут (логотип/фавикон) режет себя сам на 1 МБ, а максимальное тело, реально виденное на нашем проде за 30 дней, — ~190 КБ на 112 тыс. запросов, ответов 413 ноль.

## Чего здесь намеренно НЕТ

Три вещи, которые есть в развёрнутой копии, но специфичны для окружения за TLS-терминирующим edge. Они описаны комментарием в шапке файла, а не внесены в него:

1. **Префикс `http://` у адресов сайтов** — на обычной установке с публичным IP это означает отдачу открытым текстом вообще без сертификата. Обратное (отсутствие префикса за таким прокси) в июле положило наш control-plane домен на несколько часов, поэтому это записано, а не оставлено на переоткрытие следующим.
2. **`auto_https off`** — замерено, что при явных `http://` у всех блоков это сегодня no-op (`caddy adapt` с ним и без даёт одни и те же слушатели `[':80']`); держим как дешёвую страховку от блока, добавленного позже без схемы.
3. **Редирект корня на наш лендинг** — специфика entire.vc, у чужой инсталляции его нет.

## Стиль

Отступы — существующие в файле 2 пробела. `caddy fmt` хочет табы по всему файлу; это состояние `main` до данного PR, и применение утопило бы правку в переформатировании всего файла. Диф чисто аддитивный: +68 / −0.

— Daedalus, Entire VC