### PR TITLE
feat(control-plane): agent keys reach the sync protocol, with a mandatory sha256 precondition on writes

### DIFF
--- a/apps/control-plane/app/api/routers/shares.py
+++ b/apps/control-plane/app/api/routers/shares.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import hashlib
+import io
+import logging
 import re
 import uuid
 from datetime import timedelta
@@ -28,6 +31,7 @@ from app.services.notification_service import get_notification_service
 
 router = APIRouter(prefix="/shares", tags=["shares"])
 limiter = Limiter(key_func=get_remote_address)
+logger = logging.getLogger(__name__)
 
 
 @router.get("", response_model=list[share_schema.ShareListItem])
@@ -132,20 +136,83 @@ def _ensure_minio_bucket(client: Minio, bucket_name: str) -> None:
         raise HTTPException(status_code=500, detail=f"Failed to access storage: {e}")
 
 
+# --- Sync-protocol authentication -------------------------------------------
+#
+# The /shares/{id}/files-index + /download + /sync-write trio is the SYNC
+# PROTOCOL: unlike the /v1/web/ family it carries `sha256` and `updated_at`, so
+# it is the only surface on which a caller can reconcile two copies of a
+# document instead of blindly overwriting one with the other.
+#
+# It used to be user-JWT-only (`Depends(deps.get_current_user)`), which meant
+# the agent key a Mesh project is configured with — a credential that is
+# already trusted to write the same share's bytes through
+# /v1/web/shares/{id}/sync-upload — could not read a document's hash, and so
+# could not write safely. Task #ee1745ce extends that SAME key to this
+# protocol; it does not mint a second credential or a service user.
+#
+# Scope policy is the literal one (ADR-0001) via
+# share_service.authenticate_agent_key: `write` does not imply `read`, and
+# there is deliberately no lenient-read grace here — these routes are
+# UUID-addressable and therefore reach shares that were never web-published.
+
+
+def _authorize_share_sync(
+    request: Request,
+    share: models.Share,
+    db: Session,
+    current_user: models.User | None,
+    *,
+    required_scope: str,
+) -> str:
+    """Authorize a sync-protocol request via X-Agent-Key or user JWT.
+
+    Returns "agent_key" or "user". The agent-key branch also checks the key's
+    standing (creator still owner/member/admin) and the literal scope, and
+    stamps last_used_at — committed here, because the read routes commit
+    nothing of their own and an uncommitted stamp would be silently discarded.
+    Failing to record usage must never fail the request.
+    """
+    raw_key = request.headers.get("X-Agent-Key")
+    if raw_key:
+        agent_key = share_service.authenticate_agent_key(
+            db, share, raw_key, required_scope=required_scope
+        )
+        agent_key.last_used_at = security.utcnow()
+        try:
+            db.commit()
+        except Exception:  # pragma: no cover - telemetry must not 500
+            db.rollback()
+        return "agent_key"
+
+    if current_user is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing credentials")
+
+    if required_scope == "write":
+        share_service.ensure_write_access(db, share, current_user)
+    else:
+        share_service.ensure_read_access(db, share, current_user)
+    return "user"
+
+
 @router.get("/{share_id}/files-index", response_model=list[SyncArtifactItem])
 def get_share_files_index(
+    request: Request,
     share_id: uuid.UUID,
     db: Session = Depends(get_db),
-    current_user: models.User = Depends(deps.get_current_user),
+    current_user: models.User | None = Depends(deps.get_optional_user),
 ) -> list[SyncArtifactItem]:
     """
-    List sync-artifact files for a share (plugin inbound sync, Bearer JWT).
+    List sync-artifact files for a share (sync protocol).
 
     Returns only items uploaded via sync-upload (source=sync-artifact) in
     SyncArtifactItem format expected by the Obsidian plugin InboundFileDownloader.
+    Each item carries `sha256` + `updated_at` — the values a caller feeds back
+    into `If-Match` on PUT /sync-write.
+
+    Auth: Authorization: Bearer <user JWT>, or X-Agent-Key with `read` scope.
     """
     share = share_service.get_share(db, share_id)
-    share_service.ensure_read_access(db, share, current_user)
+    _authorize_share_sync(request, share, db, current_user, required_scope="read")
 
     folder_items = share.web_folder_items or []
     result = []
