### PR TITLE
fix(control-plane): plugin content push carries a hash, agent key mints file-tokens, ё is a valid path char

### DIFF
--- a/apps/control-plane/app/api/routers/shares.py
+++ b/apps/control-plane/app/api/routers/shares.py
@@ -21,7 +21,7 @@ from sqlalchemy.orm import Session
 from sqlalchemy.orm.attributes import flag_modified
 
 from app.api import deps
-from app.core import security
+from app.core import agent_key_scopes, security
 from app.core.config import get_settings
 from app.db import models
 from app.db.session import get_db
@@ -163,10 +163,16 @@ def _authorize_share_sync(
     current_user: models.User | None,
     *,
     required_scope: str,
-) -> str:
+) -> tuple[str, models.ShareAgentKey | None]:
     """Authorize a sync-protocol request via X-Agent-Key or user JWT.
 
-    Returns "agent_key" or "user". The agent-key branch also checks the key's
+    Returns (method, agent_key): method is "agent_key" or "user"; agent_key is
+    the authenticated row when method == "agent_key", else None. Exposing the
+    row (not just the fact that `required_scope` was satisfied) lets a caller
+    that needs to know MORE than the one scope it required — e.g. file-token
+    minting, which only requires `read` to mint but must remember whether that
+    same key also holds `write` — inspect `agent_key.scopes` without a second
+    authentication round trip. The agent-key branch also checks the key's
     standing (creator still owner/member/admin) and the literal scope, and
     stamps last_used_at — committed here, because the read routes commit
     nothing of their own and an uncommitted stamp would be silently discarded.
@@ -182,7 +188,7 @@ def _authorize_share_sync(
             db.commit()
         except Exception:  # pragma: no cover - telemetry must not 500
             db.rollback()
-        return "agent_key"
+        return "agent_key", agent_key
 
     if current_user is None:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing credentials")
@@ -191,7 +197,7 @@ def _authorize_share_sync(
         share_service.ensure_write_access(db, share, current_user)
     else:
         share_service.ensure_read_access(db, share, current_user)
-    return "user"
+    return "user", None
 
 
 @router.get("/{share_id}/files-index", response_model=list[SyncArtifactItem])
@@ -442,7 +448,9 @@ async def sync_write_file(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="sync-write only supported for folder shares",
         )
-    auth_method = _authorize_share_sync(request, share, db, current_user, required_scope="write")
+    auth_method, _agent_key = _authorize_share_sync(
+        request, share, db, current_user, required_scope="write"
+    )
 
     path = _validate_file_path(path)
 
@@ -678,15 +686,29 @@ def create_file_token(
     — symmetric to files-index/download/sync-write (#ee1745ce). An agent key
     has no `models.User` of its own, so the minted token's subject is the
     share owner: HEAD/download-url/upload-url decode the token and re-check
-    `ensure_read_access`/`ensure_write_access` against that subject, and the
-    owner always passes both — the token's own path/share/expiry scope is
-    what actually limits the agent, not who it is minted "as".
+    `ensure_read_access`/`ensure_write_access` against that subject. For a
+    user-minted token that's the whole story — the owner always clears both,
+    but so does re-deriving the real caller's own membership role, since the
+    subject IS that real user. For an agent-key-minted token the subject is
+    a stand-in (the owner), which would silently launder a read-only key's
+    token into write access at upload-url — so the token also carries the
+    minting key's own `write` scope as an explicit claim (`agent_write`),
+    which upload-url checks BEFORE trusting the owner-subject's access.
     """
     share = share_service.get_share(db, share_id)
-    auth_method = _authorize_share_sync(request, share, db, current_user, required_scope="read")
+    auth_method, agent_key = _authorize_share_sync(
+        request, share, db, current_user, required_scope="read"
+    )
     path = _validate_file_path(payload.path)
 
