### PR TITLE
fix(control-plane): make web_doc_id write-once, never overwrite an existing value

### DIFF
--- a/apps/control-plane/app/services/share_service.py
+++ b/apps/control-plane/app/services/share_service.py
@@ -11,10 +11,13 @@ from sqlalchemy.orm import Session, joinedload
 
 from app.core import agent_key_scopes, security
 from app.core.config import get_settings
+from app.core.logging import get_logger
 from app.db import models
 from app.schemas import share as share_schema
 from app.services import audit_service
 from app.utils import slug as slug_utils
+
+logger = get_logger(__name__)
 
 
 def get_web_url(share: models.Share) -> str | None:
@@ -336,11 +339,36 @@ def update_share(
     if payload.web_content_updated_at is not None:
         share.web_content_updated_at = payload.web_content_updated_at
 
-    # Handle web doc_id update (y-sweet document ID for real-time sync)
+    # Handle web doc_id update (y-sweet document ID for real-time sync).
+    # `web_doc_id` is the storage key of the share's y-sweet document — the
+    # server signs it verbatim into the relay auth token (web.py). It is
+    # adopt-once: the plugin resends this field on every publish-toggle, so
+    # accepting a later, different value would silently repoint an already-
+    # live share at a DIFFERENT y-sweet document (content looks "vanished"
+    # to the user). Once a non-empty value is stored, it is immutable —
+    # a differing incoming value is ignored and logged, never applied
+    # (#54b07714).
     if payload.web_doc_id is not None:
-        old_doc_id = share.web_doc_id
-        changes["web_doc_id"] = {"old": old_doc_id is not None, "new": payload.web_doc_id != ""}
-        share.web_doc_id = payload.web_doc_id if payload.web_doc_id else None
+        if share.web_doc_id:
+            if payload.web_doc_id != share.web_doc_id:
+                logger.warning(
+                    "Ignoring attempt to change an already-set web_doc_id",
+                    extra={
+                        "share_id": str(share.id),
+                        "existing_web_doc_id": share.web_doc_id,
+                        "attempted_web_doc_id": payload.web_doc_id,
+                        "event": "web_doc_id_change_rejected",
+                    },
+                )
+                changes["web_doc_id"] = {
+                    "old": True,
+                    "new": True,
+                    "rejected_change": True,
+                }
+            # else: identical value resent (e.g. repeat publish-toggle) — no-op.
+        else:
+            changes["web_doc_id"] = {"old": False, "new": payload.web_doc_id != ""}
+            share.web_doc_id = payload.web_doc_id if payload.web_doc_id else None
 
     # TR-39: reject the RESULTING state of this update if it would leave the
     # share public + published with no content — regardless of which field(s)

--- a/apps/control-plane/tests/test_web_publish.py
+++ b/apps/control-plane/tests/test_web_publish.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import logging
 import secrets
 
 import pytest
@@ -1111,6 +1112,109 @@ class TestShareWebDocIdField:
         )
         assert update_response.status_code == 200
         assert update_response.json()["web_doc_id"] == test_doc_id