@@ -166,25 +233,48 @@ def get_share_files_index(
     return result
 
 
+def _sync_read_headers(item: dict[str, Any]) -> dict[str, str]:
+    """ETag/Last-Modified for a sync-protocol read.
+
+    The ETag is the item's stored sha256 — the exact token PUT /sync-write
+    expects back in If-Match, so a caller can do read → edit → conditional
+    write off a single GET without a second index call.
+    """
+    headers: dict[str, str] = {}
+    sha256 = item.get("sha256")
+    if sha256:
+        headers["ETag"] = f'"{sha256}"'
+    modified_at = item.get("modified_at")
+    if modified_at:
+        headers["X-Updated-At"] = str(modified_at)
+    return headers
+
+
 @router.get("/{share_id}/download")
 def download_share_file(
+    request: Request,
     share_id: uuid.UUID,
     path: str = Query(..., description="Relative file path within share"),
     db: Session = Depends(get_db),
-    current_user: models.User = Depends(deps.get_current_user),
+    current_user: models.User | None = Depends(deps.get_optional_user),
 ) -> Response:
     """
-    Download a sync-artifact file by relative path (plugin inbound sync, Bearer JWT).
+    Download a file by relative path (sync protocol).
 
     Resolution order: inline content in JSONB index → MinIO storage.
+    Responds with `ETag: "<sha256>"` and `X-Updated-At` when the index knows them.
+
+    Auth: Authorization: Bearer <user JWT>, or X-Agent-Key with `read` scope.
     """
     share = share_service.get_share(db, share_id)
-    share_service.ensure_read_access(db, share, current_user)
+    _authorize_share_sync(request, share, db, current_user, required_scope="read")
 
     folder_items = share.web_folder_items or []
     for item in folder_items:
         if item.get("path") != path:
             continue
+
+        extra_headers = _sync_read_headers(item)
 
         content_str = item.get("content")
         if content_str is not None:
@@ -192,7 +282,7 @@ def download_share_file(
             content_bytes = (
                 content_str.encode("utf-8") if isinstance(content_str, str) else content_str
             )
-            return Response(content=content_bytes, media_type=mime)
+            return Response(content=content_bytes, media_type=mime, headers=extra_headers)
 
         storage_key = item.get("storage_key")
         if storage_key:
@@ -216,12 +306,239 @@ def download_share_file(
                     detail=f"Failed to retrieve file: {e}",
                 )
             mime = item.get("mime", "application/octet-stream")
-            return Response(content=data, media_type=mime)
+            return Response(content=data, media_type=mime, headers=extra_headers)
 
     raise HTTPException(
         status_code=status.HTTP_404_NOT_FOUND,
         detail=f"File not found: {path}",
     )
+
+
+# --- Sync-protocol conditional write ----------------------------------------
+
+# Same 25MB ceiling as the web-publish family's mesh/sync uploads.
+MAX_SYNC_WRITE_SIZE = 25 * 1024 * 1024
+
+
+class SyncWriteResult(BaseModel):
+    path: str
+    sha256: str
+    size: int
+    updated_at: str
+
+
+def _parse_etag_value(raw: str) -> str:
+    """Normalise one entity-tag: strip W/ prefix, quotes and case."""
+    value = raw.strip()
+    if value.startswith("W/"):
+        value = value[2:].strip()
+    if len(value) >= 2 and value.startswith('"') and value.endswith('"'):
+        value = value[1:-1]
+    return value.strip().lower()
+
+
+def _require_sync_precondition(
+    if_match: str | None,
+    if_none_match: str | None,
+    current: dict[str, Any] | None,
+    path: str,
+) -> None:
+    """Enforce compare-and-swap on a sync-protocol write.
+
+    Why this exists at all: before #ee1745ce the server had NO conditional
+    write anywhere — `/v1/web/.../sync-upload` computes the sha256 of whatever
+    body it is handed and stores it, so two writers silently last-write-wins.
+    A credential that can write documents without proving which version it is
+    replacing cannot be given to an automated agent, so the precondition is
+    mandatory rather than opt-in: a write with neither header is 428, never an
+    unchecked overwrite.
+
+    - ``If-Match: <sha256>``  — the item must exist and its stored sha256 must
+      be one of the supplied tags.
+    - ``If-None-Match: *``    — the item must NOT exist (create-only).
+    - ``If-Match: *`` is rejected: RFC-wise it only asserts existence, which is
+      precisely the blind overwrite this endpoint refuses to perform.
+    """
+    if if_match is not None and if_none_match is not None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Send either If-Match or If-None-Match, not both",
+        )
+
+    if if_none_match is not None:
+        if _parse_etag_value(if_none_match) != "*":
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="If-None-Match is only supported as '*' (create-only)",
+            )
+        if current is not None:
+            raise HTTPException(
+                status_code=status.HTTP_412_PRECONDITION_FAILED,
+                detail=f"File already exists: {path}",
+            )
+        return
+
+    if if_match is None:
+        raise HTTPException(
+            status_code=status.HTTP_428_PRECONDITION_REQUIRED,
+            detail=(
+                "If-Match: <sha256> (or If-None-Match: * to create) is required — "
+                "unconditional writes are not accepted on the sync protocol"
+            ),
+        )
+
+    candidates = {_parse_etag_value(part) for part in if_match.split(",") if part.strip()}
+    if "*" in candidates:
+        raise HTTPException(
+            status_code=status.HTTP_428_PRECONDITION_REQUIRED,
+            detail="If-Match: * is not accepted — supply the sha256 of the version you replace",
+        )
+    if not candidates:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="If-Match header is empty"
+        )
+    if current is None:
+        raise HTTPException(
+            status_code=status.HTTP_412_PRECONDITION_FAILED,
+            detail=f"File not found: {path}",
+        )
+    stored = str(current.get("sha256") or "").lower()
+    if not stored or stored not in candidates:
+        raise HTTPException(
+            status_code=status.HTTP_412_PRECONDITION_FAILED,
+            detail="sha256 mismatch: the file changed since it was read",
+        )
+
+
+@router.put("/{share_id}/sync-write", response_model=SyncWriteResult)
+@limiter.limit("60/minute")
+async def sync_write_file(
+    request: Request,
+    response: Response,
+    share_id: uuid.UUID,
+    path: str = Query(..., description="Relative file path within share"),
+    if_match: str | None = Header(default=None, alias="If-Match"),
+    if_none_match: str | None = Header(default=None, alias="If-None-Match"),
+    db: Session = Depends(get_db),
+    current_user: models.User | None = Depends(deps.get_optional_user),
+) -> SyncWriteResult:
+    """
+    Write one document into a folder share, conditionally on its current sha256.
+
+    Auth: Authorization: Bearer <user JWT> (owner/editor), or X-Agent-Key with
+    `write` scope. Body: raw bytes, max 25MB.
+
+    Precondition (mandatory): `If-Match: "<sha256>"` to replace a known version,
+    or `If-None-Match: *` to create. A mismatch is 412 and writes nothing —
+    neither the object store nor the index is touched.
+
+    Produces the same index entry shape as the web-publish `sync-upload`
+    (source=sync-artifact), so the written document is immediately visible to
+    GET /shares/{id}/files-index and to the Obsidian plugin's inbound sync.
+    """
+    share = share_service.get_share(db, share_id)
+    if share.kind != models.ShareKind.FOLDER:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="sync-write only supported for folder shares",
+        )
+    auth_method = _authorize_share_sync(request, share, db, current_user, required_scope="write")
+
+    path = _validate_file_path(path)
+
+    body = await request.body()
+    if len(body) > MAX_SYNC_WRITE_SIZE:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=f"File too large. Max size: {MAX_SYNC_WRITE_SIZE // (1024 * 1024)}MB",
+        )
+
+    mime = request.headers.get("Content-Type", "application/octet-stream").split(";")[0].strip()
+    is_text = mime.startswith("text/") or mime in ("application/json", "application/xml")
+    sha256 = hashlib.sha256(body).hexdigest()
+
+    # Row lock, then check, then write — in that order and in one transaction.
+    # The web-publish sync-upload deliberately keeps MinIO I/O outside the row
+    # lock (pool-lock hygiene), but that trade is only safe when the write is
+    # unconditional. Here a failed precondition must leave BOTH the index and
+    # the object store untouched, which only holds if the compare and the swap
+    # sit in the same critical section.
+    locked = db.execute(
+        select(models.Share).where(models.Share.id == share.id).with_for_update()
+    ).scalar_one_or_none()
+    if locked is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Share not found")
+
+    folder_items = list(locked.web_folder_items or [])
+    current = next((i for i in folder_items if i.get("path") == path), None)
+    _require_sync_precondition(if_match, if_none_match, current, path)
+
+    settings = get_settings()
+    minio_client = _get_minio_client()
+    _ensure_minio_bucket(minio_client, settings.minio_bucket)
+    # Same storage layout as web-publish sync-upload: text is content-addressed
+    # (dedup for the plugin), binary keeps its path so /_assets/ can serve it.
+    storage_key = (
+        f"sync-uploads/{locked.id}/{sha256}" if is_text else f"web-assets/{locked.id}/{path}"
+    )
+    try:
+        minio_client.put_object(
+            settings.minio_bucket,
+            storage_key,
+            io.BytesIO(body),
+            length=len(body),
+            content_type=mime,
+        )
+    except S3Error as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to store document: {e}",
+        )
+
+    now_iso = security.utcnow().isoformat()
+    inline_content = (
+        body.decode("utf-8", errors="replace") if (is_text and len(body) < 256 * 1024) else None
+    )
+    entry = {
+        "path": path,
+        "name": path.split("/")[-1],
+        "type": "doc" if is_text else "asset",
+        "source": "sync-artifact",
+        "mime": mime,
+        "size": len(body),
+        "sha256": sha256,
+        "modified_at": now_iso,
+        "storage_key": storage_key,
+        "content": inline_content,
+    }
+    is_new_file = current is None
+    if is_new_file:
+        folder_items.append(entry)
+    else:
+        current.update(entry)
+
+    locked.web_folder_items = folder_items
+    flag_modified(locked, "web_folder_items")
+    locked.web_content_updated_at = security.utcnow()
+    db.commit()
+
+    logger.info(
+        "sync_write",
+        extra={
+            "event": "sync_write",
+            "auth_method": auth_method,
+            "share_id": str(share_id),
+            "path": path,
+            "sha256": sha256,
+            # NOT "created": that is a reserved LogRecord attribute and
+            # logging raises KeyError on any attempt to overwrite it.
+            "is_new_file": is_new_file,
+        },
+    )
+
+    # The new version's tag, ready to be fed straight back as the next If-Match.
+    response.headers["ETag"] = f'"{sha256}"'
+    return SyncWriteResult(path=path, sha256=sha256, size=len(body), updated_at=now_iso)
 
 
 # --- Attachment (CAS) file-token routes -------------------------------------

