### PR TITLE
fix(install): name the cause when the published images have no arm64 build

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ You want your team in Obsidian, editing together, publishing docs — without gi
 Full walkthrough — DNS, production hardening, systemd, troubleshooting — lives in the
 **[Installation Guide](docs/installation.md)**. The short version:
 
+> **arm64 hosts** (Apple Silicon, Graviton, Ampere, Raspberry Pi): the published images
+> are `linux/amd64` only — `control-plane`, `web-publish` and `relay-server` alike. Run
+> `export DOCKER_DEFAULT_PLATFORM=linux/amd64` first to use them under emulation, or see
+> [Installation → Architecture](docs/installation.md#architecture).
+
 ```bash
 git clone https://github.com/entire-vc/evc-team-relay.git
 cd evc-team-relay/infra
@@ -72,11 +77,6 @@ bash ../scripts/pull-published-images.sh
 
 docker compose up -d
 ```
-
-> **arm64 hosts** (Apple Silicon, Graviton, Ampere, Raspberry Pi): the published images
-> are `linux/amd64` only. Run `export DOCKER_DEFAULT_PLATFORM=linux/amd64` before the
-> two commands above to use them under emulation — see
-> [Installation → Architecture](docs/installation.md#architecture).
 
 **Services** (once DNS points your bare `DOMAIN_BASE`, `cp.DOMAIN_BASE`, and `docs.DOMAIN_BASE` at your server and Caddy has issued certs):
 - Relay Server: `wss://yourdomain.com` (your `DOMAIN_BASE` itself — no `relay.` subdomain)

--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ bash ../scripts/pull-published-images.sh
 docker compose up -d
 ```
 
+> **arm64 hosts** (Apple Silicon, Graviton, Ampere, Raspberry Pi): the published images
+> are `linux/amd64` only. Run `export DOCKER_DEFAULT_PLATFORM=linux/amd64` before the
+> two commands above to use them under emulation — see
+> [Installation → Architecture](docs/installation.md#architecture).
+
 **Services** (once DNS points your bare `DOMAIN_BASE`, `cp.DOMAIN_BASE`, and `docs.DOMAIN_BASE` at your server and Caddy has issued certs):
 - Relay Server: `wss://yourdomain.com` (your `DOMAIN_BASE` itself — no `relay.` subdomain)
 - Control Plane API: `https://cp.yourdomain.com`

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -17,6 +17,22 @@ This guide covers installing EVC Team Relay on a Linux server using Docker Compo
 - Domain name with DNS access
 - (Optional) SSL certificates or use Caddy's automatic HTTPS
 
+### Architecture
+
+**The published images are `linux/amd64` only** — `control-plane`, `web-publish`
+and `relay-server` alike. There is no `arm64` manifest, so on an arm64 host
+(Apple Silicon, AWS Graviton, Ampere at Hetzner/OVH, Raspberry Pi) the install
+below stops at the pull step unless you run them under emulation:
+
+```bash
+export DOCKER_DEFAULT_PLATFORM=linux/amd64
+```
+
+Export it for the whole session rather than prefixing one command: `relay-server`
+is pulled later by `docker compose up`, not by the pull script, and it needs the
+same setting. Emulated amd64 on arm64 is noticeably slower — fine for a local
+trial or demo, not what we'd recommend for a production install.
+
 ### Ports
 
 | Port | Service | Required |
@@ -150,9 +166,10 @@ This tags them locally as `infra-control-plane:latest` / `infra-web-publish:late
 `docker compose up` picks up without attempting to build. Pass a version to pin one
 (`bash scripts/pull-published-images.sh 1.10.0`) instead of the default `latest`.
 
-> linux/amd64 only for now — there is no arm64 manifest yet, so this fails on Apple Silicon
-> or other arm64 hosts without emulation (e.g. `export DOCKER_DEFAULT_PLATFORM=linux/amd64`
-> under Docker Desktop).
+> **arm64 hosts:** these images are linux/amd64 only, and so is `relay-server` in step 7 —
+> `export DOCKER_DEFAULT_PLATFORM=linux/amd64` for the session before running this (see
+> [Architecture](#architecture) above). The script refuses with an explanation rather than
+> pulling something that can't run.
 
 If you do have org access and want to build from source instead (e.g. active development),
 skip this step and run `docker compose up -d --build` in step 7.

--- a/scripts/pull-published-images.sh
+++ b/scripts/pull-published-images.sh
@@ -86,14 +86,27 @@ MSG
   exit 1
 }
 
+# Echoes the published platform list when it is READABLE and genuinely lacks
+# our platform; returns non-zero in every other case, including "the manifest
+# told us nothing". That distinction is the whole point: an empty list means
+# we could not look, not that the platform is absent. Conflating the two is
+# how an unrelated failure (a typo in the version argument, an expired login)
+# ends up being reported as an architecture problem — the same wrong-diagnosis
+# class this script exists to remove, reintroduced one level down.
+platform_missing_from() {
+  local image="$1" available
+  [ -n "${PLATFORM_ARCH}" ] || return 1
+  available="$(manifest_platforms "$image" | sort -u | paste -sd, -)"
+  [ -n "$available" ] || return 1
+  printf '%s' "$available" | tr ',' '\n' | grep -qx "${PLATFORM_ARCH}" && return 1
+  printf 'linux/%s' "${available//,/, linux\/}"
+}
+
 PLATFORM="$(effective_platform)"
 PLATFORM_ARCH="${PLATFORM##*/}"
 
-if [ -n "${PLATFORM_ARCH}" ]; then
-  AVAILABLE="$(manifest_platforms "${REGISTRY}/control-plane:${VERSION}" | sort -u | paste -sd, -)"
-  if [ -n "${AVAILABLE}" ] && ! printf '%s' "${AVAILABLE}" | tr ',' '\n' | grep -qx "${PLATFORM_ARCH}"; then
-    unsupported_platform_error "${PLATFORM}" "linux/${AVAILABLE//,/, linux\/}"
-  fi
+if AVAILABLE="$(platform_missing_from "${REGISTRY}/control-plane:${VERSION}")"; then
+  unsupported_platform_error "${PLATFORM}" "${AVAILABLE}"
 fi
 
 for component in control-plane web-publish; do
@@ -101,10 +114,11 @@ for component in control-plane web-publish; do
   if ! docker pull "${REGISTRY}/${component}:${VERSION}"; then
     # Belt and braces: the preflight above is skipped whenever the manifest
     # could not be read, so a platform mismatch can still land here. Name the
-    # cause rather than leaving the daemon's raw error as the last word.
-    if [ -n "${PLATFORM_ARCH}" ] \
-       && ! manifest_platforms "${REGISTRY}/${component}:${VERSION}" | grep -qx "${PLATFORM_ARCH}"; then
-      unsupported_platform_error "${PLATFORM}" ""
+    # cause only when the manifest actually proves it — otherwise the daemon's
+    # own error is the honest last word, and a bad version argument stays a
+    # bad version argument instead of being blamed on your CPU.
+    if AVAILABLE="$(platform_missing_from "${REGISTRY}/${component}:${VERSION}")"; then
+      unsupported_platform_error "${PLATFORM}" "${AVAILABLE}"
     fi
     exit 1
   fi

--- a/scripts/pull-published-images.sh
+++ b/scripts/pull-published-images.sh
@@ -10,10 +10,12 @@
 # Both images are published publicly by .github/workflows/release.yml on
 # every version tag; no login is required to pull them.
 #
-# linux/amd64 only for now (same for relay-server) — there is no arm64
-# manifest, so this fails on Apple Silicon / arm64 hosts without emulation
-# (e.g. `export DOCKER_DEFAULT_PLATFORM=linux/amd64` under Docker Desktop).
-# Tracked separately; not fixed here.
+# Published images are linux/amd64 only — see the preflight below, which
+# refuses with an explanation rather than letting the Docker daemon's own
+# "no matching manifest for linux/arm64/v8" surface with no cause and no way
+# forward. relay-server (pulled later by `docker compose up`, not by this
+# script) is amd64-only for the same reason, so the workaround below has to
+# be exported for the whole session, not just this command.
 #
 # Usage:
 #   bash scripts/pull-published-images.sh [version]   # default: latest
@@ -27,9 +29,85 @@ set -euo pipefail
 VERSION="${1:-latest}"
 REGISTRY="ghcr.io/entire-vc/evc-team-relay"
 
+# The platform docker will actually ask the registry for: DOCKER_DEFAULT_PLATFORM
+# wins if set, otherwise the daemon's own os/arch. Asking the daemon (not `uname`)
+# is what matters — on Docker Desktop the daemon runs in a Linux VM whose arch is
+# the thing the registry is queried with.
+effective_platform() {
+  if [ -n "${DOCKER_DEFAULT_PLATFORM:-}" ]; then
+    printf '%s' "${DOCKER_DEFAULT_PLATFORM}"
+    return
+  fi
+  docker version --format '{{.Server.Os}}/{{.Server.Arch}}' 2>/dev/null || printf ''
+}
+
+# Platforms present in a published manifest list, one per line. Empty output
+# means "could not determine" — an older docker without `docker manifest`, no
+# network, a moved tag. That is deliberately NOT treated as a failure: an
+# unreadable manifest must not block a pull that might well succeed.
+manifest_platforms() {
+  docker manifest inspect "$1" 2>/dev/null \
+    | sed -n 's/.*"architecture": *"\([^"]*\)".*/\1/p' \
+    | grep -v '^unknown$' || true
+}
+
+unsupported_platform_error() {
+  local want="$1" have="$2"
+  cat >&2 <<MSG
+
+ERROR: the published Team Relay images do not include your platform.
+
+  your platform:     ${want}
+  images published:  ${have:-linux/amd64 only}
+
+The images built by our release pipeline are linux/amd64 only. This affects
+every arm64 host: Apple Silicon, AWS Graviton, Ampere at Hetzner/OVH,
+Raspberry Pi. Two ways forward:
+
+  1. Run the amd64 images under emulation. Slower, but the whole documented
+     install path works unchanged. Export it for the session, because
+     'docker compose up' later pulls relay-server, which is amd64-only too:
+
+         export DOCKER_DEFAULT_PLATFORM=linux/amd64
+         bash scripts/pull-published-images.sh ${VERSION}
+
+  2. Build from source for your own architecture instead of pulling:
+
+         docker build -t infra-control-plane:latest apps/control-plane
+         docker build -t infra-web-publish:latest  apps/web-publish
+
+     Note that web-publish needs a GitHub token with read access to our
+     @entire-vc npm packages (apps/web-publish/.npmrc); if you don't have
+     one, option 1 is your path.
+
+Tracking arm64 images: https://github.com/entire-vc/evc-team-relay/issues
+
+MSG
+  exit 1
+}
+
+PLATFORM="$(effective_platform)"
+PLATFORM_ARCH="${PLATFORM##*/}"
+
+if [ -n "${PLATFORM_ARCH}" ]; then
+  AVAILABLE="$(manifest_platforms "${REGISTRY}/control-plane:${VERSION}" | sort -u | paste -sd, -)"
+  if [ -n "${AVAILABLE}" ] && ! printf '%s' "${AVAILABLE}" | tr ',' '\n' | grep -qx "${PLATFORM_ARCH}"; then
+    unsupported_platform_error "${PLATFORM}" "linux/${AVAILABLE//,/, linux\/}"
+  fi
+fi
+
 for component in control-plane web-publish; do
   echo "Pulling ${REGISTRY}/${component}:${VERSION}..."
-  docker pull "${REGISTRY}/${component}:${VERSION}"
+  if ! docker pull "${REGISTRY}/${component}:${VERSION}"; then
+    # Belt and braces: the preflight above is skipped whenever the manifest
+    # could not be read, so a platform mismatch can still land here. Name the
+    # cause rather than leaving the daemon's raw error as the last word.
+    if [ -n "${PLATFORM_ARCH}" ] \
+       && ! manifest_platforms "${REGISTRY}/${component}:${VERSION}" | grep -qx "${PLATFORM_ARCH}"; then
+      unsupported_platform_error "${PLATFORM}" ""
+    fi
+    exit 1
+  fi
   docker tag "${REGISTRY}/${component}:${VERSION}" "infra-${component}:latest"
 done
 


### PR DESCRIPTION
## What this fixes

The documented install path stopped at its very first command on any arm64 host, showing only this:

```
$ bash scripts/pull-published-images.sh
Error response from daemon: no matching manifest for linux/arm64/v8 in the
manifest list entries: no match for platform in manifest: not found
```

No cause, no way forward. The amd64-only limit was recorded **in a source comment inside the script** — invisible to the person running it.

## What it does now

`pull-published-images.sh` checks the published manifest against the platform docker will actually request (`DOCKER_DEFAULT_PLATFORM` if set, otherwise the daemon's own `os/arch` — not `uname`, which on Docker Desktop reports the host rather than the Linux VM that talks to the registry), and refuses with the platform, what is published, and two concrete ways forward.

**The check cannot take away a pull that would have worked.** If the manifest can't be read (older docker without `docker manifest`, no network, a moved tag) that is deliberately *not* fatal: it falls through to the normal `docker pull`, and the same explanation is attached to a pull failure as well. The check can only add information, never withhold.

The workaround is documented as an `export`, not a one-command prefix, because `docker compose up` in step 7 pulls `relay-server`, which is amd64-only too — working around it once would leave the reader stuck again two steps later.

Docs: the architecture requirement is stated up front in `installation.md`, where a reader decides whether to start at all, rather than only at step 6; plus a note in the README quick start.

## Verified live on arm64

Host: Apple Silicon, daemon `linux/arm64`.

**Negative control — the documented path as-is:**
```
your platform:     linux/arm64
images published:  linux/amd64
...
export DOCKER_DEFAULT_PLATFORM=linux/amd64
exit=1
```

**Positive control — does the advice the message gives actually work?**
```
$ export DOCKER_DEFAULT_PLATFORM=linux/amd64 && bash scripts/pull-published-images.sh
Done. infra-control-plane:latest and infra-web-publish:latest are ready
exit=0
control-plane: linux/amd64
web-publish:   linux/amd64
```

The message isn't just printed — the path it recommends was followed to the end and produces working images.

## What this PR does NOT do

It does not add arm64 images. That is a separate decision, and it now has measurements behind it: a native ARM runner builds control-plane in 18s against 17s for amd64, while QEMU emulation takes 130s. Measuring it also surfaced that the `web-publish` release build currently succeeds only because of a warm build cache rather than because it can authenticate to our private npm packages — that needs resolving before arm64 images are possible, and it is out of scope here.