### PR TITLE
ci: add release-drift check + fix latest-tag ordering in release.yml

### DIFF
--- a/.github/workflows/release-drift.yml
+++ b/.github/workflows/release-drift.yml
@@ -31,8 +31,14 @@ jobs:
 
       - name: Check for stale unreleased changes to shipped code
         id: drift
+        env:
+          # Passed via env:, not interpolated directly into the script --
+          # github.event.inputs.* is attacker-controllable on
+          # workflow_dispatch, and inlining it as ${{ }} into a run: block is
+          # a shell-injection vector (flagged by this repo's own semgrep CI).
+          MAX_AGE_DAYS_INPUT: ${{ github.event.inputs.max_age_days }}
         run: |
-          MAX_AGE_DAYS="${{ github.event.inputs.max_age_days || '7' }}"
+          MAX_AGE_DAYS="${MAX_AGE_DAYS_INPUT:-7}"
 
           LAST_TAG=$(git describe --tags --abbrev=0)
           echo "last_tag=$LAST_TAG" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release-drift.yml
+++ b/.github/workflows/release-drift.yml
@@ -1,0 +1,140 @@
+name: Release drift check
+
+# Nothing else notices when `main` runs ahead of the last published release.
+# deploy.yml (our own prod, on push to main) and release.yml (self-hosters,
+# on a version tag) are two independent triggers, and no signal connects
+# "we shipped it to ourselves" to "we shipped it to everyone else" — that gap
+# let a P0 fix sit unreleased for 13 days / 36 commits before anyone noticed
+# (#e15cc24c). This is the sentinel for that gap.
+
+on:
+  schedule:
+    - cron: '0 7 * * 1' # Monday 07:00 UTC
+  workflow_dispatch:
+    inputs:
+      max_age_days:
+        description: 'Override the staleness threshold (days) for a manual run, e.g. to prove this check can fail'
+        required: false
+        default: '7'
+
+jobs:
+  check-drift:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0 # need full history for git describe/rev-list against tags
+
+      - name: Check for stale unreleased changes to shipped code
+        id: drift
+        run: |
+          MAX_AGE_DAYS="${{ github.event.inputs.max_age_days || '7' }}"
+
+          LAST_TAG=$(git describe --tags --abbrev=0)
+          echo "last_tag=$LAST_TAG" >> "$GITHUB_OUTPUT"
+
+          # Count only commits touching what a release actually ships --
+          # apps/, infra/, scripts/. Of the 36 commits behind the last real
+          # drift incident, ~5 were docs-only; a check that reddens on those
+          # gets ignored within a month and stops catching the real case.
+          DRIFT_COMMITS=$(git rev-list --count "${LAST_TAG}"..origin/main -- apps/ infra/ scripts/)
+          echo "drift_commits=$DRIFT_COMMITS" >> "$GITHUB_OUTPUT"
+
+          if [ "$DRIFT_COMMITS" -eq 0 ]; then
+            echo "No unreleased changes to shipped paths since $LAST_TAG -- clean."
+            echo "is_stale=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Age of the DRIFT, not the age of the last release: measure from
+          # the OLDEST unreleased commit touching shipped code, not from the
+          # tag's own commit time. A release from months ago with one fresh
+          # commit yesterday is not what this check exists to catch; a
+          # release from months ago with a fix sitting unreleased for two
+          # weeks is.
+          OLDEST_DRIFT_SHA=$(git rev-list --reverse "${LAST_TAG}"..origin/main -- apps/ infra/ scripts/ | head -1)
+          OLDEST_DRIFT_TS=$(git log -1 --format=%ct "$OLDEST_DRIFT_SHA")
+          NOW_TS=$(date +%s)
+          AGE_DAYS=$(( (NOW_TS - OLDEST_DRIFT_TS) / 86400 ))
+          echo "age_days=$AGE_DAYS" >> "$GITHUB_OUTPUT"
+          echo "oldest_drift_sha=$OLDEST_DRIFT_SHA" >> "$GITHUB_OUTPUT"
+
+          echo "$DRIFT_COMMITS commit(s) touching apps/infra/scripts unreleased since $LAST_TAG; oldest is $AGE_DAYS day(s) old ($OLDEST_DRIFT_SHA)."
+
+          if [ "$AGE_DAYS" -gt "$MAX_AGE_DAYS" ]; then
+            echo "is_stale=true" >> "$GITHUB_OUTPUT"
+            echo "::error::main has shipped-code changes unreleased for ${AGE_DAYS}d (threshold ${MAX_AGE_DAYS}d) since ${LAST_TAG}. Cut a release: git tag vX.Y.Z && git push origin vX.Y.Z"
+            exit 1
+          else
+            echo "is_stale=false" >> "$GITHUB_OUTPUT"
+            echo "Within the ${MAX_AGE_DAYS}d threshold -- not stale yet."
+          fi
+
+      - name: Open/update a tracking issue when stale
+        if: failure() && steps.drift.outputs.is_stale == 'true'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const title = 'main has unreleased changes older than the drift threshold';
+            const body = [
+              `**${{ steps.drift.outputs.drift_commits }}** commit(s) touching \`apps/\`, \`infra/\`, or \`scripts/\` are unreleased since \`${{ steps.drift.outputs.last_tag }}\`.`,
+              `Oldest unreleased commit: \`${{ steps.drift.outputs.oldest_drift_sha }}\`, ${{ steps.drift.outputs.age_days }} day(s) old.`,
+              '',
+              'Cut a release: `git tag vX.Y.Z && git push origin vX.Y.Z` (release.yml builds, smoke-tests, and publishes on push of the tag).',
+              '',
+              `_Workflow run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}_`,
+            ].join('\n');
+
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'release-drift',
+            });
+
+            if (existing.data.length > 0) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.data[0].number,
+                body,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: ['release-drift'],
+              });
+            }
+
+      - name: Close the tracking issue once clean
+        if: success() && steps.drift.outputs.is_stale == 'false'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'release-drift',
+            });
+            for (const issue of existing.data) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed',
+              });
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: 'A release was cut -- closing, drift check is clean again.',
+              });
+            }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,10 +40,16 @@ jobs:
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/control-plane
+          # No `latest` here on purpose: this job runs before smoke-test, so
+          # tagging `latest` here would move it onto an unvalidated image the
+          # moment a build succeeds — a failing smoke-test would then leave
+          # self-hosters' default `pull-published-images.sh` pulling a broken
+          # release forever, with the GitHub Release itself never created to
+          # signal anything went wrong. `latest` only moves in promote-latest,
+          # after smoke-test has passed against these exact immutable tags.
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push control-plane
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
@@ -60,10 +66,11 @@ jobs:
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/web-publish
+          # See the control-plane metadata step above for why `latest` is
+          # deliberately absent here.
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push web-publish
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
@@ -146,6 +153,38 @@ jobs:
         if: failure()
         working-directory: infra
         run: docker compose logs
