### PR TITLE
docs(adr): stop restating the relay-server tag in prose

### DIFF
--- a/docs/adr-relay-server-own-fork.md
+++ b/docs/adr-relay-server-own-fork.md
@@ -4,8 +4,13 @@
 
 ## Decision (read this before touching relay-server)
 
-`relay-server` runs our **own image `ghcr.io/entire-vc/evc-relay-server`** (pinned, currently
-`:0.9.7`), built from a fork of **`no-instructions/y-sweet`** (MIT). See `infra/docker-compose.yml`.
+`relay-server` runs our **own image `ghcr.io/entire-vc/evc-relay-server`**, pinned by tag,
+built from a fork of **`no-instructions/y-sweet`** (MIT).
+
+**The tag lives in `infra/docker-compose.yml` and only there.** This ADR deliberately does not
+repeat it: the number written here said `:0.9.7` while the compose file said `:0.9.9` and the
+production host was running `:0.9.10` — three answers to one question, because a version copied
+into prose has no way of staying true. Read the compose file.
 
 We used to pull the closed `docker.system3.md/relay-server` binary (System3 = a commercial
 y-sweet distributor). PR #99 swapped it for our ghcr image. **The System3 binary and its access


### PR DESCRIPTION
The ADR said the relay-server image is "pinned, currently `:0.9.7`". At the same moment `infra/docker-compose.yml` pinned `:0.9.9` and the production host was running `:0.9.10` — three answers to one question, the ADR's being three releases stale.

The fix is to delete the copy rather than refresh it. A version number restated in prose has no mechanism for staying true; refreshing it just resets the clock on the same drift. The ADR now says the tag lives in `infra/docker-compose.yml` and only there, and says why, so the next person who finds a mismatch knows which file wins.

Everything else in the ADR — the decision itself, the reasoning about vendor lock, the issuer/verifier explanation, the note about where documents live — is unchanged and still accurate.

`docs/configuration.md` also names a version, but scoped as "as of image `0.9.9`" against the compose pin, which is exactly what it is. Left alone.
