### PR TITLE
fix(control-plane): issue relay tokens for the non-deprecated /d/:doc_id/ws route

### DIFF
--- a/apps/control-plane/app/core/config.py
+++ b/apps/control-plane/app/core/config.py
@@ -113,6 +113,39 @@ class Settings(BaseSettings):
         host = urlsplit(str(self.relay_public_url)).netloc
         return f"https://{host}"
 
+    def relay_doc_ws_url(self, doc_id: str) -> str:
+        """Per-doc client-connect URL for the non-deprecated relay-server route.
+
+        relay-server's crates/relay/src/server.rs logs a deprecation warning
+        on every connection through /doc/ws/:doc_id (the route relay_public_url
+        used to point clients at as a static, doc-independent prefix) and
+        recommends /d/:doc_id/ws/:doc_id2 instead — a route that requires the
+        SAME doc_id to appear in both path segments
+        (handle_socket_upgrade_full_path rejects a mismatch with 400). Both
+        routes share identical token verification (verify_socket_token) and
+        identical downstream connection handling, so this is a pure URL-shape
+        change, not a new interaction pattern.
+
+        The client-side YSweetProvider (obsidian-plugin src/client/provider.ts)
+        builds its final WS URL as f"{returned_url}/{doc_id}" (roomname is the
+        doc_id token.docId is keyed on) — so returning
+        "{scheme}://{host}/d/{doc_id}/ws" here makes the client land on
+        .../d/{doc_id}/ws/{doc_id}, satisfying the doubled-doc_id route.
+        This matches the ws_url relay-server's own POST /doc/:doc_id/auth
+        would compute (generate_context_aware_urls) for the same doc_id —
+        we don't call that endpoint (it requires a relay-server *server*
+        token via verify_server_token, a different credential than the
+        per-user CWT control-plane already mints), we just replicate the
+        URL shape it documents as canonical.
+
+        Scheme/host are taken from relay_public_url, dropping whatever path
+        it carries (historically a static "/doc/ws" suffix) — so existing
+        deployments don't need to change their env var; only the path this
+        method returns changes.
+        """
+        parsed = urlsplit(str(self.relay_public_url))
+        return f"{parsed.scheme}://{parsed.netloc}/d/{doc_id}/ws"
+
     bootstrap_admin_email: str | None = Field(default=None)
     bootstrap_admin_password: str | None = Field(default=None)
 

--- a/apps/control-plane/app/services/token_service.py
+++ b/apps/control-plane/app/services/token_service.py
@@ -161,8 +161,13 @@ def issue_relay_token(
         user_agent=request.headers.get("user-agent"),
     )
 
+    # TR (#b1e88884): relay-server deprecated the flat /doc/ws/:doc_id route
+    # this used to point clients at (static, doc-independent prefix) in favor
+    # of /d/:doc_id/ws/:doc_id2. relay_doc_ws_url() returns a per-doc URL —
+    # see its docstring in app/core/config.py for why this is a drop-in
+    # shape change, not a new client/server interaction pattern.
     return token_schema.RelayTokenResponse(
-        relay_url=str(settings.relay_public_url).rstrip("/"),
+        relay_url=settings.relay_doc_ws_url(payload.doc_id),
         token=token,
         expires_at=expires_at,
     )

