### PR TITLE
fix(auth): create_relay_token_cwt default issuer to a relay-server-allowlisted value

### DIFF
--- a/apps/control-plane/app/core/security.py
+++ b/apps/control-plane/app/core/security.py
@@ -215,7 +215,7 @@ def create_relay_token_cwt(
     mode: str,
     expires_minutes: int,
     audience: str | None = None,
-    issuer: str = "relay-control-plane",
+    issuer: str = "relay-server",
     share_id: str | None = None,
 ) -> str:
     """Create CWT (CBOR Web Token) for relay-server authentication.
@@ -267,9 +267,13 @@ def create_relay_token_cwt(
             tokens with no aud claim (MissingAudience) once it knows to expect one.
         issuer: Token issuer. Must be one of relay-server's VALID_ISSUERS allowlist
             ("relay-server", "auth.system3.dev", "auth.system3.md" as of image 0.9.9) —
-            see Settings.relay_token_issuer. Default kept at "relay-control-plane" for
-            call-site backward-compat, but callers going through token_service.py
-            override this via settings.relay_token_issuer.
+            see Settings.relay_token_issuer. Default is "relay-server", matching
+            Settings.relay_token_issuer's own default (#7908e17e — the previous
+            default here, "relay-control-plane", is NOT in the allowlist and was
+            enshrined as "correct" by two tests that have since been rewritten to
+            assert allowlist membership instead; callers going through
+            token_service.py still override this explicitly via
+            settings.relay_token_issuer).
         share_id: Share UUID the token was issued against (added as CWT_CLAIM_SHARE)
 
     Returns:

--- a/apps/control-plane/tests/test_cwt_tokens.py
+++ b/apps/control-plane/tests/test_cwt_tokens.py
@@ -27,6 +27,13 @@ from app.core.security import (
     verify_relay_token_cwt,
 )
 
+# Mirrors relay-server's own allowlist (ghcr.io/entire-vc/evc-relay-server,
+# crates/y-sweet-core/src/auth.rs VALID_ISSUERS, as of image 0.9.9). Not
+# imported from there — different repo/language — so this is a deliberate
+# duplicate, not a shared source of truth; if relay-server's allowlist ever
+# changes, this constant must be updated by hand (#7908e17e).
+RELAY_SERVER_VALID_ISSUERS = ("relay-server", "auth.system3.dev", "auth.system3.md")
+
 # ── Helpers ──────────────────────────────────────────────────
 
 
@@ -303,12 +310,30 @@ class TestCWTClaims:
         _, claims, _, _ = _decode_cwt_raw(token)
         assert CWT_CLAIM_SHARE not in claims
 
-    def test_iss_claim(self):
+    def test_iss_claim_default_is_relay_server_allowlisted(self):
+        """The default issuer must be one relay-server actually accepts.
+
+        Regression test for #7908e17e: the previous default,
+        "relay-control-plane", is NOT in relay-server's VALID_ISSUERS and was
+        rejected with InvalidClaims — this test used to assert that rejected
+        value as the expected/correct behavior, enshrining the bug rather
+        than catching it. Assert allowlist membership, not a specific string,
+        so a future default change that's still valid doesn't spuriously
+        break this test.
+        """
         private_key, _ = _make_keypair()
         token = create_relay_token_cwt(private_key, "k1", "doc-123", "write", 60)
 
         _, claims, _, _ = _decode_cwt_raw(token)
-        assert claims[CWT_CLAIM_ISS] == "relay-control-plane"
+        assert claims[CWT_CLAIM_ISS] in RELAY_SERVER_VALID_ISSUERS
+
+    def test_relay_control_plane_issuer_is_not_allowlisted(self):
+        """Negative control for the above: prove the OLD default really would
+        have failed relay-server's check, so the positive assertion isn't
+        vacuously true. If relay-server's allowlist ever grows to include
+        "relay-control-plane", this test should be deleted, not weakened.
+        """
+        assert "relay-control-plane" not in RELAY_SERVER_VALID_ISSUERS
 
     def test_custom_issuer(self):
         private_key, _ = _make_keypair()
@@ -365,7 +390,9 @@ class TestCWTVerification:
 
         claims = verify_relay_token_cwt(public_key, token)
 
-        assert claims["iss"] == "relay-control-plane"
+        # See test_iss_claim_default_is_relay_server_allowlisted (#7908e17e)
+        # for why this asserts allowlist membership, not a specific value.
+        assert claims["iss"] in RELAY_SERVER_VALID_ISSUERS
         assert claims["scope"] == "doc:doc-abc:rw"
         assert "iat" in claims
 


### PR DESCRIPTION
## Summary

`create_relay_token_cwt`'s default `issuer` value ("relay-control-plane") is not in relay-server's `VALID_ISSUERS` allowlist and gets rejected with `InvalidClaims`. Harmless today (the one production call site, `token_service.py`, already passes `issuer=` explicitly) but two tests asserted the rejected value as correct — enshrining the bug, so a future caller that forgot `issuer=` would pass CI and silently break prod auth (same class as the prior 6-month outage, #f3cb5365).

Fixed the default to `"relay-server"` — the same value `Settings.relay_token_issuer` already defaults to.

## Deviation from the task author's stated preference

The task suggested making `issuer` a required kwarg instead (option 2) as the safer fix. I went with fixing the default (option 1) because grepping `test_cwt_tokens.py` found **22 unrelated call sites** relying on the default (testing exp/ttl/doc_id/scope/etc., not issuer behavior) — requiring all of them to pass `issuer=` would be pure mechanical churn for zero additional safety, since the actual risk this task cares about (a *future production* caller forgetting `issuer=`) is caught identically either way: a valid default gets issued instead of a rejected one. Happy to revisit if there's a reason to prefer the loud-failure-on-omission behavior specifically.

## Test plan
- [x] Rewrote the two tests that asserted the old (rejected) default as correct — `test_iss_claim` → `test_iss_claim_default_is_relay_server_allowlisted` (asserts allowlist membership, not a literal string), and `test_roundtrip_verify` (same change).
- [x] Added `test_relay_control_plane_issuer_is_not_allowlisted` — negative control proving the old default really would fail relay-server's check, so the positive assertion above isn't vacuously true.
- [x] `uv run pytest -k cwt` — 33 passed.
- [x] `uv run pytest` (full suite) — 756 passed, 1 skipped, 0 failed.
- [ ] Live WS-upgrade probe against tr-relay-vm post-deploy (will paste to the tracking task).