### PR TITLE
fix(infra): bump relay-server pin 0.9.9 -> 0.9.12 to match live prod

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -239,7 +239,7 @@ services:
         condition: service_completed_successfully
 
   relay-server:
-    image: ghcr.io/entire-vc/evc-relay-server:0.9.9
+    image: ghcr.io/entire-vc/evc-relay-server:0.9.12
     depends_on:
       minio:
         condition: service_healthy


### PR DESCRIPTION
The product-repo compose file was two releases behind our own live
deployment. A self-hoster following this repo's docs got a build we
don't actually operate; a naive redeploy from this repo onto our live
instance would have silently downgraded relay-server 0.9.12 -> 0.9.9.

0.9.9 -> 0.9.12 delta (evc-relay-server compare relay-0.9.9..relay-0.9.12):
- fix: upstream filemeta path-traversal guard + Yrs delete-handling
  backport (server-side hardening against `../` writes to filemeta_v0)
- fix(auth): log the previously-silent key_id auth-mismatch failure
  path + add relay_server_http_auth_success_total counter
- feat(metrics): relay_server_docs_active_total gauge +
  doc_connections_opened_total/closed_total counters, plus a fix for
  a per-doc_id cardinality leak in the existing subscriptions gauge
  (dead label values were never removed, only zeroed)
- ci/docs/repo hygiene (CI gate, README, SECURITY.md, SUPPORT.md,
  issue templates, drop unused upstream y-sweet-worker/python/debugger
  trees)

No relay.toml or environment changes required for this bump — no new
config keys, no new required env vars, across either hop (0.9.9→0.9.10
or 0.9.10→0.9.12).

## Note: our internal ops-repo tracked pin is still 0.9.10

Our own deployment runs 0.9.12 (confirmed live via `docker ps` right
before this bump), matching what this PR now pins. Our internal
ops-repo's tracked copy is still at 0.9.10 — one release behind. That
gap is smaller and out of scope for this change; noting it here rather
than fixing it in this PR.

Not merging this myself — held pending review.

## Verification (against the 0.9.12 image, local Docker stack)

Stack: postgres + minio + control-plane (built from this repo,
freshly-generated local secrets, never touches prod) + relay-server
pulled from ghcr at :0.9.12.

**Pin now matches live**:
```
- image: ghcr.io/entire-vc/evc-relay-server:0.9.9
+ image: ghcr.io/entire-vc/evc-relay-server:0.9.12
```

**Live WS-upgrade returns 101** (real CWT doc token minted via
control-plane's own token-issuing code path, real doc created via
`/doc/new` with a server-scoped token, real `websockets` client
connecting from inside the compose network):
```
CONNECTED, response status: 101 Switching Protocols
Response headers: {'connection': 'upgrade', 'upgrade': 'websocket',
'sec-websocket-accept': 'knORMSlqWch8Opm9JU+cUcl00UM=',
'relay-server-version': '0.9.12', 'date': 'Thu, 20 Aug 2026 21:05:21 GMT'}
CLOSED CLEANLY
```
(`relay-server-version: 0.9.12` response header independently confirms
the image actually serving the request.)

**`relay_server_sync_protocol_connections_total` present and
non-zero while a real sync connection is open** (not just "service
started"), scraped mid-connection:
```
relay_server_docs_active_total 1
relay_server_sync_protocol_connections_total 1
```
(0.9.12 also exposes `doc_connections_opened_total`/`closed_total` and
`docs_active_total`, new in this delta — all observed incrementing
correctly across a real connect/close cycle during this same run.)

Local verification stack torn down after testing (`docker compose down -v`),
generated secrets and `relay.toml`/`.env` deleted, not committed.