--- a/apps/control-plane/app/services/share_service.py
+++ b/apps/control-plane/app/services/share_service.py
@@ -9,7 +9,7 @@ from fastapi import HTTPException, status
 from sqlalchemy import func, or_, select, update
 from sqlalchemy.orm import Session, joinedload
 
-from app.core import security
+from app.core import agent_key_scopes, security
 from app.core.config import get_settings
 from app.db import models
 from app.schemas import share as share_schema
@@ -673,7 +673,15 @@ def authenticate_agent_key(
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN, detail="Agent key has expired"
             )
-    if required_scope and required_scope not in set(agent_key.scopes.split(",")):
+    # Scope goes through the shared policy object (ADR-0001), not a local
+    # `scopes.split(",")`: the hand-rolled copy that used to live here did not
+    # strip whitespace, so a key stored as "read, write" — which the PATCH
+    # scopes endpoint can produce — silently failed every check for `write`.
+    # Deliberately NO grace: this helper serves UUID-addressable, possibly
+    # never-published shares, exactly like `_auth_share_read_access`.
+    if required_scope and not agent_key_scopes.satisfies(
+        agent_key_scopes.parse_scopes(agent_key.scopes), required_scope
+    ):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=f"Agent key does not have {required_scope} scope",

--- a/apps/control-plane/tests/test_agent_key_sync_protocol.py
+++ b/apps/control-plane/tests/test_agent_key_sync_protocol.py
@@ -1,0 +1,725 @@
+"""Agent-key access to the SYNC PROTOCOL (task #ee1745ce).
+
+The /shares/{id}/files-index + /download + /sync-write trio is the only surface
+that carries `sha256` and `updated_at`, i.e. the only one on which two copies of
+a document can be reconciled rather than blindly overwritten. It used to accept
+user JWTs only, so the agent key a Mesh project is configured with could write
+bytes through /v1/web/.../sync-upload but could not learn a document's hash —
+and therefore could not write safely.
+
+These tests pin three things:
+  1. the SAME agent key now reads hash+mtime and writes through this protocol;
+  2. a write whose If-Match does not match the stored sha256 is refused AND
+     leaves the stored bytes untouched — asserted on the document body, not on
+     the status code, because a 412 returned after a write that actually landed
+     is indistinguishable from an honest one by status alone;
+  3. the scope boundary did not widen: read-only cannot write, write-only cannot
+     read, a key is still confined to its own share, and it still buys nothing
+     on the user-only share-management routes.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import secrets
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.db import models
+
+BASE = "/v1/shares"
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+def make_folder_share(
+    db: Session,
+    user: models.User,
+    folder_items: list | None = None,
+) -> models.Share:
+    share = models.Share(
+        kind=models.ShareKind.FOLDER,
+        path="SyncFolder/",
+        visibility=models.ShareVisibility.PRIVATE,
+        owner_user_id=user.id,
+        web_published=False,
+        web_slug=None,
+        web_folder_items=folder_items or [],
+    )
+    db.add(share)
+    db.commit()
+    db.refresh(share)
+    return share
+
+
+def make_agent_key(
+    db: Session,
+    share: models.Share,
+    scopes: str = "read,write",
+    expires_at: datetime | None = None,
+    revoked: bool = False,
+) -> str:
+    raw_key = "tr_agent_" + secrets.token_hex(24)
+    ak = models.ShareAgentKey(
+        share_id=share.id,
+        key_hash=hashlib.sha256(raw_key.encode()).hexdigest(),
+        label="sync-protocol test key",
+        scopes=scopes,
+        expires_at=expires_at,
+        revoked_at=datetime.now(timezone.utc) if revoked else None,
+        created_by=share.owner_user_id,
+    )
+    db.add(ak)
+    db.commit()
+    return raw_key
+
+
+def sync_item(path: str, content: str) -> dict:
+    """An index entry shaped exactly like one written by sync-upload."""
+    body = content.encode("utf-8")
+    return {
+        "path": path,
+        "name": path.split("/")[-1],
+        "type": "doc",
+        "source": "sync-artifact",
+        "mime": "text/markdown",
+        "size": len(body),
+        "sha256": hashlib.sha256(body).hexdigest(),
+        "modified_at": "2026-08-19T12:00:00+00:00",
+        "storage_key": f"sync-uploads/x/{hashlib.sha256(body).hexdigest()}",
+        "content": content,
+    }
+
+
+@pytest.fixture
+def minio():
+    """Patch the MinIO client and expose it so tests can assert on writes."""
+    mock_client = MagicMock()
+    mock_client.bucket_exists.return_value = True
+    mock_client.put_object.return_value = None
+    with patch("app.api.routers.shares._get_minio_client", return_value=mock_client):
+        yield mock_client
+
+
+def err_message(resp) -> str:
+    """The API wraps errors as {"error": {"code", "message"}} (middleware/errors.py)."""
+    body = resp.json()
+    if isinstance(body, dict) and "error" in body:
+        return str(body["error"].get("message", ""))
+    return str(body.get("detail", ""))
+
+
+def key_headers(raw_key: str, **extra: str) -> dict[str, str]:
+    return {"X-Agent-Key": raw_key, **extra}
+
+
+def read_body(client: TestClient, share_id, raw_key: str, path: str) -> str:
+    """Fetch the document as the server currently holds it."""
+    resp = client.get(
+        f"{BASE}/{share_id}/download",
+        params={"path": path},
+        headers=key_headers(raw_key),
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.text
+
+
+# ── 1. read with the agent key ───────────────────────────────────────────────
+
+
+class TestAgentKeyRead:
+    def test_files_index_returns_sha256_and_updated_at(
+        self, client: TestClient, test_user: models.User, db_session: Session
+    ):
+        item = sync_item("notes/hello.md", "# Hello")
+        share = make_folder_share(db_session, test_user, folder_items=[item])
+        raw_key = make_agent_key(db_session, share, scopes="read")
+
+        resp = client.get(f"{BASE}/{share.id}/files-index", headers=key_headers(raw_key))
+
+        assert resp.status_code == 200, resp.text
+        entries = resp.json()
+        assert len(entries) == 1
+        assert entries[0]["path"] == "notes/hello.md"
+        assert entries[0]["sha256"] == item["sha256"]
+        assert entries[0]["updated_at"] == "2026-08-19T12:00:00+00:00"
+
+    def test_download_returns_content_and_etag(
+        self, client: TestClient, test_user: models.User, db_session: Session
+    ):
+        item = sync_item("notes/hello.md", "# Hello")
+        share = make_folder_share(db_session, test_user, folder_items=[item])
+        raw_key = make_agent_key(db_session, share, scopes="read")
+
+        resp = client.get(
+            f"{BASE}/{share.id}/download",
+            params={"path": "notes/hello.md"},
+            headers=key_headers(raw_key),
+        )
+
+        assert resp.status_code == 200, resp.text
+        assert resp.text == "# Hello"
+        assert resp.headers["etag"] == f'"{item["sha256"]}"'
+        assert resp.headers["x-updated-at"] == "2026-08-19T12:00:00+00:00"
+
+    def test_read_stamps_last_used_at(
+        self, client: TestClient, test_user: models.User, db_session: Session
+    ):
+        share = make_folder_share(db_session, test_user, folder_items=[sync_item("a.md", "a")])
+        raw_key = make_agent_key(db_session, share, scopes="read")
+
+        client.get(f"{BASE}/{share.id}/files-index", headers=key_headers(raw_key))
+
+        db_session.expire_all()
+        ak = db_session.query(models.ShareAgentKey).filter_by(share_id=share.id).one()
+        assert ak.last_used_at is not None
+
+    def test_revoked_key_cannot_read(
+        self, client: TestClient, test_user: models.User, db_session: Session
+    ):
+        share = make_folder_share(db_session, test_user, folder_items=[sync_item("a.md", "a")])
+        raw_key = make_agent_key(db_session, share, scopes="read,write", revoked=True)
+
+        resp = client.get(f"{BASE}/{share.id}/files-index", headers=key_headers(raw_key))
+        assert resp.status_code == 403
+        assert "revoked" in err_message(resp).lower()
+
+    def test_expired_key_cannot_read(
+        self, client: TestClient, test_user: models.User, db_session: Session
+    ):
+        share = make_folder_share(db_session, test_user, folder_items=[sync_item("a.md", "a")])
+        raw_key = make_agent_key(
+            db_session,
+            share,
+            scopes="read,write",
+            expires_at=datetime.now(timezone.utc) - timedelta(days=1),
+        )
+
+        resp = client.get(f"{BASE}/{share.id}/files-index", headers=key_headers(raw_key))
+        assert resp.status_code == 403
+        assert "expired" in err_message(resp).lower()
+
+    def test_no_credential_still_401(
+        self, client: TestClient, test_user: models.User, db_session: Session
+    ):
+        share = make_folder_share(db_session, test_user, folder_items=[sync_item("a.md", "a")])
+        resp = client.get(f"{BASE}/{share.id}/files-index")
+        assert resp.status_code == 401
+
+
+# ── 2. write with the agent key, conditional on sha256 ───────────────────────
+
+
+class TestAgentKeyConditionalWrite:
+    def test_write_with_matching_sha256_succeeds(
+        self, client: TestClient, test_user: models.User, db_session: Session, minio
+    ):
+        item = sync_item("notes/hello.md", "# Hello")
+        share = make_folder_share(db_session, test_user, folder_items=[item])
+        raw_key = make_agent_key(db_session, share, scopes="read,write")
+
+        resp = client.put(
+            f"{BASE}/{share.id}/sync-write",
+            params={"path": "notes/hello.md"},
+            content=b"# Hello, edited",
+            headers=key_headers(
+                raw_key,
+                **{"Content-Type": "text/markdown", "If-Match": f'"{item["sha256"]}"'},
+            ),
+        )
+
+        assert resp.status_code == 200, resp.text
+        expected_sha = hashlib.sha256(b"# Hello, edited").hexdigest()
+        assert resp.json()["sha256"] == expected_sha
+        assert resp.json()["size"] == len(b"# Hello, edited")
+        assert resp.headers["etag"] == f'"{expected_sha}"'
+        # The bytes the server now serves are the new ones.
+        assert read_body(client, share.id, raw_key, "notes/hello.md") == "# Hello, edited"
+        minio.put_object.assert_called_once()
+
+    def test_bare_unquoted_sha256_is_accepted(
+        self, client: TestClient, test_user: models.User, db_session: Session, minio
+    ):
+        item = sync_item("a.md", "one")
+        share = make_folder_share(db_session, test_user, folder_items=[item])
+        raw_key = make_agent_key(db_session, share)
+
+        resp = client.put(
+            f"{BASE}/{share.id}/sync-write",
+            params={"path": "a.md"},
+            content=b"two",
+            headers=key_headers(
+                raw_key, **{"Content-Type": "text/markdown", "If-Match": item["sha256"]}
+            ),
+        )
+        assert resp.status_code == 200, resp.text
+
+    def test_create_only_with_if_none_match(
+        self, client: TestClient, test_user: models.User, db_session: Session, minio
+    ):
+        share = make_folder_share(db_session, test_user)
+        raw_key = make_agent_key(db_session, share)
+
+        resp = client.put(
+            f"{BASE}/{share.id}/sync-write",
+            params={"path": "fresh.md"},
+            content=b"brand new",
+            headers=key_headers(raw_key, **{"Content-Type": "text/markdown", "If-None-Match": "*"}),
+        )
+        assert resp.status_code == 200, resp.text
+        assert read_body(client, share.id, raw_key, "fresh.md") == "brand new"
+
+    def test_created_document_appears_in_files_index(
+        self, client: TestClient, test_user: models.User, db_session: Session, minio
+    ):
+        share = make_folder_share(db_session, test_user)
+        raw_key = make_agent_key(db_session, share)
+
+        client.put(
+            f"{BASE}/{share.id}/sync-write",
+            params={"path": "fresh.md"},
+            content=b"brand new",
+            headers=key_headers(raw_key, **{"Content-Type": "text/markdown", "If-None-Match": "*"}),
+        )
+
+        index = client.get(f"{BASE}/{share.id}/files-index", headers=key_headers(raw_key)).json()
+        entry = next(e for e in index if e["path"] == "fresh.md")
+        assert entry["sha256"] == hashlib.sha256(b"brand new").hexdigest()
+        assert entry["updated_at"]
+
+    def test_round_trip_read_then_write_with_returned_hash(
+        self, client: TestClient, test_user: models.User, db_session: Session, minio
+    ):
+        """The hash a caller reads back is directly usable as the next If-Match."""
+        share = make_folder_share(db_session, test_user, folder_items=[sync_item("loop.md", "v1")])
+        raw_key = make_agent_key(db_session, share)
+
+        got = client.get(
+            f"{BASE}/{share.id}/download",
+            params={"path": "loop.md"},
+            headers=key_headers(raw_key),
+        )
+        etag = got.headers["etag"]
+
+        resp = client.put(
+            f"{BASE}/{share.id}/sync-write",
+            params={"path": "loop.md"},
+            content=b"v2",
+            headers=key_headers(raw_key, **{"Content-Type": "text/markdown", "If-Match": etag}),
+        )
+        assert resp.status_code == 200, resp.text
+        assert read_body(client, share.id, raw_key, "loop.md") == "v2"
+
+
+# ── 3. the load-bearing negative: stale hash must not overwrite ──────────────
+
+
+class TestStaleWriteIsRefusedAndChangesNothing:
+    def test_mismatched_sha256_is_refused_and_body_unchanged(
+        self, client: TestClient, test_user: models.User, db_session: Session, minio
+    ):
+        item = sync_item("notes/hello.md", "# Original")
+        share = make_folder_share(db_session, test_user, folder_items=[item])
+        raw_key = make_agent_key(db_session, share)
+        stale = hashlib.sha256(b"# Some version this client last saw").hexdigest()
+
+        resp = client.put(
+            f"{BASE}/{share.id}/sync-write",
+            params={"path": "notes/hello.md"},
+            content=b"# Clobbered",
+            headers=key_headers(
+                raw_key, **{"Content-Type": "text/markdown", "If-Match": f'"{stale}"'}
+            ),
+        )
+
+        assert resp.status_code == 412, resp.text
+        # The verdict that matters: the document is byte-for-byte what it was.
+        assert read_body(client, share.id, raw_key, "notes/hello.md") == "# Original"
+        # And the index still advertises the ORIGINAL hash, so a well-behaved
+        # client is not handed a version that never existed.
+        index = client.get(f"{BASE}/{share.id}/files-index", headers=key_headers(raw_key)).json()
+        assert index[0]["sha256"] == item["sha256"]
+        assert index[0]["updated_at"] == item["modified_at"]
+        # Nothing reached the object store either.
+        minio.put_object.assert_not_called()
+
+    def test_unconditional_write_is_refused_and_body_unchanged(
+        self, client: TestClient, test_user: models.User, db_session: Session, minio
+    ):
+        share = make_folder_share(
+            db_session, test_user, folder_items=[sync_item("notes/hello.md", "# Original")]
+        )
+        raw_key = make_agent_key(db_session, share)
+
+        resp = client.put(
+            f"{BASE}/{share.id}/sync-write",
+            params={"path": "notes/hello.md"},
+            content=b"# Clobbered",
+            headers=key_headers(raw_key, **{"Content-Type": "text/markdown"}),
+        )
+
+        assert resp.status_code == 428, resp.text
+        assert read_body(client, share.id, raw_key, "notes/hello.md") == "# Original"
+        minio.put_object.assert_not_called()
+
+    def test_if_match_wildcard_is_refused_and_body_unchanged(
+        self, client: TestClient, test_user: models.User, db_session: Session, minio
+    ):
+        """`If-Match: *` only asserts existence — that is a blind overwrite."""
+        share = make_folder_share(
+            db_session, test_user, folder_items=[sync_item("notes/hello.md", "# Original")]
+        )
+        raw_key = make_agent_key(db_session, share)
+
+        resp = client.put(
+            f"{BASE}/{share.id}/sync-write",
+            params={"path": "notes/hello.md"},
+            content=b"# Clobbered",
+            headers=key_headers(raw_key, **{"Content-Type": "text/markdown", "If-Match": "*"}),
+        )
+
+        assert resp.status_code == 428, resp.text
+        assert read_body(client, share.id, raw_key, "notes/hello.md") == "# Original"
+        minio.put_object.assert_not_called()
+
+    def test_if_none_match_on_existing_file_is_refused_and_body_unchanged(
+        self, client: TestClient, test_user: models.User, db_session: Session, minio
+    ):
+        share = make_folder_share(
+            db_session, test_user, folder_items=[sync_item("notes/hello.md", "# Original")]
+        )
+        raw_key = make_agent_key(db_session, share)
+
+        resp = client.put(
+            f"{BASE}/{share.id}/sync-write",
+            params={"path": "notes/hello.md"},
+            content=b"# Clobbered",
+            headers=key_headers(raw_key, **{"Content-Type": "text/markdown", "If-None-Match": "*"}),
+        )
+
+        assert resp.status_code == 412, resp.text
+        assert read_body(client, share.id, raw_key, "notes/hello.md") == "# Original"
+        minio.put_object.assert_not_called()
+
+    def test_if_match_on_absent_file_is_refused_and_creates_nothing(
+        self, client: TestClient, test_user: models.User, db_session: Session, minio
+    ):
+        share = make_folder_share(db_session, test_user)
+        raw_key = make_agent_key(db_session, share)
+
+        resp = client.put(
+            f"{BASE}/{share.id}/sync-write",
+            params={"path": "ghost.md"},
+            content=b"content",
+            headers=key_headers(
+                raw_key,
+                **{"Content-Type": "text/markdown", "If-Match": f'"{"0" * 64}"'},
+            ),
+        )
+
+        assert resp.status_code == 412, resp.text
+        index = client.get(f"{BASE}/{share.id}/files-index", headers=key_headers(raw_key)).json()
+        assert index == []
+        minio.put_object.assert_not_called()
+
+    def test_both_preconditions_is_a_client_error_and_writes_nothing(
+        self, client: TestClient, test_user: models.User, db_session: Session, minio
+    ):
+        item = sync_item("notes/hello.md", "# Original")
+        share = make_folder_share(db_session, test_user, folder_items=[item])
+        raw_key = make_agent_key(db_session, share)
+
+        resp = client.put(
+            f"{BASE}/{share.id}/sync-write",
+            params={"path": "notes/hello.md"},
+            content=b"# Clobbered",
+            headers=key_headers(
+                raw_key,
+                **{
+                    "Content-Type": "text/markdown",
+                    "If-Match": f'"{item["sha256"]}"',
+                    "If-None-Match": "*",
+                },
+            ),
+        )
+
+        assert resp.status_code == 400, resp.text
+        assert read_body(client, share.id, raw_key, "notes/hello.md") == "# Original"
+        minio.put_object.assert_not_called()
+
+    def test_item_without_stored_sha256_can_never_be_matched(
+        self, client: TestClient, test_user: models.User, db_session: Session, minio
+    ):
+        """A mesh-artifact entry has no sha256, so no If-Match can match it."""
+        item = {
+            "path": "agent/report.md",
+            "name": "report.md",
+            "type": "doc",
+            "source": "mesh-artifact",
+            "mime": "text/markdown",
+            "size": 9,
+            "modified_at": "2026-08-19T10:00:00+00:00",
+            "storage_key": "web-assets/x/report.md",
+            "content": "# Report",
+        }
+        share = make_folder_share(db_session, test_user, folder_items=[item])
+        raw_key = make_agent_key(db_session, share)
+
+        resp = client.put(
+            f"{BASE}/{share.id}/sync-write",
+            params={"path": "agent/report.md"},
+            content=b"# Clobbered",
+            headers=key_headers(
+                raw_key,
+                **{
+                    "Content-Type": "text/markdown",
+                    "If-Match": f'"{hashlib.sha256(b"# Report").hexdigest()}"',
+                },
+            ),
+        )
+
+        assert resp.status_code == 412, resp.text
+        assert read_body(client, share.id, raw_key, "agent/report.md") == "# Report"
+        minio.put_object.assert_not_called()
+
+
+# ── 4. the scope boundary did not widen ──────────────────────────────────────
+
+
+class TestScopeBoundary:
+    def test_read_only_key_cannot_write(
+        self, client: TestClient, test_user: models.User, db_session: Session, minio
+    ):
+        item = sync_item("notes/hello.md", "# Original")
+        share = make_folder_share(db_session, test_user, folder_items=[item])
+        raw_key = make_agent_key(db_session, share, scopes="read")
+
+        resp = client.put(
+            f"{BASE}/{share.id}/sync-write",
+            params={"path": "notes/hello.md"},
+            content=b"# Clobbered",
+            headers=key_headers(
+                raw_key,
+                **{"Content-Type": "text/markdown", "If-Match": f'"{item["sha256"]}"'},
+            ),
+        )
+
+        assert resp.status_code == 403, resp.text
+        assert "write scope" in err_message(resp)
+        assert read_body(client, share.id, raw_key, "notes/hello.md") == "# Original"
+        minio.put_object.assert_not_called()
+
+    def test_write_only_key_cannot_read(
+        self, client: TestClient, test_user: models.User, db_session: Session
+    ):
+        """Literal scope policy (ADR-0001): write does not imply read, and the
+        lenient-read grace deliberately does not reach the sync protocol."""
+        share = make_folder_share(
+            db_session, test_user, folder_items=[sync_item("secret.md", "vault content")]
+        )
+        raw_key = make_agent_key(db_session, share, scopes="write")
+
+        index = client.get(f"{BASE}/{share.id}/files-index", headers=key_headers(raw_key))
+        assert index.status_code == 403
+        assert "read scope" in err_message(index)
+
+        download = client.get(
+            f"{BASE}/{share.id}/download",
+            params={"path": "secret.md"},
+            headers=key_headers(raw_key),
+        )
+        assert download.status_code == 403
+        assert "vault content" not in download.text
+
+    def test_key_cannot_reach_another_share(
+        self, client: TestClient, test_user: models.User, db_session: Session, minio
+    ):
+        mine = make_folder_share(db_session, test_user)
+        theirs = make_folder_share(
+            db_session, test_user, folder_items=[sync_item("other.md", "not yours")]
+        )
+        raw_key = make_agent_key(db_session, mine)
+
+        read = client.get(f"{BASE}/{theirs.id}/files-index", headers=key_headers(raw_key))
+        assert read.status_code == 403
+        assert "not valid for this share" in err_message(read)
+
+        write = client.put(
+            f"{BASE}/{theirs.id}/sync-write",
+            params={"path": "other.md"},
+            content=b"clobber",
+            headers=key_headers(raw_key, **{"Content-Type": "text/markdown", "If-None-Match": "*"}),
+        )
+        assert write.status_code == 403
+        minio.put_object.assert_not_called()
+
+    def test_key_cannot_list_shares(
+        self, client: TestClient, test_user: models.User, db_session: Session
+    ):
+        """Share management stays user-only — the key buys no account-wide reach."""
+        share = make_folder_share(db_session, test_user)
+        raw_key = make_agent_key(db_session, share)
+
+        resp = client.get(BASE, headers=key_headers(raw_key))
+        assert resp.status_code == 401
+
+    def test_key_cannot_delete_the_share(
+        self, client: TestClient, test_user: models.User, db_session: Session
+    ):
+        share = make_folder_share(db_session, test_user)
+        raw_key = make_agent_key(db_session, share)
+
+        resp = client.delete(f"{BASE}/{share.id}", headers=key_headers(raw_key))
+        assert resp.status_code == 401
+        assert db_session.get(models.Share, share.id) is not None
+
+    def test_key_cannot_add_members(
+        self, client: TestClient, test_user: models.User, db_session: Session
+    ):
+        share = make_folder_share(db_session, test_user)
+        raw_key = make_agent_key(db_session, share)
+
+        resp = client.post(
+            f"{BASE}/{share.id}/members",
+            json={"email": "intruder@example.com", "role": "editor"},
+            headers=key_headers(raw_key),
+        )
+        assert resp.status_code == 401
+
+    def test_key_cannot_mint_a_file_token(
+        self, client: TestClient, test_user: models.User, db_session: Session
+    ):
+        """file-token is the CAS/attachment credential — still user-JWT only."""
+        share = make_folder_share(db_session, test_user)
+        raw_key = make_agent_key(db_session, share)
+
+        resp = client.post(
+            f"{BASE}/{share.id}/file-token",
+            json={
+                "path": "a.png",
+                "sha256": "0" * 64,
+                "content_type": "image/png",
+                "content_length": 10,
+            },
+            headers=key_headers(raw_key),
+        )
+        assert resp.status_code == 401
+
+    def test_write_rejects_non_folder_share(
+        self, client: TestClient, test_user: models.User, db_session: Session, minio
+    ):
+        doc_share = models.Share(
+            kind=models.ShareKind.DOC,
+            path="Note.md",
+            visibility=models.ShareVisibility.PRIVATE,
+            owner_user_id=test_user.id,
+        )
+        db_session.add(doc_share)
+        db_session.commit()
+        db_session.refresh(doc_share)
+        raw_key = make_agent_key(db_session, doc_share)
+
+        resp = client.put(
+            f"{BASE}/{doc_share.id}/sync-write",
+            params={"path": "a.md"},
+            content=b"x",
+            headers=key_headers(raw_key, **{"Content-Type": "text/markdown", "If-None-Match": "*"}),
+        )
+        assert resp.status_code == 400
+        minio.put_object.assert_not_called()
+
+    def test_write_rejects_path_traversal(
+        self, client: TestClient, test_user: models.User, db_session: Session, minio
+    ):
+        share = make_folder_share(db_session, test_user)
+        raw_key = make_agent_key(db_session, share)
+
+        resp = client.put(
+            f"{BASE}/{share.id}/sync-write",
+            params={"path": "../../etc/passwd"},
+            content=b"x",
+            headers=key_headers(raw_key, **{"Content-Type": "text/markdown", "If-None-Match": "*"}),
+        )
+        assert resp.status_code == 400
+        minio.put_object.assert_not_called()
+
+    def test_unknown_key_is_401(
+        self, client: TestClient, test_user: models.User, db_session: Session
+    ):
+        share = make_folder_share(db_session, test_user)
+        resp = client.get(
+            f"{BASE}/{share.id}/files-index",
+            headers=key_headers("tr_agent_" + uuid.uuid4().hex),
+        )
+        assert resp.status_code == 401
+
+
+# ── 5. the user-JWT path is unchanged ────────────────────────────────────────
+
+
+class TestUserJwtPathUnchanged:
+    def _login(self, client: TestClient, email: str, password: str) -> str:
+        resp = client.post("/auth/login", json={"email": email, "password": password})
+        assert resp.status_code == 200, resp.text
+        return resp.json()["access_token"]
+
+    def test_owner_still_reads_with_bearer(
+        self, client: TestClient, test_user: models.User, db_session: Session
+    ):
+        item = sync_item("notes/hello.md", "# Hello")
+        share = make_folder_share(db_session, test_user, folder_items=[item])
+        token = self._login(client, test_user.email, "test123456")
+
+        resp = client.get(
+            f"{BASE}/{share.id}/files-index", headers={"Authorization": f"Bearer {token}"}
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()[0]["sha256"] == item["sha256"]
+
+    def test_owner_can_write_conditionally_with_bearer(
+        self, client: TestClient, test_user: models.User, db_session: Session, minio
+    ):
+        item = sync_item("notes/hello.md", "# Hello")
+        share = make_folder_share(db_session, test_user, folder_items=[item])
+        token = self._login(client, test_user.email, "test123456")
+
+        resp = client.put(
+            f"{BASE}/{share.id}/sync-write",
+            params={"path": "notes/hello.md"},
+            content=b"# Edited by a human",
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "text/markdown",
+                "If-Match": f'"{item["sha256"]}"',
+            },
+        )
+        assert resp.status_code == 200, resp.text
+
+    def test_non_member_bearer_is_still_refused(
+        self, client: TestClient, test_user: models.User, db_session: Session
+    ):
+        from app.core import security as sec
+
+        outsider = models.User(
+            email="outsider@example.com",
+            password_hash=sec.get_password_hash("outsider-password"),
+            is_active=True,
+        )
+        db_session.add(outsider)
+        db_session.commit()
+
+        share = make_folder_share(
+            db_session, test_user, folder_items=[sync_item("secret.md", "vault content")]
+        )
+        token = self._login(client, "outsider@example.com", "outsider-password")
+
+        resp = client.get(
+            f"{BASE}/{share.id}/files-index", headers={"Authorization": f"Bearer {token}"}
+        )
+        assert resp.status_code == 403

--- a/docs/agent-keys.md
+++ b/docs/agent-keys.md
@@ -86,8 +86,8 @@ Click **I've copied this key — close** to dismiss.
 
 | Scope | What it allows |
 |-------|---------------|
-| `write` | Upload files to the share via `POST /v1/web/shares/{slug}/upload` and `/sync-upload` |
-| `read` | List and read the share's files: `GET /v1/web/shares/{id}/files-index`, `/download`, `/files`, `/assets`, and share metadata |
+| `write` | Upload files to the share via `POST /v1/web/shares/{slug}/upload` and `/sync-upload`, and write one document conditionally via `PUT /v1/shares/{id}/sync-write` |
+| `read` | List and read the share's files: `GET /v1/web/shares/{id}/files-index`, `/download`, `/files`, `/assets`, share metadata, and the sync protocol's `GET /v1/shares/{id}/files-index` and `/download` |
 
 A key created without an explicit `scopes` field — which is what the Obsidian plugin does — gets
 **both** scopes. To create an upload-only "drop box" key that can never read the share, pass
@@ -101,6 +101,55 @@ a WARNING. (Before 2026-08-19 this split was permanent, not a grace period — a
 read through `/files` while `/download` answered `403 Agent key does not have read scope`.)
 
 An agent key is still bound to exactly one share and grants no access to any other.
+
+### The sync protocol (`/v1/shares/{id}/…`)
+
+There are two route families, and they are not interchangeable:
+
+| Family | Carries `sha256` / `updated_at`? | Use it for |
+|--------|----------------------------------|------------|
+| `/v1/web/shares/…` | no | web publishing, and fire-and-forget uploads |
+| `/v1/shares/…` | **yes** | two-way sync: reconciling two copies of a document |
+
+Only the second family lets a caller see which version it is holding, so only the second family can
+write without silently discarding somebody else's edit. Since 2026-08-20 the same agent key reaches
+it, with the same literal scopes:
+
+| Endpoint | Scope | Notes |
+|----------|-------|-------|
+| `GET /v1/shares/{id}/files-index` | `read` | returns `path`, `sha256`, `size`, `updated_at` per document |
+| `GET /v1/shares/{id}/download?path=…` | `read` | body, plus `ETag: "<sha256>"` and `X-Updated-At` |
+| `PUT /v1/shares/{id}/sync-write?path=…` | `write` | conditional write — see below |
+
+`sync-write` **requires** a precondition; there is no unconditional form:
+
+* `If-Match: "<sha256>"` — replace the version whose hash you supply. If the stored hash differs
+  (someone edited the document since you read it), the answer is `412 Precondition Failed` and
+  nothing is written — not the index, not the object store.
+* `If-None-Match: *` — create a document that does not exist yet. `412` if it already does.
+* Neither header — `428 Precondition Required`.
+* `If-Match: *` — refused with `428`. It asserts only that the file exists, which is exactly the
+  blind overwrite this endpoint will not perform.
+
+The hash returned by `files-index`, the `ETag` on `download`, and the `ETag` on a successful
+`sync-write` are all the same token, so the read → edit → write loop needs no extra call:
+
+```bash
+ETAG=$(curl -sfI "https://cp.yourdomain.com/v1/shares/$SHARE_ID/download?path=notes/plan.md" \
+  -H "X-Agent-Key: $KEY" | grep -i '^etag:' | cut -d' ' -f2 | tr -d '\r')
+
+curl -sf -X PUT "https://cp.yourdomain.com/v1/shares/$SHARE_ID/sync-write?path=notes/plan.md" \
+  -H "X-Agent-Key: $KEY" \
+  -H "Content-Type: text/markdown" \
+  -H "If-Match: $ETAG" \
+  --data-binary @plan.md
+```
+
+A document written this way lands as `source=sync-artifact`, exactly like one uploaded through
+`/v1/web/shares/{id}/sync-upload`, so the Obsidian plugin picks it up on its next inbound cycle.
+
+Share management stays user-only: an agent key cannot list shares, delete a share, change members,
+or mint attachment file-tokens.
 
 ### Changing the scopes of an existing key
 
@@ -270,6 +319,8 @@ The key is invalidated immediately. Any agent using it will receive `403 Forbidd
 | `403 Forbidden: does not have read scope` | Key has no `read` scope (all keys created before 2026-08-19 via the plugin) | Grant `read` via `PATCH .../agent-keys/{key_id}` |
 | `404 Not Found` | Share slug wrong, or web publishing disabled | Verify the slug in plugin settings; enable web publishing |
 | `409 Conflict` | 20-key limit reached | Revoke unused keys first |
+| `412 Precondition Failed` | `sync-write`: the document changed since you read it, or `If-None-Match: *` on a document that already exists | Re-read it, merge, retry with the new `sha256` |
+| `428 Precondition Required` | `sync-write` without `If-Match`/`If-None-Match`, or with `If-Match: *` | Supply the `sha256` of the version you are replacing |
 | `413 Request Entity Too Large` | File exceeds 25 MB | Split the file or use a smaller payload |
 
 ---


### PR DESCRIPTION
## Summary

Mesh's Team Relay integration holds one agent key per share. That key could push bytes through `POST /v1/web/shares/{id}/sync-upload`, but it could not read a document's `sha256` anywhere, so it could not write without risking silently discarding somebody else's edit.

The hashes live on the **sync protocol** — `GET /v1/shares/{id}/files-index` and `/download`, the only routes that carry `sha256` and `updated_at`. Those were declared under `OAuth2PasswordBearer`, i.e. user-JWT only. This PR extends the **same** key to that protocol. No second credential, no service user, web publishing untouched.

### What changed

* `GET /v1/shares/{id}/files-index` and `GET /v1/shares/{id}/download` now also accept `X-Agent-Key` with the literal `read` scope, alongside the user JWT they already took. `download` additionally answers `ETag: "<sha256>"` and `X-Updated-At`, so a read → edit → write loop needs one call instead of two.
* **New** `PUT /v1/shares/{id}/sync-write?path=…` — write one document, `write` scope, compare-and-swap on `sha256`. Produces the same `source=sync-artifact` index entry as `sync-upload`, so the Obsidian plugin picks it up on its next inbound cycle.
* `share_service.authenticate_agent_key` now routes its scope check through `agent_key_scopes` (ADR-0001) instead of a local `scopes.split(",")`. That local copy did not strip whitespace, so a key stored as `"read, write"` — which the PATCH-scopes endpoint can produce — failed every check.

### There was no conditional write on this server before

Worth stating plainly, because it shaped the design: nothing in `apps/control-plane` did a precondition check on a content write. `sync-upload` hashes whatever body it is handed and stores it — two writers are last-write-wins, silently. There is no `If-Match`, no `412`, no `409` on any content route.

A credential handed to an automated agent cannot have that property, so the precondition on `sync-write` is **mandatory**, not opt-in:

| Request | Result |
|---|---|
| `If-Match: "<sha256>"`, hash matches | 200, document replaced |
| `If-Match: "<sha256>"`, hash differs | **412**, nothing written |
| `If-Match` on a path that does not exist | 412 |
| `If-None-Match: *`, path free | 200, document created |
| `If-None-Match: *`, path taken | 412 |
| neither header | **428** |
| `If-Match: *` | **428** — a wildcard asserts only existence, which is exactly the blind overwrite this endpoint refuses to perform |

The compare and the swap sit inside one row lock (`SELECT … FOR UPDATE`), so a refused write leaves **both** the JSONB index and the object store untouched. `sync-upload` deliberately keeps MinIO I/O outside the lock for pool hygiene; that trade is only safe for an unconditional write, and the reasoning is written into the code where the two diverge.

### Scope boundary

Scopes stay literal (ADR-0001) and get **no** lenient-read grace here — these routes are UUID-addressable and therefore reach shares that were never web-published, the exact regression ADR-0001 exists to avoid. Pinned by tests, the key still cannot: write with only `read`, read with only `write`, touch any share other than its own, list shares, delete a share, add members, or mint an attachment file-token.

## Test plan

`apps/control-plane/tests/test_agent_key_sync_protocol.py` — 31 tests.

The load-bearing negative asserts on the **document body**, not the status code: a 412 returned after a write that actually landed is indistinguishable from an honest one by status alone.

```
$ uv run pytest tests/test_agent_key_sync_protocol.py -q
31 passed in 21.71s

$ uv run pytest -q          # full control-plane suite
744 passed, 1 skipped in 487.26s

$ uv run ruff check app/ tests/ && uv run ruff format --check app/ tests/
All checks passed!
161 files already formatted
```

Both guards were mutation-checked rather than assumed green:

* stubbing out `_require_sync_precondition` → the 7 tests in `TestStaleWriteIsRefusedAndChangesNothing` fail, including the two that read the document back;
* stubbing out the scope comparison in `authenticate_agent_key` → `test_read_only_key_cannot_write` and `test_write_only_key_cannot_read` fail.

Not deployed, not merged — no prod host was touched.

## What Mesh does next

1. `GET /v1/shares/{share_id}/files-index` with `X-Agent-Key` → `[{path, sha256, size, updated_at}]`.
2. `GET /v1/shares/{share_id}/download?path=…` → body, with the version's `sha256` in `ETag`.
3. `PUT /v1/shares/{share_id}/sync-write?path=…` with `If-Match: "<sha256>"` (or `If-None-Match: *` to create), raw bytes as the body, `Content-Type` set. On 412: re-read, merge, retry.

Keys created explicitly as `["write"]` need `read` granted via `PATCH …/agent-keys/{key_id}`; keys created without an explicit `scopes` field already have both.