+
+  promote-latest:
+    # Moves `latest` onto the images this run just built, but ONLY after
+    # smoke-test has proven them against a clean database exactly the way
+    # `pull-published-images.sh` (the default self-hoster install path) would
+    # pull them. No rebuild here — `imagetools create` just repoints the
+    # `latest` tag at the already-pushed, already-tested manifest by digest,
+    # so this cannot silently diverge from what smoke-test actually checked.
+    needs: [build-and-push, smoke-test]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Point latest at this release's tested images
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          for IMAGE in control-plane web-publish; do
+            REF="${REGISTRY}/${IMAGE_PREFIX}/${IMAGE}:${VERSION}"
+            docker buildx imagetools create --tag "${REGISTRY}/${IMAGE_PREFIX}/${IMAGE}:latest" "$REF"
+          done
 
   create-release:
     needs: [build-and-push, smoke-test]


### PR DESCRIPTION
## Summary

From #e15cc24c: a P0 fix sat merged-but-unreleased for 13 days / 36 commits before anyone noticed. Nothing connects "shipped to our own prod" (deploy.yml, on push to main) to "shipped to self-hosters" (release.yml, on a version tag).

- **`release-drift.yml`** — weekly (+ `workflow_dispatch` with an overridable threshold) check for commits touching `apps/`/`infra/`/`scripts/` unreleased since the last tag, older than 7 days. Opens/updates a tracking issue on drift, closes it once clean.
- **`release.yml` reorder** — `build-and-push` now publishes only immutable version tags (`{{version}}`, `{{major}}.{{minor}}`), never `latest`. `smoke-test` boots those version tags from a clean DB exactly like a self-hoster's `pull-published-images.sh` would (unchanged). A new `promote-latest` job (needs both `build-and-push` and `smoke-test`) repoints `latest` at the already-tested manifest via `docker buildx imagetools create` — no rebuild, so it can't diverge from what smoke-test checked. Before this, `latest` moved in the same job as the build, so a failing smoke-test still left self-hosters' default install path pulling an untested image.

## Test plan — verified by running, not by reading (both workflows are otherwise unexercised)

- [x] YAML syntax valid (`python3 -c "import yaml; yaml.safe_load(...)"`) for both files
- [ ] `release-drift.yml` dispatched manually post-merge with default threshold → expect green (no drift right after v1.11.0)
- [ ] `release-drift.yml` dispatched manually with a deliberately-lowered threshold → expect red, proving it can actually fail and isn't an evergreen check
- [ ] `release.yml`'s new ordering verified on the next real tag: `latest` only moves after `smoke-test` passes (or a manual `workflow_dispatch`/test tag if the next real release isn't imminent)