### PR TITLE
fix(backup): restore-test.sh asserts key tables non-empty

### DIFF
--- a/infra/backup/restore-test.sh
+++ b/infra/backup/restore-test.sh
@@ -80,6 +80,24 @@ log "Public tables found: ${TABLE_COUNT}"
 [ "${TABLE_COUNT:-0}" -gt 0 ] || fail "Restore produced 0 tables — dump may be empty or corrupt"
 pass "Restore-test PASSED: ${TABLE_COUNT} tables in ${POSTGRES_DB}"
 
+# Verify key tables are non-empty. TABLE_COUNT>0 alone proves only that the
+# dump's SCHEMA restored — a schema-only or truncated backup (e.g. pg_dump
+# run against an app that failed to connect and dumped zero rows) passes
+# that check while containing no actual data. Check row counts on the
+# tables that matter for an actual disaster-recovery, not just "some tables
+# exist".
+KEY_TABLES="users shares share_members"
+for KEY_TABLE in ${KEY_TABLES}; do
+    ROW_COUNT=$(docker exec "${CONTAINER_NAME}" \
+        psql -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -tAc \
+        "SELECT count(*) FROM ${KEY_TABLE}" 2>/dev/null) \
+        || fail "Key table '${KEY_TABLE}' missing or unreadable in restored DB"
+    ROW_COUNT="${ROW_COUNT//[[:space:]]/}"
+    log "Table ${KEY_TABLE}: ${ROW_COUNT} rows"
+    [ "${ROW_COUNT:-0}" -gt 0 ] || fail "Key table '${KEY_TABLE}' is EMPTY after restore — dump may be a schema-only or truncated backup"
+done
+pass "Key tables non-empty: ${KEY_TABLES}"
+
 echo ""
 echo "=== RESTORE-TEST RESULT ==="
 echo "Backup: ${BACKUP_FILE}"


### PR DESCRIPTION
## Проблема

`restore-test.sh` (учение по восстановлению) ассертировал только `TABLE_COUNT > 0` после восстановления дампа. Структурно валидный дамп с пустыми таблицами (schema-only, или truncated backup) проходил бы этот прогон как PASS — именно ту проверку, ради которой заводится учение («данные реально восстанавливаются»), скрипт не делал.

## Фикс

После проверки `TABLE_COUNT>0` добавлена проверка количества строк в ключевых таблицах — `users`, `shares`, `share_members`. Пустая любая из них → `fail`.

## Верификация

**Позитивный контроль** — реальный свежий бэкап с прод (`relay-20260820-04.sql.gz`, забран как есть):
```
Table users: 101 rows
Table shares: 79 rows
Table share_members: 41 rows
✓ Key tables non-empty: users shares share_members
=== RESTORE-TEST RESULT === ... Status: PASS
```

**Негативный контроль** — тот же реальный схема (`pg_dump --schema-only` из восстановленной копии того же дампа, побайтово та же структура, ноль строк в каждой таблице):
```
[...] Public tables found: 20
✓ Restore-test PASSED: 20 tables in relay     ← старая проверка сказала бы PASS здесь
Table users: 0 rows
✗ Key table 'users' is EMPTY after restore — dump may be a schema-only or truncated backup
```
Exit code `1` — прогон падает там, где раньше молча прошёл бы.

## Test plan
- [x] `bash -n` — синтаксис
- [x] Позитивный контроль на реальном свежем бэкапе — PASS
- [x] Негативный контроль на schema-only дампе той же структуры — FAIL (было бы PASS без фикса)