### PR TITLE
fix(control-plane): collect test rate-limiters by introspection, not a hand-written list

### DIFF
--- a/apps/control-plane/tests/conftest.py
+++ b/apps/control-plane/tests/conftest.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+import importlib
 import os
+import pkgutil
 import sys
 from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
+from slowapi import Limiter
 from sqlalchemy.pool import StaticPool
 
 # Ensure the project package is importable when tests run without an editable install.
@@ -13,6 +16,8 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
+import app.api.routers as routers_pkg
+import app.main as main_module
 from app.core.config import get_settings
 from app.core.security import generate_ed25519_keypair
 from app.db import session as session_module
@@ -88,26 +93,51 @@ def db_session(db_connection):
         yield session
 
 
+def _collect_rate_limiters() -> list[Limiter]:
+    """Collect every module-level slowapi Limiter under app.api.routers + app.main.
+
+    Introspected rather than hand-enumerated: a hand-maintained list silently
+    falls behind as routers are added — that is exactly how `web.limiter` and
+    `webhooks.limiter` went unreset for every test (Mesh #c3acaa8d). The
+    `webhooks` one is the dangerous case: its endpoint is windowed at 1 HOUR,
+    so a leaked counter can never recover inside a single (~6 min) test run.
+
+    A new router that declares its own `limiter = Limiter(...)` is picked up
+    here automatically, without anyone having to remember to edit this file.
+    """
+    seen: dict[int, Limiter] = {}
+    prefix = f"{routers_pkg.__name__}."
+    for module_info in pkgutil.iter_modules(routers_pkg.__path__, prefix=prefix):
+        module = importlib.import_module(module_info.name)
+        for value in vars(module).values():
+            if isinstance(value, Limiter):
+                seen[id(value)] = value
+    for value in vars(main_module).values():
+        if isinstance(value, Limiter):
+            seen[id(value)] = value
+    return list(seen.values())
+
+
 @pytest.fixture
 def client(engine, db_connection):
-    # Reset rate limiters before each test to avoid cross-test pollution
-    from app.api.routers import admin_ui, agent_keys, auth, invites, metrics, shares, tokens
+    # Reset rate limiters before each test to avoid cross-test pollution.
     from app.db.session import get_db
-    from app.main import limiter as main_limiter
 
-    # Clear all limiter storages
-    limiters = [
-        main_limiter,
-        auth.limiter,
-        shares.limiter,
-        tokens.limiter,
-        invites.limiter,
-        metrics._limiter,
-        agent_keys.limiter,
-        admin_ui.limiter,
-    ]
-    for lim in limiters:
-        if hasattr(lim, "_storage") and lim._storage:
+    for lim in _collect_rate_limiters():
+        # `_storage` is slowapi's internal handle on the backing store. It is
+        # present on every Limiter today (verified: MemoryStorage, has
+        # .reset()), but it is a private attribute — a slowapi version bump
+        # could rename/remove it. Silently skipping a missing attribute would
+        # turn this into a no-op reset that nobody notices (the exact failure
+        # mode this whole fixture exists to prevent), so fail loudly instead.
+        if not hasattr(lim, "_storage"):
+            raise RuntimeError(
+                f"slowapi Limiter {lim!r} has no `_storage` attribute — slowapi's "
+                "internal API has likely changed and this test-isolation reset is "
+                "silently broken. Update `_collect_rate_limiters`'s reset logic for "
+                "the new slowapi internals before trusting any rate-limit test."
+            )
+        if lim._storage:
             lim._storage.reset()
 
     app = build_app()

