### PR TITLE
fix(control-plane): lock Docker image deps to uv.lock, not a fresh pip resolve

### DIFF
--- a/apps/control-plane/Dockerfile
+++ b/apps/control-plane/Dockerfile
@@ -1,8 +1,14 @@
 FROM python:3.12-slim
 
+# Pin the uv binary itself (not just what it resolves) so the build tool is
+# reproducible too, not only the Python deps it locks in.
+COPY --from=ghcr.io/astral-sh/uv:0.12.5 /uv /uvx /usr/local/bin/
+
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
-    PYTHONPATH=/app
+    PYTHONPATH=/app \
+    UV_PROJECT_ENVIRONMENT=/app/.venv \
+    PATH="/app/.venv/bin:$PATH"
 
 WORKDIR /app
 
@@ -10,11 +16,14 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends build-essential libpq-dev && \
     rm -rf /var/lib/apt/lists/*
 
-COPY pyproject.toml /app/pyproject.toml
+COPY uv.lock pyproject.toml /app/
 COPY app /app/app
 COPY alembic.ini /app/alembic.ini
 
-RUN pip install --upgrade pip && pip install --no-cache-dir .
+# --locked fails the build if uv.lock is out of sync with pyproject.toml
+# instead of silently re-resolving; --no-dev excludes the [dependency-groups]
+# dev group (pytest/pytest-asyncio) from the production image.
+RUN uv sync --locked --no-dev
 
 # Non-root runtime user. admin_ui.py writes uploaded favicons/logos to
 # app/static/uploads at runtime, so that path needs to be writable by it.


### PR DESCRIPTION
## Problem

`apps/control-plane/Dockerfile` copied only `pyproject.toml` and ran a bare
`pip install .`. `uv.lock` was never copied into the build context and never
used — dependencies re-resolved fresh on every build within `pyproject.toml`'s
version ranges, so image contents were non-deterministic across builds of the
same commit (spot-checked: `fastapi` resolved to 0.141.1 unlocked vs 0.136.3
per `uv.lock`, among ~30 other packages that moved).

## Fix

- `COPY uv.lock pyproject.toml /app/` instead of just `pyproject.toml`
- `RUN uv sync --locked --no-dev` instead of `pip install .`
  - `--locked` fails the build (instead of silently re-resolving) if the lock
    ever drifts from `pyproject.toml`
  - `--no-dev` excludes the `[dependency-groups]` dev group
    (`pytest`/`pytest-asyncio`) from the production image
- `uv` itself is copied in from a pinned tag (`ghcr.io/astral-sh/uv:0.12.5`)
  rather than `:latest`, so the build tool is reproducible too, not just what
  it resolves
- `PATH`/`UV_PROJECT_ENVIRONMENT` wired so the venv `uv sync` creates at
  `/app/.venv` is actually on `PATH` at runtime (this exact gap — green build,
  `ModuleNotFoundError` at runtime — bit a sibling repo, contenthub, per the
  precedent linked in the task)

## Verification

1. **Baseline healthy first** (per contenthub `#79c92860` precondition — don't
   lock in an already-broken resolve): built the unlocked Dockerfile as-is,
   `python -c "import app"` succeeded, captured baseline `pip list`.
2. **Two `--no-cache` builds from the identical (post-fix) Dockerfile
   content** produced byte-identical `uv pip list` output (`diff` empty).
3. **Spot-checked** `fastapi`/`bcrypt`/`cryptography`/`pydantic`/`sqlalchemy`/
   `authlib`/`cbor2`/`minio`/`alembic`/`uvicorn` versions in the built image
   against `uv.lock` — exact match on all 10.
4. **Diffed locked image vs. the unlocked baseline**: every version that
   differs moved *down* to the locked value (expected — locking pins to what
   was resolvable when `uv.lock` was generated); nothing present in the
   baseline is missing from the locked image (except `pip` itself, which
   uv's minimal venv doesn't seed — expected, not a functional gap).
5. **Full smoke test, not just import**: ran the locked image against a
   throwaway local Postgres (no prod contact), applied `alembic upgrade head`
   cleanly, started the container with generated secrets
   (`JWT_SECRET`/`MINIO_*`/`RELAY_PRIVATE_KEY` — the app fail-closes on the
   insecure defaults, which is correct behavior, not a regression), and
   `GET /v1/health` returned `200 {"ok":true}`.

Full evidence (baseline vs. locked pip lists, build logs, health-check output)
is in the Mesh task comment.

There is a pre-existing, unrelated `semgrep` failure on `main` right now
(unpinned `actions/checkout@v4` in `.github/workflows/hold-gate.yml`) — not
touched by this change.