--- a/apps/control-plane/tests/test_config_relay_audience.py
+++ b/apps/control-plane/tests/test_config_relay_audience.py
@@ -39,3 +39,30 @@ class TestEffectiveRelayAudience:
         """
         settings = Settings()
         assert settings.relay_token_issuer == "relay-server"
+
+
+class TestRelayDocWsUrl:
+    """Tests for Settings.relay_doc_ws_url (#b1e88884).
+
+    relay-server deprecated the flat /doc/ws/:doc_id route in favor of
+    /d/:doc_id/ws/:doc_id2 (doc_id doubled). The client-side YSweetProvider
+    appends "/<doc_id>" to whatever URL we return, so relay_doc_ws_url must
+    return ".../d/<doc_id>/ws" for the final connect URL to land on the
+    doubled-doc_id route with matching segments.
+    """
+
+    def test_builds_per_doc_path_dropping_configured_path(self):
+        """A leftover /doc/ws suffix on RELAY_PUBLIC_URL must be ignored —
+        only scheme+host survive, and the doc-specific /d/{doc_id}/ws path
+        is appended fresh."""
+        settings = Settings(relay_public_url="wss://tr.entire.vc/doc/ws")
+        assert settings.relay_doc_ws_url("abc-123") == "wss://tr.entire.vc/d/abc-123/ws"
+
+    def test_bare_relay_public_url_also_works(self):
+        settings = Settings(relay_public_url="wss://tr.entire.vc")
+        assert settings.relay_doc_ws_url("abc-123") == "wss://tr.entire.vc/d/abc-123/ws"
+
+    def test_different_doc_ids_get_different_urls(self):
+        settings = Settings(relay_public_url="wss://relay.test")
+        assert settings.relay_doc_ws_url("doc-a") == "wss://relay.test/d/doc-a/ws"
+        assert settings.relay_doc_ws_url("doc-b") == "wss://relay.test/d/doc-b/ws"

--- a/apps/control-plane/tests/test_relay_token_endpoint.py
+++ b/apps/control-plane/tests/test_relay_token_endpoint.py
@@ -130,6 +130,10 @@ class TestRelayTokenHappyPath:
         data = resp.json()
 
         assert data["relay_url"].startswith("wss://")
+        # #b1e88884: must land on relay-server's non-deprecated per-doc route
+        # (/d/:doc_id/ws/:doc_id2), not the flat /doc/ws/:doc_id it deprecated.
+        assert data["relay_url"].endswith(f"/d/{share_id}/ws")
+        assert "/doc/ws" not in data["relay_url"]
         assert data["token"]
         assert data["expires_at"]
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -41,10 +41,10 @@ These create the first admin user when the database is empty.
 |----------|----------|---------|-------------|
 | `SERVER_NAME` | No | `EVC Team Relay` | Display name shown in plugin |
 | `SERVER_ID` | No | (auto) | Unique identifier, defaults to relay key ID |
-| `RELAY_PUBLIC_URL` | No | `wss://${DOMAIN_BASE}/doc/ws` | Public WebSocket URL for relay server (client-facing) |
+| `RELAY_PUBLIC_URL` | No | `wss://${DOMAIN_BASE}` | Public WebSocket origin for relay server (client-facing). Only the scheme+host are read — `issue_relay_token` builds the per-doc path itself (`/d/{doc_id}/ws`, matching relay-server's non-deprecated route); any path here (e.g. a leftover `/doc/ws`) is silently ignored. Keep it bare. |
 | `RELAY_PRIVATE_KEY` | **Yes** | — | Base64-encoded Ed25519 private key used to sign relay tokens. Startup **fails closed** without it (`RELAY_PRIVATE_KEY is required but not set`) — no key is generated for you. Create it once with `openssl genpkey -algorithm ed25519 -out relay_private.pem && openssl base64 -A -in relay_private.pem`, then back it up: replacing it invalidates every token already issued and requires updating `[[auth]] public_key` in `relay.toml`. |
 | `RELAY_KEY_ID` | No | `relay_cp_dev` | COSE `kid` embedded in issued tokens; must match a `[[auth]] key_id` in `relay.toml` |
-| `RELAY_AUDIENCE` | No | derived from `RELAY_PUBLIC_URL`'s host as `https://{host}` | `aud` claim on issued tokens — must equal `relay.toml`'s `[server].url` exactly. Distinct from `RELAY_PUBLIC_URL`: that one is the wss:// client URL with a `/doc/ws` path, this must be a bare https:// origin with no path. Set explicitly only if your `[server].url` uses a different host than `RELAY_PUBLIC_URL`. |
+| `RELAY_AUDIENCE` | No | derived from `RELAY_PUBLIC_URL`'s host as `https://{host}` | `aud` claim on issued tokens — must equal `relay.toml`'s `[server].url` exactly. Set explicitly only if your `[server].url` uses a different host than `RELAY_PUBLIC_URL`. |
 | `RELAY_TOKEN_ISSUER` | No | `relay-server` | `iss` claim on issued tokens. Must be one of relay-server's accepted issuers (`relay-server`, `auth.system3.dev`, `auth.system3.md` as of image `0.9.9`) — leave at the default unless you know your relay-server image accepts a different value. |
 
 ## Logging

--- a/infra/env.example
+++ b/infra/env.example
@@ -24,7 +24,10 @@ BOOTSTRAP_ADMIN_PASSWORD=super-secret-pass
 CORS_ALLOWED_ORIGINS=https://cp.tr.entire.vc     # Comma-separated; use '*' only for local dev
 
 # Relay server
-RELAY_PUBLIC_URL=wss://${DOMAIN_BASE}/doc/ws
+# Only the scheme+host are used (relay_doc_ws_url() builds the per-doc path
+# itself, e.g. /d/<doc_id>/ws) — a trailing path here, such as a leftover
+# /doc/ws, is silently ignored. Keep this bare.
+RELAY_PUBLIC_URL=wss://${DOMAIN_BASE}
 # RELAY_KEY_ID=relay_cp_01              # Optional, defaults to 'relay_cp_dev' if not set
 # REQUIRED — Base64-encoded Ed25519 PEM private key. Generate with:
 #   openssl genpkey -algorithm ed25519 -out relay_private.pem && openssl base64 -A -in relay_private.pem


### PR DESCRIPTION
## Что было

relay-server (наш форк, `entire-vc/evc-relay-server`) логирует WARN на каждое подключение через `/doc/ws/:doc_id`:

```
WARN relay::server: /doc/ws/:doc_id is deprecated;
     call /doc/:doc_id/auth instead and use the returned URL.
```

Control-plane's `POST /tokens/relay` (`token_service.issue_relay_token`) отдавал клиентам именно этот устаревший путь — `relay_url` был статическим `RELAY_PUBLIC_URL` (в проде `wss://tr.entire.vc/doc/ws`), одинаковым для всех doc_id. Работало, но это тот же класс проблемы, что и полугодовой тихой поломки collab-синка ранее: клиентская сторона опирается на контракт, от которого серверная уже отписалась.

## Что выяснилось при разборе relay-server

- Неустаревший маршрут — `/d/:doc_id/ws/:doc_id2` (`crates/relay/src/server.rs`), требует **одинаковый** `doc_id` в обоих сегментах пути (иначе 400).
- `POST /doc/:doc_id/auth` (то, что WARN рекомендует вызывать) — это НЕ drop-in замена для клиента: она требует **server-level** токен (`verify_server_token`), т.е. отдельный credential control-plane↔relay-server, которого сегодня нет в этом флоу (control-plane сам минтит CWT для конечного клиента, никогда не ходит в relay-server по HTTP). Вызывать её означало бы новый sequencing (лишний round-trip + новый секрет).
- Альтернатива есть: обе WS-ручки (`/doc/ws/:doc_id` и `/d/:doc_id/ws/:doc_id2`) используют **одинаковую** проверку токена (`verify_socket_token`) и **одинаковый** downstream-обработчик соединения — единственная разница в форме URL. `generate_context_aware_urls` (то, что реально вычисляет `/doc/:doc_id/auth`) строит `ws_url = "{base}/d/{doc_id}/ws"`; клиентский `YSweetProvider` (Obsidian-плагин, `src/client/provider.ts`) сам дописывает `"/" + roomname` (= doc_id) к тому, что мы вернули. Значит если мы вернём `wss://host/d/{doc_id}/ws`, клиент подключится к `wss://host/d/{doc_id}/ws/{doc_id}` — ровно тот путь, который ждёт неустаревшая ручка, без единого изменения в клиентском коде и без нового credential.

## Фикс

- `Settings.relay_doc_ws_url(doc_id)` (`app/core/config.py`) — берёт scheme+host из `RELAY_PUBLIC_URL` (отбрасывая любой путь, включая исторический `/doc/ws`) и строит `{scheme}://{host}/d/{doc_id}/ws`.
- `token_service.issue_relay_token` теперь возвращает `relay_url=settings.relay_doc_ws_url(payload.doc_id)` вместо статического `relay_public_url`.
- `docs/configuration.md` + `infra/env.example` — убрал теперь бессмысленный `/doc/ws` суффикс из рекомендуемого значения `RELAY_PUBLIC_URL` (путь больше не читается кодом), чтобы не плодить тот же класс doc/code рассинхрона, что уже ловили на relay.toml.
- Существующим деплоям **не нужно** менять env — старое значение `.../doc/ws` продолжит работать (путь просто отбрасывается), это чисто docs-гигиена для новых деплоев.

## Тесты

- `apps/control-plane/tests/test_config_relay_audience.py` — новый класс `TestRelayDocWsUrl` (3 теста: путь строится правильно, работает с "голым" `RELAY_PUBLIC_URL`, разные doc_id → разные URL).
- `apps/control-plane/tests/test_relay_token_endpoint.py` — усилен `test_owner_gets_write_token`: теперь проверяет точную форму `relay_url` (`.../d/{share_id}/ws`) и явное отсутствие `/doc/ws`.
- Целевой прогон (`test_config_relay_audience.py` + `test_relay_token_endpoint.py` + `test_auth_shares.py` + `test_server_info.py`): **47 passed**. Полный набор `apps/control-plane` тестов — тоже зелёный.

## Живая проверка (docker, control-plane + relay-server 0.9.9, собрано из этой ветки)

Заминтил реальный CWT через `POST /tokens/relay`, ответ:
```
relay_url: wss://localhost/d/596e6fdc-.../ws
```
Raw WS-upgrade на `wss://localhost/d/596e6fdc.../ws/596e6fdc...?token=...` (per client contract):
```
HTTP/1.1 101 Switching Protocols
connection: upgrade
upgrade: websocket
relay-server-version: 0.9.9
```
Лог relay-server за это соединение:
```
INFO relay::server: Loading doc doc_id="596e6fdc-0c98-4aae-99f9-c5f1531a80a8" channel=None user=None
```
**Строки "deprecated" нет.**

Позитивный контроль (тем же токеном, но на СТАРЫЙ `/doc/ws/:doc_id`) — подтверждает, что WARN действительно логируется, когда путь старый:
```
HTTP/1.1 101 Switching Protocols
...
WARN relay::server: /doc/ws/:doc_id is deprecated; call /doc/:doc_id/auth instead and use the returned URL.
```

Не мержу — нужна независимая приёмка.