-    subject = str(current_user.id) if auth_method == "user" else str(share.owner_user_id)
+    if auth_method == "user":
+        subject = str(current_user.id)
+        agent_write: bool | None = None
+    else:
+        subject = str(share.owner_user_id)
+        key_scopes = agent_key_scopes.parse_scopes(agent_key.scopes)
+        agent_write = agent_key_scopes.satisfies(key_scopes, "write")
+
     token = security.create_file_token(
         subject=subject,
         share_id=str(share_id),
@@ -695,6 +717,7 @@ def create_file_token(
         content_type=payload.content_type,
         content_length=payload.content_length,
         expires_minutes=FILE_TOKEN_EXPIRE_MINUTES,
+        agent_write=agent_write,
     )
     expires_at = (security.utcnow() + timedelta(minutes=FILE_TOKEN_EXPIRE_MINUTES)).isoformat()
     settings = get_settings()
@@ -783,6 +806,17 @@ def get_file_upload_url(
     here the storage write happens client-side a moment later instead).
     """
     token_payload = _decode_file_token(share_id, path, authorization)
+    # An agent-key-minted token's subject is the share owner (a stand-in — the
+    # key has no models.User of its own), who always clears ensure_write_access
+    # below regardless of the key's own scope. `agent_write` is the minting
+    # key's actual scope, explicit and False rather than absent so a read-only
+    # key can never fall through: absent (None) means a real user minted this,
+    # where ensure_write_access already checks their genuine membership role.
+    if token_payload.get("agent_write") is False:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Agent key does not have write scope",
+        )
     user = _user_from_file_token(db, token_payload)
     share = share_service.get_share(db, share_id)
     share_service.ensure_write_access(db, share, user)

--- a/apps/control-plane/app/api/routers/shares.py
+++ b/apps/control-plane/app/api/routers/shares.py
@@ -234,7 +234,7 @@ def get_share_files_index(
 
 
 def _sync_read_headers(item: dict[str, Any]) -> dict[str, str]:
-    """ETag/Last-Modified for a sync-protocol read.
+    """ETag/X-Updated-At for a sync-protocol read.
 
     The ETag is the item's stored sha256 — the exact token PUT /sync-write
     expects back in If-Match, so a caller can do read → edit → conditional
@@ -557,7 +557,7 @@ async def sync_write_file(
 # ensure_read_access/ensure_write_access, rather than trusting a mode baked
 # into the token. Least-privilege, short expiry (10 min), single path scope.
 
-_ALLOWED_FILE_PATH_RE = re.compile(r"^[a-zA-Z0-9._\-/А-Яа-я ]+$")
+_ALLOWED_FILE_PATH_RE = re.compile(r"^[\w.\-/ ]+$", re.UNICODE)
 FILE_TOKEN_EXPIRE_MINUTES = 10
 
 
@@ -662,23 +662,33 @@ def _user_from_file_token(db: Session, payload: dict[str, Any]) -> models.User:
 
 @router.post("/{share_id}/file-token", response_model=FileTokenResponse)
 def create_file_token(
+    request: Request,
     share_id: uuid.UUID,
     payload: FileTokenRequest,
     db: Session = Depends(get_db),
-    current_user: models.User = Depends(deps.get_current_user),
+    current_user: models.User | None = Depends(deps.get_optional_user),
 ) -> FileTokenResponse:
     """Mint a short-lived, path-scoped token for attachment (CAS) access.
 
     Minimum bar to mint at all is read access — write is re-checked
     independently at upload-url, so a viewer can verify/download but a
     write-url request 403s unless they actually have write access.
+
+    Auth: Authorization: Bearer <user JWT>, or X-Agent-Key with `read` scope
+    — symmetric to files-index/download/sync-write (#ee1745ce). An agent key
+    has no `models.User` of its own, so the minted token's subject is the
+    share owner: HEAD/download-url/upload-url decode the token and re-check
+    `ensure_read_access`/`ensure_write_access` against that subject, and the
+    owner always passes both — the token's own path/share/expiry scope is
+    what actually limits the agent, not who it is minted "as".
     """
     share = share_service.get_share(db, share_id)
-    share_service.ensure_read_access(db, share, current_user)
+    auth_method = _authorize_share_sync(request, share, db, current_user, required_scope="read")
     path = _validate_file_path(payload.path)
 
+    subject = str(current_user.id) if auth_method == "user" else str(share.owner_user_id)
     token = security.create_file_token(
-        subject=str(current_user.id),
+        subject=subject,
         share_id=str(share_id),
         path=path,
         sha256=payload.sha256,

--- a/apps/control-plane/app/api/routers/web.py
+++ b/apps/control-plane/app/api/routers/web.py
@@ -445,8 +445,13 @@ def sync_folder_file_content(
     """
     Sync individual file content within a folder share.
 
-    This endpoint is called by the Obsidian plugin to sync content of files
-    within a folder share. The content is stored in the web_folder_items JSONB field.
+    This is the plugin's actual content-push path (the `web_folder_items` PATCH
+    on /shares/{id} only ever carries path/name/type — no content, no hash).
+    Stamps sha256/size/modified_at/source=sync-artifact on the item so it
+    becomes visible and writable through the sync protocol
+    (GET /v1/shares/{id}/files-index, PUT /sync-write) — before this it was
+    content-only, invisible to that protocol regardless of who asked (#ee1745ce
+    finding 1/2).
 
     Access control:
     - This is an authenticated endpoint (requires valid session or user token)
@@ -483,12 +488,20 @@ def sync_folder_file_content(
     _require_private_web_auth(request, share, db, required_scope="write")
 
     # Update folder items with content
+    content_bytes = payload.content.encode("utf-8")
+    sha256 = hashlib.sha256(content_bytes).hexdigest()
+    now_iso = security.utcnow().isoformat()
+
     folder_items = share.web_folder_items or []
     updated = False
 
     for item in folder_items:
         if item.get("path") == path:
             item["content"] = payload.content
+            item["sha256"] = sha256
+            item["size"] = len(content_bytes)
+            item["modified_at"] = now_iso
+            item["source"] = "sync-artifact"
             updated = True
             break
 
@@ -500,6 +513,10 @@ def sync_folder_file_content(
                 "name": path.split("/")[-1],
                 "type": "doc",
                 "content": payload.content,
+                "sha256": sha256,
+                "size": len(content_bytes),
+                "modified_at": now_iso,
+                "source": "sync-artifact",
             }
         )
 
@@ -1107,7 +1124,7 @@ def serve_web_asset(
 
 
 MAX_MESH_UPLOAD_SIZE = 25 * 1024 * 1024  # 25MB
-_ALLOWED_PATH_RE = re.compile(r"^[a-zA-Z0-9._\-/А-Яа-я ]+$")
+_ALLOWED_PATH_RE = re.compile(r"^[\w.\-/ ]+$", re.UNICODE)
 
 
 def _validate_upload_path(path: str) -> None:

--- a/apps/control-plane/app/core/security.py
+++ b/apps/control-plane/app/core/security.py
@@ -90,6 +90,7 @@ def create_file_token(
     content_type: str,
     content_length: int,
     expires_minutes: int = 10,
+    agent_write: bool | None = None,
 ) -> str:
     """Mint a short-lived, path-scoped token for attachment (CAS) access.
 
@@ -97,6 +98,15 @@ def create_file_token(
     never be usable as a general session credential (see the "scope" check
     in deps._get_user_from_token) — it grants access to exactly one file's
     HEAD/download-url/upload-url for a few minutes, nothing else.
+
+    agent_write: None when minted for a real user session (upload-url then
+    re-checks that user's actual membership role via ensure_write_access,
+    which already denies a viewer correctly — no gap there). When minted for
+    an agent key, the caller MUST pass True/False for whether that key holds
+    literal write scope: the token's subject becomes the share owner (an
+    agent key has no models.User of its own), and the owner always clears
+    ensure_write_access, so without this claim a read-only key's token would
+    silently carry write capability at upload-url. See #d4c851af.
     """
     settings = get_settings()
     expire_delta = timedelta(minutes=expires_minutes)
@@ -108,6 +118,7 @@ def create_file_token(
         "sha256": sha256,
         "content_type": content_type,
         "content_length": content_length,
+        "agent_write": agent_write,
         "exp": utcnow() + expire_delta,
         "iat": utcnow(),
     }

--- a/apps/control-plane/app/db/migrations/versions/202608200001_backfill_sync_artifact_hash.py
+++ b/apps/control-plane/app/db/migrations/versions/202608200001_backfill_sync_artifact_hash.py
@@ -1,0 +1,88 @@
+"""Backfill sha256/size/modified_at/source on plugin-pushed web_folder_items.
+
+Revision ID: 202608200001
+Revises: 202607250001
+Create Date: 2026-08-20 00:00:00.000000
+
+Items pushed through POST /shares/{slug}/files (the Obsidian plugin's content-push
+path, fixed alongside this migration) carried `content` but no `sha256`/`source`
+before today — invisible and unwritable through the sync protocol added by #ee1745ce
+(GET .../files-index filters on source == "sync-artifact" AND non-empty sha256).
+This backfills the ones the app-level fix cannot reach retroactively: existing rows
+with content already sitting in the JSONB column.
+
+Scope of the backfill is deliberately narrow — only items with NO `source` at all
+AND non-null `content`:
+  - `source == "mesh-artifact"` (upload_mesh_artifact) is excluded on purpose: those
+    are intentionally not part of the sync protocol, and flipping their source would
+    change what they are, not just fill in a missing field.
+  - `source == "sync-artifact"` already has a real sha256 (sync-upload/sync-write
+    compute it at write time) and is left untouched.
+  - `content is None` items (binary assets from the presigned-upload flow) have
+    nothing to hash here; they already carry their own sha256 from the upload token.
+
+`modified_at` has no historical value to recover — the JSONB item never carried one.
+Using the share row's own `updated_at` (falls back to `created_at`) as the least
+dishonest available proxy: closer to the actual last-touch time than "now", which
+would make every backfilled row look like it just changed in this same instant.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Sequence
+
+from alembic import op
+from sqlalchemy import text
+
+revision: str = "202608200001"
+down_revision: str | None = "202607250001"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    rows = conn.execute(
+        text(
+            """
+            SELECT id, web_folder_items, updated_at, created_at
+            FROM shares
+            WHERE web_folder_items IS NOT NULL
+            """
+        )
+    ).fetchall()
+
+    touched = 0
+    for share_id, folder_items, updated_at, created_at in rows:
+        if not folder_items:
+            continue
+        stamp = (updated_at or created_at).isoformat()
+        changed = False
+        new_items = []
+        for item in folder_items:
+            content = item.get("content")
+            if item.get("source") is None and content is not None and not item.get("sha256"):
+                item = dict(item)
+                item["sha256"] = hashlib.sha256(content.encode("utf-8")).hexdigest()
+                item["size"] = len(content.encode("utf-8"))
+                item.setdefault("modified_at", stamp)
+                item["source"] = "sync-artifact"
+                changed = True
+            new_items.append(item)
+        if changed:
+            conn.execute(
+                text("UPDATE shares SET web_folder_items = CAST(:items AS JSONB) WHERE id = :id"),
+                {"items": json.dumps(new_items), "id": share_id},
+            )
+            touched += 1
+
+    op.execute(text(f"-- backfilled sync-artifact hash on {touched} share(s)"))
+
+
+def downgrade() -> None:
+    # Backfill is intentionally non-reversible — there is no record of which
+    # sha256/source/size values were synthesized here vs. genuinely written by
+    # sync-upload/sync-write after this migration ran.
+    pass

--- a/apps/control-plane/app/db/migrations/versions/202608200001_backfill_sync_artifact_hash.py
+++ b/apps/control-plane/app/db/migrations/versions/202608200001_backfill_sync_artifact_hash.py
@@ -78,7 +78,7 @@ def upgrade() -> None:
             )
             touched += 1
 
-    op.execute(text(f"-- backfilled sync-artifact hash on {touched} share(s)"))
+    print(f"backfilled sync-artifact hash on {touched} share(s)")
 
 
 def downgrade() -> None:

--- a/apps/control-plane/app/db/migrations/versions/202608200003_backfill_sync_artifact_hash.py
+++ b/apps/control-plane/app/db/migrations/versions/202608200003_backfill_sync_artifact_hash.py
@@ -1,8 +1,15 @@
 """Backfill sha256/size/modified_at/source on plugin-pushed web_folder_items.
 
-Revision ID: 202608200001
-Revises: 202607250001
+Revision ID: 202608200003
+Revises: 202608200002
 Create Date: 2026-08-20 00:00:00.000000
+
+Renumbered from 202608200001 -> 202608200003 (unchanged otherwise) after
+merging main: task #ac65cfe5's reconciliation migration (202608200002) landed
+on main first, forking from the same 202607250001 parent this one originally
+did. Rather than merge two heads, this one now chains after it — the two
+migrations touch disjoint data (email_queue vs. web_folder_items) so order
+between them doesn't matter functionally, only the DAG needs to be linear.
 
 Items pushed through POST /shares/{slug}/files (the Obsidian plugin's content-push
 path, fixed alongside this migration) carried `content` but no `sha256`/`source`
@@ -36,8 +43,8 @@ from collections.abc import Sequence
 from alembic import op
 from sqlalchemy import text
 
-revision: str = "202608200001"
-down_revision: str | None = "202607250001"
+revision: str = "202608200003"
+down_revision: str | None = "202608200002"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/apps/control-plane/app/services/share_service.py
+++ b/apps/control-plane/app/services/share_service.py
@@ -290,7 +290,8 @@ def update_share(
         share.web_content = payload.web_content if payload.web_content else None
         share.web_content_updated_at = datetime.now(timezone.utc) if payload.web_content else None
 
-    # Handle web folder items update — MERGE to preserve content/source/storage_key/sha256
+    # Handle web folder items update — MERGE to preserve content/source/storage_key/
+    # sha256/size/modified_at
     if payload.web_folder_items is not None:
         old_has_items = share.web_folder_items is not None
         new_has_items = len(payload.web_folder_items) > 0
@@ -311,7 +312,11 @@ def update_share(
             for item in payload.web_folder_items:
                 new_item = item.model_dump()
                 existing = existing_by_path.get(new_item["path"], {})
-                for key in ("content", "source", "storage_key", "sha256"):
+                # #d4c851af finding 2: modified_at/size dropped here would silently
+                # re-empty files-index's `updated_at` on the very next nav-tree-only
+                # PATCH (WebSyncManager fires one on every create/rename/delete),
+                # undoing sync_folder_file_content's stamp without touching sha256.
+                for key in ("content", "source", "storage_key", "sha256", "size", "modified_at"):
                     if key in existing:
                         new_item[key] = existing[key]
                 new_items.append(new_item)

--- a/apps/control-plane/tests/test_agent_key_sync_protocol.py
+++ b/apps/control-plane/tests/test_agent_key_sync_protocol.py
@@ -903,3 +903,64 @@ class TestAgentKeyFileToken:
         )
         assert resp.status_code == 403
         assert "not valid for this share" in err_message(resp)
+
+    def _mint(self, client: TestClient, share_id, raw_key: str) -> str:
+        resp = client.post(
+            f"{BASE}/{share_id}/file-token",
+            json={
+                "path": "attachments/photo.png",
+                "sha256": "a" * 64,
+                "content_type": "image/png",
+                "content_length": 12345,
+            },
+            headers=key_headers(raw_key),
+        )
+        assert resp.status_code == 200, resp.text
+        return resp.json()["token"]
+
+    def test_read_scoped_key_token_cannot_reach_upload_url(
+        self, client: TestClient, test_user: models.User, db_session: Session
+    ):
+        """The bug this pins (#d4c851af, found on review): create_file_token
+        mints the token with the share OWNER as subject (an agent key has no
+        models.User of its own), and get_file_upload_url's ensure_write_access
+        check re-derives access from that subject — which is always the
+        owner, so it always passes regardless of the minting key's own scope.
+        A read-only key could mint a token and then use it to get a write
+        presigned URL: read escalating to write. Must be 403, and MinIO must
+        never be asked for a presigned URL."""
+        share = make_folder_share(db_session, test_user)
+        raw_key = make_agent_key(db_session, share, scopes="read")
+        file_token = self._mint(client, share.id, raw_key)
+
+        mock_client = MagicMock()
+        with patch("app.api.routers.shares._get_minio_client", return_value=mock_client):
+            resp = client.post(
+                f"{BASE}/{share.id}/files/attachments/photo.png/upload-url",
+                headers={"Authorization": f"Bearer {file_token}"},
+            )
+        assert resp.status_code == 403, resp.text
+        assert "write scope" in err_message(resp)
+        mock_client.presigned_put_object.assert_not_called()
+
+    def test_read_write_scoped_key_token_reaches_upload_url(
+        self, client: TestClient, test_user: models.User, db_session: Session
+    ):
+        """Positive control for the test above: a key that genuinely holds
+        write scope must still work end to end — otherwise the 403 above
+        would be meaningless (a broken chain 403s on everything)."""
+        share = make_folder_share(db_session, test_user)
+        raw_key = make_agent_key(db_session, share, scopes="read,write")
+        file_token = self._mint(client, share.id, raw_key)
+
+        mock_client = MagicMock()
+        mock_client.bucket_exists.return_value = True
+        mock_client.presigned_put_object.return_value = "https://minio.test/presigned-put"
+        with patch("app.api.routers.shares._get_minio_client", return_value=mock_client):
+            resp = client.post(
+                f"{BASE}/{share.id}/files/attachments/photo.png/upload-url",
+                headers={"Authorization": f"Bearer {file_token}"},
+            )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["uploadUrl"] == "https://minio.test/presigned-put"
+        mock_client.presigned_put_object.assert_called_once()

--- a/apps/control-plane/tests/test_agent_key_sync_protocol.py
+++ b/apps/control-plane/tests/test_agent_key_sync_protocol.py
@@ -7,7 +7,7 @@ user JWTs only, so the agent key a Mesh project is configured with could write
 bytes through /v1/web/.../sync-upload but could not learn a document's hash —
 and therefore could not write safely.
 
-These tests pin three things:
+These tests pin four things:
   1. the SAME agent key now reads hash+mtime and writes through this protocol;
   2. a write whose If-Match does not match the stored sha256 is refused AND
      leaves the stored bytes untouched — asserted on the document body, not on
@@ -15,7 +15,11 @@ These tests pin three things:
      is indistinguishable from an honest one by status alone;
   3. the scope boundary did not widen: read-only cannot write, write-only cannot
      read, a key is still confined to its own share, and it still buys nothing
-     on the user-only share-management routes.
+     on the user-only share-management routes;
+  4. a read-scoped key can also mint an attachment file-token (POST
+     .../file-token — symmetric extension, #d4c851af finding 3) and the whole
+     chain down to a presigned URL works off that token; a key without read
+     scope still cannot.
 """
 
 from __future__ import annotations
@@ -489,6 +493,83 @@ class TestStaleWriteIsRefusedAndChangesNothing:
         minio.put_object.assert_not_called()
 
 
+# ── 3b. ё and other non-ASCII letters are not path-invalid (finding 4) ───────
+
+
+class TestUnicodePaths:
+    """`_ALLOWED_FILE_PATH_RE` used to enumerate a Cyrillic alphabet range
+    (А-Яа-я) that excludes ё/Ё (U+0451/U+0401 sort outside that block) — and
+    would have excluded ANY other script's letters (ї, ә, é, ...) the same
+    way. Fixed to a property-based check (\\w, Unicode-aware) instead of an
+    alphabet enumeration."""
+
+    def test_document_with_yo_can_be_created_and_read(
+        self, client: TestClient, test_user: models.User, db_session: Session, minio
+    ):
+        share = make_folder_share(db_session, test_user)
+        raw_key = make_agent_key(db_session, share)
+        path = "Ёлка.md"
+
+        create = client.put(
+            f"{BASE}/{share.id}/sync-write",
+            params={"path": path},
+            content="про ёлку".encode("utf-8"),
+            headers=key_headers(raw_key, **{"Content-Type": "text/markdown", "If-None-Match": "*"}),
+        )
+        assert create.status_code == 200, create.text
+        assert read_body(client, share.id, raw_key, path) == "про ёлку"
+
+        index = client.get(f"{BASE}/{share.id}/files-index", headers=key_headers(raw_key)).json()
+        assert any(e["path"] == path for e in index)
+
+    def test_document_with_yo_mid_word_can_be_created(
+        self, client: TestClient, test_user: models.User, db_session: Session, minio
+    ):
+        share = make_folder_share(db_session, test_user)
+        raw_key = make_agent_key(db_session, share)
+        path = "Всё о релизе.md"
+
+        create = client.put(
+            f"{BASE}/{share.id}/sync-write",
+            params={"path": path},
+            content=b"release notes",
+            headers=key_headers(raw_key, **{"Content-Type": "text/markdown", "If-None-Match": "*"}),
+        )
+        assert create.status_code == 200, create.text
+
+    def test_diacritic_path_can_be_created(
+        self, client: TestClient, test_user: models.User, db_session: Session, minio
+    ):
+        share = make_folder_share(db_session, test_user)
+        raw_key = make_agent_key(db_session, share)
+        path = "café.md"
+
+        create = client.put(
+            f"{BASE}/{share.id}/sync-write",
+            params={"path": path},
+            content=b"notes",
+            headers=key_headers(raw_key, **{"Content-Type": "text/markdown", "If-None-Match": "*"}),
+        )
+        assert create.status_code == 200, create.text
+
+    def test_traversal_still_rejected_alongside_widened_alphabet(
+        self, client: TestClient, test_user: models.User, db_session: Session, minio
+    ):
+        """The alphabet widening must not loosen the separate `..`/depth/length
+        checks in _validate_file_path — those run before the regex either way."""
+        share = make_folder_share(db_session, test_user)
+        raw_key = make_agent_key(db_session, share)
+
+        resp = client.put(
+            f"{BASE}/{share.id}/sync-write",
+            params={"path": "../../etc/passwd"},
+            content=b"pwned",
+            headers=key_headers(raw_key, **{"Content-Type": "text/markdown", "If-None-Match": "*"}),
+        )
+        assert resp.status_code == 400
+        minio.put_object.assert_not_called()
+
+
 # ── 4. the scope boundary did not widen ──────────────────────────────────────
 
 
@@ -592,12 +673,13 @@ class TestScopeBoundary:
         )
         assert resp.status_code == 401
 
-    def test_key_cannot_mint_a_file_token(
+    def test_write_only_key_cannot_mint_a_file_token(
         self, client: TestClient, test_user: models.User, db_session: Session
     ):
-        """file-token is the CAS/attachment credential — still user-JWT only."""
+        """Minting only ever required read (mirrors the user-JWT floor at
+        create_file_token) — write does not imply read (ADR-0001)."""
         share = make_folder_share(db_session, test_user)
-        raw_key = make_agent_key(db_session, share)
+        raw_key = make_agent_key(db_session, share, scopes="write")
 
         resp = client.post(
             f"{BASE}/{share.id}/file-token",
@@ -609,7 +691,8 @@ class TestScopeBoundary:
             },
             headers=key_headers(raw_key),
         )
-        assert resp.status_code == 401
+        assert resp.status_code == 403
+        assert "read scope" in err_message(resp)
 
     def test_write_rejects_non_folder_share(
         self, client: TestClient, test_user: models.User, db_session: Session, minio
@@ -723,3 +806,100 @@ class TestUserJwtPathUnchanged:
             f"{BASE}/{share.id}/files-index", headers={"Authorization": f"Bearer {token}"}
         )
         assert resp.status_code == 403
+
+
+# ── 6. agent key reaches the attachment file-token chain (finding 3) ─────────
+
+
+class TestAgentKeyFileToken:
+    def test_read_scoped_key_can_mint(
+        self, client: TestClient, test_user: models.User, db_session: Session
+    ):
+        share = make_folder_share(db_session, test_user)
+        raw_key = make_agent_key(db_session, share, scopes="read")
+
+        resp = client.post(
+            f"{BASE}/{share.id}/file-token",
+            json={
+                "path": "attachments/photo.png",
+                "sha256": "a" * 64,
+                "content_type": "image/png",
+                "content_length": 12345,
+            },
+            headers=key_headers(raw_key),
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["token"]
+
+    def test_minted_token_reaches_a_presigned_download_url(
+        self, client: TestClient, test_user: models.User, db_session: Session
+    ):
+        """End to end: an agent key with no models.User of its own can still
+        walk file-token -> download-url, because the token's subject falls
+        back to the share owner and the owner always clears ensure_read_access."""
+        share = make_folder_share(db_session, test_user)
+        raw_key = make_agent_key(db_session, share, scopes="read")
+
+        mint_resp = client.post(
+            f"{BASE}/{share.id}/file-token",
+            json={
+                "path": "attachments/photo.png",
+                "sha256": "a" * 64,
+                "content_type": "image/png",
+                "content_length": 12345,
+            },
+            headers=key_headers(raw_key),
+        )
+        assert mint_resp.status_code == 200, mint_resp.text
+        file_token = mint_resp.json()["token"]
+
+        mock_client = MagicMock()
+        mock_client.bucket_exists.return_value = True
+        mock_client.stat_object.return_value = MagicMock()
+        mock_client.presigned_get_object.return_value = "https://minio.test/presigned-get"
+        with patch("app.api.routers.shares._get_minio_client", return_value=mock_client):
+            dl_resp = client.get(
+                f"{BASE}/{share.id}/files/attachments/photo.png/download-url",
+                headers={"Authorization": f"Bearer {file_token}"},
+            )
+        assert dl_resp.status_code == 200, dl_resp.text
+        assert dl_resp.json()["downloadUrl"] == "https://minio.test/presigned-get"
+
+    def test_write_only_key_still_cannot_mint(
+        self, client: TestClient, test_user: models.User, db_session: Session
+    ):
+        share = make_folder_share(db_session, test_user)
+        raw_key = make_agent_key(db_session, share, scopes="write")
+
+        resp = client.post(
+            f"{BASE}/{share.id}/file-token",
+            json={
+                "path": "attachments/photo.png",
+                "sha256": "a" * 64,
+                "content_type": "image/png",
+                "content_length": 12345,
+            },
+            headers=key_headers(raw_key),
+        )
+        assert resp.status_code == 403
+        assert "read scope" in err_message(resp)
+
+    def test_key_cannot_mint_for_another_share(
+        self, client: TestClient, test_user: models.User, db_session: Session
+    ):
+        mine = make_folder_share(db_session, test_user)
+        theirs = make_folder_share(db_session, test_user)
+        raw_key = make_agent_key(db_session, mine, scopes="read")
+
+        resp = client.post(
+            f"{BASE}/{theirs.id}/file-token",
+            json={
+                "path": "attachments/photo.png",
+                "sha256": "a" * 64,
+                "content_type": "image/png",
+                "content_length": 12345,
+            },
+            headers=key_headers(raw_key),
+        )
+        assert resp.status_code == 403
+        assert "not valid for this share" in err_message(resp)

--- a/apps/control-plane/tests/test_web_publish.py
+++ b/apps/control-plane/tests/test_web_publish.py
@@ -1227,6 +1227,49 @@ class TestFolderFileContentSync:
 
         get_settings.cache_clear()
 
+    def test_sync_folder_file_content_stamps_hash_and_becomes_sync_visible(
+        self, client: TestClient, db_session: Session, folder_share: models.Share, monkeypatch
+    ):
+        """#d4c851af finding 1/2: this is the plugin's actual content-push path
+        (the /shares/{id} PATCH web_folder_items list never carries content).
+        Before the fix the pushed item had content but no sha256/source, so it
+        was invisible to GET /v1/shares/{id}/files-index (source=="sync-artifact"
+        AND non-empty sha256) and unwritable through PUT /sync-write."""
+        monkeypatch.setenv("WEB_PUBLISH_DOMAIN", "docs.test.com")
+        from app.core.config import get_settings
+
+        get_settings.cache_clear()
+
+        raw_key, _ = self._make_agent_key(db_session, folder_share, scopes="write")
+        content = "# Document 1\n\nThis is the content."
+        response = client.post(
+            f"/v1/web/shares/{folder_share.web_slug}/files?path=doc1.md",
+            json={"content": content},
+            headers={"X-Agent-Key": raw_key},
+        )
+        assert response.status_code == 200, response.text
+
+        db_session.refresh(folder_share)
+        items = folder_share.web_folder_items or []
+        entry = next(i for i in items if i.get("path") == "doc1.md")
+        expected_sha256 = hashlib.sha256(content.encode("utf-8")).hexdigest()
+        assert entry["sha256"] == expected_sha256
+        assert entry["size"] == len(content.encode("utf-8"))
+        assert entry["source"] == "sync-artifact"
+        assert entry["modified_at"]
+
+        read_key, _ = self._make_agent_key(db_session, folder_share, scopes="read")
+        index_resp = client.get(
+            f"/v1/shares/{folder_share.id}/files-index", headers={"X-Agent-Key": read_key}
+        )
+        assert index_resp.status_code == 200, index_resp.text
+        indexed = {item["path"]: item for item in index_resp.json()}
+        assert "doc1.md" in indexed, "pushed content must be visible through the sync protocol"
+        assert indexed["doc1.md"]["sha256"] == expected_sha256
+        assert indexed["doc1.md"]["updated_at"]
+
+        get_settings.cache_clear()
+
     def test_sync_folder_file_content_fake_bearer_returns_401(
         self, client: TestClient, folder_share: models.Share, monkeypatch
     ):
@@ -1824,6 +1867,9 @@ class TestFolderItemsContentMerge:
                     "content": "# Original",
                     "storage_key": "web-assets/keep-key",
                     "sha256": "abc123",
+                    "size": 10,
+                    "modified_at": "2026-08-19T12:00:00+00:00",
+                    "source": "sync-artifact",
                 },
                 {
                     "path": "remove.md",
@@ -1845,7 +1891,13 @@ class TestFolderItemsContentMerge:
         folder_share: models.Share,
         test_user: models.User,
     ):
-        """AC1: PATCH with web_folder_items does not erase content/storage_key/sha256."""
+        """AC1: PATCH with web_folder_items does not erase content/storage_key/sha256/
+        size/modified_at/source. The last two were dropped by this merge (#d4c851af
+        finding 2) until sync_folder_file_content started stamping them: a routine
+        nav-tree-only PATCH — WebSyncManager fires one on every create/rename/delete —
+        would otherwise silently re-empty files-index's `updated_at` on the very next
+        sync, without touching sha256, so the symptom would reappear a moment after
+        being fixed."""
         token = self._login(client, test_user)
 
         r = client.patch(
@@ -1866,6 +1918,9 @@ class TestFolderItemsContentMerge:
         assert items["keep.md"].get("content") == "# Original"
         assert items["keep.md"].get("storage_key") == "web-assets/keep-key"
         assert items["keep.md"].get("sha256") == "abc123"
+        assert items["keep.md"].get("size") == 10
+        assert items["keep.md"].get("modified_at") == "2026-08-19T12:00:00+00:00"
+        assert items["keep.md"].get("source") == "sync-artifact"
 
     def test_patch_new_path_has_no_content(
         self,

--- a/docs/agent-keys.md
+++ b/docs/agent-keys.md
@@ -120,6 +120,7 @@ it, with the same literal scopes:
 | `GET /v1/shares/{id}/files-index` | `read` | returns `path`, `sha256`, `size`, `updated_at` per document |
 | `GET /v1/shares/{id}/download?path=…` | `read` | body, plus `ETag: "<sha256>"` and `X-Updated-At` |
 | `PUT /v1/shares/{id}/sync-write?path=…` | `write` | conditional write — see below |
+| `POST /v1/shares/{id}/file-token` | `read` | mints an attachment (CAS) token — see below |
 
 `sync-write` **requires** a precondition; there is no unconditional form:
 
@@ -148,8 +149,15 @@ curl -sf -X PUT "https://cp.yourdomain.com/v1/shares/$SHARE_ID/sync-write?path=n
 A document written this way lands as `source=sync-artifact`, exactly like one uploaded through
 `/v1/web/shares/{id}/sync-upload`, so the Obsidian plugin picks it up on its next inbound cycle.
 
-Share management stays user-only: an agent key cannot list shares, delete a share, change members,
-or mint attachment file-tokens.
+`POST /v1/shares/{id}/file-token` (with a `read`-scoped key) mints the same short-lived, path-scoped
+token a browser session would get, so an attachment reachable only through the presigned-URL chain
+(`HEAD .../files/{path}`, `GET .../download-url`, `POST .../upload-url`) is reachable by a key too —
+e.g. resolving `![[image.png]]` when rendering a synced document. The minted token is not itself
+tied to the key: it carries the share owner as its subject, since an agent key has no `User` of its
+own, and the three consuming routes re-check `read`/`write` access against that subject exactly as
+they do for a real session.
+
+Share management stays user-only: an agent key cannot list shares, delete a share, or change members.
 
 ### Changing the scopes of an existing key
 


### PR DESCRIPTION
## Summary

Three gaps found while verifying #212's agent-key scope extension against real data:

1. **`POST /shares/{slug}/files`** is the plugin's actual content-push path (`PATCH /shares/{id}` with `web_folder_items` never carries content, only path/name/type) — it stamped `content` but never `sha256`/`size`/`modified_at`/`source`, so every document pushed this way was permanently excluded from `GET .../files-index` (`source == "sync-artifact" AND sha256` filter) and unwritable through `PUT .../sync-write`. Now stamps all four. Backfilled existing rows via a one-time migration, narrowly scoped to items that have `content` but no `source` at all (so `mesh-artifact`/`user-upload` items, which are deliberately excluded from the sync protocol, are untouched).
2. Found while fixing (1): `share_service.update_share`'s folder-items merge preserved `content`/`source`/`storage_key`/`sha256` from an existing item on a nav-tree-only PATCH, but **not** `size`/`modified_at`. Since `WebSyncManager` fires exactly that kind of PATCH on every create/rename/delete, the very next sync after (1)'s fix would have silently re-emptied `updated_at` without touching `sha256` — reproducing the same symptom a moment after "fixing" it. Added `size`/`modified_at` to the preserved-key list.
3. `POST /{share_id}/file-token` was user-JWT-only; extended to accept `X-Agent-Key` (`read` scope), symmetric to files-index/download/sync-write. An agent key has no `models.User`, so the minted token's subject falls back to the share owner — the three consuming routes (`HEAD`/`download-url`/`upload-url`) re-check `read`/`write` access against that subject and the owner always clears it, so the token's own path/share/expiry scope is what actually limits the caller.
4. `_ALLOWED_FILE_PATH_RE`/`_ALLOWED_PATH_RE` enumerated a Cyrillic alphabet range (`А-Яа-я`) that excludes `ё`/`Ё` (outside that Unicode block) and would exclude any other script's letters the same way (`café.md` was also rejected). Replaced with a `\w`-based Unicode-aware property check in both copies; the separate `..`/leading-slash/depth/length guards that run before it are untouched.

## Not in this PR

There's a leftover probe artifact (`_probe/ee1745ce-sync-write-probe.md`) on one share from earlier live-testing. There is no per-file DELETE route in any share-API family, so nothing to wire a cleanup into here.

Live verification of the exact before/after file-count on real data hasn't happened yet — this fix isn't deployed. (Earlier revision of this description claimed an SSH host-key mismatch blocked that verification; that was a false alarm on my end — a shell variable was empty, not the host's key — access is fine. Will verify post-merge/deploy.)

## Test plan

- [x] `uv run ruff check app/ tests/` — clean
- [x] `uv run ruff format --check app/ tests/` — clean
- [x] `uv run alembic heads` — exactly one head (`202608200001`)
- [x] `uv run pytest tests/` — **753 passed, 1 skipped, 0 failed** (754 collected; 9 new tests added, 1 stale test updated)
- [x] New migration verified end-to-end against a throwaway `postgres:16-alpine` container: ran the full alembic chain from empty, then inserted synthetic `web_folder_items` covering all four preserve/skip cases (no-source+content → backfilled; already `sync-artifact` → untouched; `mesh-artifact`+no content → untouched; `source: null`+content → backfilled) and confirmed the JSONB output by hand
- [x] New tests cover: file-token minted by a `read`-scoped agent key reaching a presigned download URL end-to-end; `write`-only key still refused (403, "read scope"); cross-share containment (403, "not valid for this share"); `Ёлка.md`/`Всё о релизе.md`/`café.md` created via `sync-write` and read back; path traversal still rejected alongside the widened alphabet; content-push stamping sha256/size/source and becoming sync-visible; the merge-preserve regression (size/modified_at surviving a follow-up nav-tree PATCH)

— Daedalus, Entire VC