+
+    def test_repeat_publish_toggle_with_same_web_doc_id_does_not_change_it(
+        self, client: TestClient, test_user: models.User
+    ):
+        """#54b07714 AC#1: toggling publish twice in a row (plugin resends the
+        same web_doc_id on every toggle) leaves the stored value unchanged."""
+        login_response = client.post(
+            "/auth/login", json={"email": test_user.email, "password": "test123456"}
+        )
+        token = login_response.json()["access_token"]
+
+        create_response = client.post(
+            "/v1/shares",
+            json={
+                "kind": "doc",
+                "path": "DocId Repeat Toggle Test.md",
+                "visibility": "private",
+                "web_published": True,
+            },
+            headers=_auth_headers(token),
+        )
+        assert create_response.status_code == 201
+        share_id = create_response.json()["id"]
+
+        test_doc_id = "s3rn:relay:relay:repeat:folder:def:doc:ghi"
+
+        # First toggle: no existing value → sets it (AC#2, reverse direction).
+        first = client.patch(
+            f"/v1/shares/{share_id}",
+            json={"web_doc_id": test_doc_id},
+            headers=_auth_headers(token),
+        )
+        assert first.status_code == 200
+        assert first.json()["web_doc_id"] == test_doc_id
+
+        # Second toggle: plugin resends the identical value → must stay the same.
+        second = client.patch(
+            f"/v1/shares/{share_id}",
+            json={"web_doc_id": test_doc_id},
+            headers=_auth_headers(token),
+        )
+        assert second.status_code == 200
+        assert second.json()["web_doc_id"] == test_doc_id
+
+    def test_differing_web_doc_id_on_already_set_share_is_ignored_and_logged(
+        self, client: TestClient, test_user: models.User, caplog: pytest.LogCaptureFixture
+    ):
+        """#54b07714 AC#3: once web_doc_id is set, a DIFFERENT incoming value
+        (e.g. plugin re-encodes the id across a version bump) must not silently
+        repoint the share at another y-sweet document. Behavior is explicit:
+        ignore the new value and log a warning — never overwrite."""
+        login_response = client.post(
+            "/auth/login", json={"email": test_user.email, "password": "test123456"}
+        )
+        token = login_response.json()["access_token"]
+
+        create_response = client.post(
+            "/v1/shares",
+            json={
+                "kind": "doc",
+                "path": "DocId Mismatch Test.md",
+                "visibility": "private",
+                "web_published": True,
+            },
+            headers=_auth_headers(token),
+        )
+        assert create_response.status_code == 201
+        share_id = create_response.json()["id"]
+
+        original_doc_id = "s3rn:relay:relay:original:folder:def:doc:ghi"
+        first = client.patch(
+            f"/v1/shares/{share_id}",
+            json={"web_doc_id": original_doc_id},
+            headers=_auth_headers(token),
+        )
+        assert first.status_code == 200
+        assert first.json()["web_doc_id"] == original_doc_id
+
+        different_doc_id = "s3rn:relay:relay:DIFFERENT:folder:def:doc:ghi"
+        with caplog.at_level(logging.WARNING, logger="app.services.share_service"):
+            second = client.patch(
+                f"/v1/shares/{share_id}",
+                json={"web_doc_id": different_doc_id},
+                headers=_auth_headers(token),
+            )
+        # Request still succeeds (this is a soft ignore, not a client error) —
+        # but the STORED value must be the original, not the differing one.
+        assert second.status_code == 200
+        assert second.json()["web_doc_id"] == original_doc_id
+        assert second.json()["web_doc_id"] != different_doc_id
+
+        rejected_logs = [
+            r for r in caplog.records if getattr(r, "event", "") == "web_doc_id_change_rejected"
+        ]
+        assert len(rejected_logs) == 1
+        assert rejected_logs[0].existing_web_doc_id == original_doc_id
+        assert rejected_logs[0].attempted_web_doc_id == different_doc_id
+
+        # A follow-up GET (fresh read) confirms the DB row itself, not just the
+        # PATCH response, holds the original value.
+        get_response = client.get(f"/v1/shares/{share_id}", headers=_auth_headers(token))
+        assert get_response.status_code == 200
+        assert get_response.json()["web_doc_id"] == original_doc_id
 
 
 class TestWebRelayTokenEndpointRemoved:


### PR DESCRIPTION
## Summary

`web_doc_id` on the `shares` table is the y-sweet document storage key for a share's live-sync document — the server signs it verbatim into the relay auth token (`web.py`). The Obsidian plugin resends this field on every publish-toggle, and `update_share()` (`share_service.py`) overwrote it unconditionally whenever the payload included it — even when a value was already stored. Since the client's encoding of this ID can change across plugin versions/logic, this could silently repoint a live share at a *different* y-sweet document — to the user, indistinguishable from web-published content vanishing.

Not live-impacting today: prod check (2026-08-20) shows 0 of 78 shares have a non-empty `web_doc_id`, 0 in live web-publish mode. That's exactly why this is worth fixing now, before there's real data to migrate.

## Change

`web_doc_id` is now **adopt-once**:
- No existing value → first publish sets it (unchanged behavior).
- Existing value + identical incoming value (repeat toggle) → no-op, unchanged.
- Existing value + **differing** incoming value → **ignored and logged** (`logger.warning`, `event=web_doc_id_change_rejected`, includes share id + both values), never applied. The PATCH still returns 200 (soft-ignore, not a client error) but the stored/returned value is the original.

## Acceptance criteria (from internal tracker `#54b07714`)

1. **Repeated publish toggle does not change `web_doc_id`** — `test_repeat_publish_toggle_with_same_web_doc_id_does_not_change_it`: two consecutive PATCHes with the same value, both return the same stored id.
2. **First publish on a share with no existing value sets it correctly** — existing `test_update_share_with_web_doc_id` covers this (untouched, still green).
3. **Differing value on an already-set share is explicitly ignored + logged, not left to chance** — `test_differing_web_doc_id_on_already_set_share_is_ignored_and_logged`: PATCH with a different id after one is already set returns the *original* value (checked both in the PATCH response and via a fresh `GET`), and asserts a `web_doc_id_change_rejected` warning was logged with the expected `existing_web_doc_id`/`attempted_web_doc_id`.

## Test evidence

```
tests/test_web_publish.py -k WebDocId
3 passed, 76 deselected

tests/test_web_publish.py tests/test_folder_shares.py tests/test_auth_shares.py tests/test_public_content_guard.py
107 passed
```

`ruff check` / `ruff format --check` clean on both changed files.

## Review

This PR is not being merged by me — it's open for review before merge, per the process for this repo.