--- a/apps/control-plane/tests/test_limiter_reset.py
+++ b/apps/control-plane/tests/test_limiter_reset.py
@@ -1,0 +1,121 @@
+"""Regression coverage for the `client` fixture's rate-limiter reset.
+
+Context (TR·control-plane, Mesh #c3acaa8d): the reset in `conftest.py` used to
+enumerate limiters by hand and missed two routers — `web` and `webhooks` — so
+their counters accumulated state ACROSS tests instead of being cleared before
+each one. The `webhooks` limiter is the most dangerous instance of this: its
+`create_webhook` endpoint is capped at 10/HOUR, and a ~6 minute full test run
+can never let an hour-scoped window recover on its own. Once enough webhook
+tests run in one session, every later one starts failing with 429 —
+deterministically, not flakily.
+
+This file has two jobs:
+  1. Prove the hole with a negative control that fails against the OLD
+     (hand-enumerated) limiter list and passes once the list is collected by
+     introspection instead.
+  2. Guard against the fix regressing back into a hand-maintained list: a new
+     router that declares its own `Limiter` must show up in the reset without
+     anyone touching `conftest.py`.
+"""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+
+def _auth_headers(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _admin_token(client: TestClient) -> str:
+    response = client.post(
+        "/auth/login",
+        json={"email": "bootstrap@example.com", "password": "super-secret"},
+    )
+    assert response.status_code == 200, response.text
+    return response.json()["access_token"]
+
+
+def _create_webhook(client: TestClient, token: str, name: str) -> int:
+    """POST /v1/webhooks once and return the status code."""
+    response = client.post(
+        "/v1/webhooks",
+        json={
+            "name": name,
+            "url": "https://example.com/hook",
+            "events": ["share.created"],
+        },
+        headers=_auth_headers(token),
+    )
+    return response.status_code
+
+
+def test_webhooks_limiter_first_of_pair(client: TestClient) -> None:
+    """First half of the cross-test 10/hour exhaustion pair.
+
+    Issues 10 webhook creations — exactly the `webhooks.limiter` budget for
+    the hour-long window declared on `POST /v1/webhooks` (`app/api/routers/
+    webhooks.py:38`, `@limiter.limit("10/hour")`). All 10 must succeed inside
+    a single test; this alone says nothing about cross-test isolation.
+    """
+    token = _admin_token(client)
+    statuses = [_create_webhook(client, token, f"hook-{i}") for i in range(10)]
+    assert statuses == [201] * 10, statuses
+
+
+def test_webhooks_limiter_second_of_pair(client: TestClient) -> None:
+    """Second half of the pair — this is the actual regression check.
+
+    If `webhooks.limiter` was NOT reset between tests (the bug), the 10/hour
+    bucket used up by `test_webhooks_limiter_first_of_pair` is still hot, and
+    the very first request here comes back 429 instead of 201 — a same-IP,
+    same-process leak that has nothing to do with this test's own traffic.
+
+    Test ordering is not guaranteed by pytest by default, but this repo runs
+    tests in file-definition order (no random-order plugin configured), so
+    the pair above always executes immediately before this one.
+    """
+    token = _admin_token(client)
+    status = _create_webhook(client, token, "hook-after-reset")
+    assert status == 201, (
+        f"expected 201 (fresh 10/hour budget after the client fixture's reset), "
+        f"got {status} — the webhooks.limiter state leaked in from the previous test"
+    )
+
+
+def test_collected_limiters_cover_every_declared_limiter() -> None:
+    """Anti-regression: the reset list must be derived, not hand-maintained.
+
+    Walks `app.api.routers.*` + `app.main` for every module-level `Limiter`
+    instance and asserts it is exactly the set the `client` fixture resets.
+    A future router that declares `limiter = Limiter(...)` and is missed by
+    the reset fails THIS test, not a flaky cross-test 429 three files away.
+    """
+    import pkgutil
+
+    from slowapi import Limiter
+
+    import app.api.routers as routers_pkg
+    import app.main as main_module
+    from tests.conftest import _collect_rate_limiters
+
+    declared: set[int] = set()
+    prefix = f"{routers_pkg.__name__}."
+    for module_info in pkgutil.iter_modules(routers_pkg.__path__, prefix=prefix):
+        module = __import__(module_info.name, fromlist=["_"])
+        for value in vars(module).values():
+            if isinstance(value, Limiter):
+                declared.add(id(value))
+    for value in vars(main_module).values():
+        if isinstance(value, Limiter):
+            declared.add(id(value))
+
+    collected = _collect_rate_limiters()
+    collected_ids = {id(lim) for lim in collected}
+
+    assert declared, "sanity check: introspection must find at least one Limiter"
+    assert collected_ids == declared, (
+        "the client fixture's collected limiter set does not match every "
+        "module-level Limiter declared under app.api.routers + app.main — "
+        "a router's rate limiter would silently accumulate state across tests"
+    )


### PR DESCRIPTION
## Summary

`apps/control-plane/tests/conftest.py`'s `client` fixture reset rate-limiter
state before each test from a hand-enumerated list of 8 limiters. Two of the
10 modules that declare their own `slowapi.Limiter` — `web.limiter` and
`webhooks.limiter` — were missing from that list, so their counters
accumulated state across tests instead of being cleared.

`webhooks.limiter` is the dangerous one: `POST /v1/webhooks` is capped at
**10/hour**, and a full test run (~6 min) can never let an hour-scoped
window recover on its own once leaked state exhausts it — once enough
webhook-touching tests run in one session, every later one starts failing
with 429, deterministically.

Measured on an instrumented full run (1505 HTTP requests) before this fix:
`POST /v1/billing/webhooks` hit 8 of its 10-per-hour budget over the run,
with no way to recover mid-run.

## Fix

- `_collect_rate_limiters()` walks every module under `app.api.routers` +
  `app.main` and picks up any module-level `Limiter` instance by
  introspection, instead of a hand-maintained list. A future router that
  declares its own `limiter = Limiter(...)` is now reset automatically.
- Hardens the reset itself: the old `hasattr(lim, "_storage")` guard
  silently no-ops if slowapi ever renames/removes that private attribute.
  It now raises loudly instead of passing quietly.

## Tests

`tests/test_limiter_reset.py` adds:
- A **negative-control pair** that reproduces the leak: 10 webhook creations
  in one test exhaust the hour window, and the very next test's first
  webhook creation gets a 429 — verified failing against the pre-fix
  conftest, green after the fix.
- An **anti-regression test** asserting the collected limiter set equals
  every module-level `Limiter` declared across `app.api.routers.*` +
  `app.main`, so a missed router fails this test directly instead of
  surfacing as a flaky cross-test 429 somewhere else.

All 8 tests that deliberately assert a 429 still pass:
`test_rate_limiting_token_issuance`, `test_protected_share_password_rate_limiting`,
`test_login_is_rate_limited`, `test_2fa_login_is_rate_limited`,
`test_rate_limit_login`, `test_password_reset_rate_limiting`,
`test_rate_limiting_share_creation`, `test_rate_limiting_member_addition`.

Full suite: 764 passed, 1 skipped (was 761 passed, 1 skipped before this
change — the +3 are the new tests in `test_limiter_reset.py`).

## Test plan

- [x] `PYTHONPATH=app uv run pytest tests/test_limiter_reset.py -v` — 3 passed
- [x] Negative control reproduced on pre-fix conftest (429), green post-fix (201)
- [x] All 8 named positive-control tests pass
- [x] Full suite green