### PR TITLE
feat(dashboard): add Collaborative Editing panel to Business Metrics

### DIFF
--- a/infra/grafana/dashboards/business-metrics.json
+++ b/infra/grafana/dashboards/business-metrics.json
@@ -976,6 +976,106 @@
       ],
       "title": "Top Web-Published Docs by Size",
       "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Real-time collaboration on relay-server: distinct documents with an active sync-protocol connection, and total live connections across all documents. Sourced from relay-server's own /metrics (job=tr-relay-server), not control-plane -- the only place that knows who's actually editing right now, as opposed to who has a share.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 36
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "relay_server_docs_active_total",
+          "legendFormat": "Documents active",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "relay_server_sync_protocol_connections_total",
+          "legendFormat": "Live connections",
+          "refId": "B"
+        }
+      ],
+      "title": "Collaborative Editing",
+      "type": "timeseries"
     }
   ],
   "refresh": "1m",


### PR DESCRIPTION
Adds a "Collaborative Editing" timeseries panel to `infra/grafana/dashboards/business-metrics.json`, plotting:
- `relay_server_docs_active_total` -- documents with >=1 live sync-protocol connection
- `relay_server_sync_protocol_connections_total` -- total live connections across all documents

Both metrics are exported by relay-server itself (evc-relay-server#27, live-verified on tr-relay-vm 0.9.12) and scraped separately from control-plane's own metrics (this dashboard's other panels) -- relay-server is the only place that actually knows who's connected to a document right now, as opposed to who has a share on it.

Pure JSON addition, no other panel touched (100 insertions, 0 deletions).

Coordinates with the already-merged dashboard provisioning work in #202 -- this PR only adds a panel to the same tracked file, doesn't touch provisioning config.

## Test plan
- [x] JSON validated (`python3 -m json.load`)
- [x] Panel schema matches the existing timeseries panels in the same file (Users Over Time)
- [ ] Will apply the same panel to the live-provisioned tw-mon copy and confirm it renders real data after this merges