### PR TITLE
fix(control-plane): serve attachment bytes ourselves, not a MinIO presigned URL

### DIFF
--- a/apps/control-plane/app/api/routers/shares.py
+++ b/apps/control-plane/app/api/routers/shares.py
@@ -619,20 +619,15 @@ def _validate_file_path(path: str) -> str:
     return path
 
 
-def _decode_file_token(share_id: uuid.UUID, path: str, authorization: str | None) -> dict[str, Any]:
-    """Decode+validate the Bearer file-token on HEAD/download-url/upload-url.
+def _decode_file_token_value(token: str, share_id: uuid.UUID, path: str) -> dict[str, Any]:
+    """Shared core: decode+validate a raw file-token string against share_id/path.
 
-    Deliberately NOT deps.get_current_user — that accepts normal session
-    JWTs, and (per its own guard) now explicitly REJECTS scope=file tokens.
-    This is the file-token-only counterpart.
+    Used by both the Authorization-header form below (HEAD/download-url mint,
+    upload-url) and the query-string form consumed by GET .../content — the
+    actual byte-serving route a client hits with a bare GET and so cannot
+    attach a header to (see that route's docstring for why the credential
+    rides in the URL there).
     """
-    if not authorization:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing credentials")
-    scheme, _, token = authorization.partition(" ")
-    if scheme.lower() != "bearer" or not token:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid Authorization header"
-        )
     try:
         payload = security.decode_access_token(token)
     except InvalidTokenError as exc:
@@ -650,6 +645,23 @@ def _decode_file_token(share_id: uuid.UUID, path: str, authorization: str | None
             status_code=status.HTTP_403_FORBIDDEN, detail="Token not valid for this path"
         )
     return payload
+
+
+def _decode_file_token(share_id: uuid.UUID, path: str, authorization: str | None) -> dict[str, Any]:
+    """Decode+validate the Bearer file-token on HEAD/download-url/upload-url.
+
+    Deliberately NOT deps.get_current_user — that accepts normal session
+    JWTs, and (per its own guard) now explicitly REJECTS scope=file tokens.
+    This is the file-token-only counterpart.
+    """
+    if not authorization:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing credentials")
+    scheme, _, token = authorization.partition(" ")
+    if scheme.lower() != "bearer" or not token:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid Authorization header"
+        )
+    return _decode_file_token_value(token, share_id, path)
 
 
 def _user_from_file_token(db: Session, payload: dict[str, Any]) -> models.User:
@@ -762,7 +774,22 @@ def get_file_download_url(
     db: Session = Depends(get_db),
     authorization: str | None = Header(default=None, alias="Authorization"),
 ) -> DownloadUrlResponse:
-    """CAS.ts readFile() step 1: mint a presigned MinIO GET for this attachment."""
+    """CAS.ts readFile() step 1: mint a control-plane URL for this attachment.
+
+    Used to mint a presigned MinIO GET directly (effef307) — unusable outside
+    the relay's own compose network, since MinIO has no public endpoint
+    (internal DNS name `minio`, no published port or vhost) and publishing
+    one would force every self-hoster to expose their object store. Now
+    returns a control-plane URL (GET .../content, below) that streams the
+    bytes itself, matching web.py's serve_web_asset precedent.
+
+    The returned URL carries the SAME file-token as its `token` query
+    credential rather than minting a second one: the token already proves
+    read access to exactly this share_id+path and is already short-lived
+    (10 min), so reusing it is not weaker than a fresh signature — and it's
+    the same shape a MinIO presigned URL already had (credential in the
+    query, no header on the final bare GET), not a new exposure class.
+    """
     token_payload = _decode_file_token(share_id, path, authorization)
     user = _user_from_file_token(db, token_payload)
     share = share_service.get_share(db, share_id)
@@ -772,12 +799,9 @@ def get_file_download_url(
     object_name = f"web-assets/{share_id}/{path}"
     minio_client = _get_minio_client()
     try:
-        # Confirm the object exists before minting the URL — a presigned GET
-        # for a missing key 404s opaquely from MinIO, not from this API.
+        # Confirm the object exists before minting the URL — GET .../content
+        # 404ing from OUR api is easier to diagnose than an opaque MinIO 403.
         minio_client.stat_object(settings.minio_bucket, object_name)
-        url = minio_client.presigned_get_object(
-            settings.minio_bucket, object_name, expires=timedelta(minutes=10)
-        )
     except S3Error as e:
         if e.code in ("NoSuchKey", "NoSuchObject"):
             raise HTTPException(
@@ -787,7 +811,65 @@ def get_file_download_url(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Failed to retrieve file: {e}",
         ) from e
-    return DownloadUrlResponse(downloadUrl=url)
+
+    # authorization is guaranteed "Bearer <token>" here — _decode_file_token
+    # already rejected anything else above.
+    _, _, raw_token = authorization.partition(" ")
+    base = settings.control_plane_public_url.rstrip("/")
+    download_url = (
+        f"{base}/shares/{share_id}/files/{quote(path, safe='/')}/content"
+        f"?token={quote(raw_token, safe='')}"
+    )
+    return DownloadUrlResponse(downloadUrl=download_url)
+
+
+@router.get("/{share_id}/files/{path:path}/content")
+def get_file_content(
+    share_id: uuid.UUID,
+    path: str,
+    token: str = Query(..., description="File-token from download-url's downloadUrl"),
+    db: Session = Depends(get_db),
+) -> Response:
+    """Serve attachment bytes directly (CAS.ts readFile() step 2).
+
+    Mirrors web.py's serve_web_asset: reads the object from MinIO server-side
+    and streams the bytes back, instead of redirecting the client to MinIO
+    directly — MinIO is not publicly reachable (effef307). Auth is a query
+    param, not a header, because this is the URL the client fetches with a
+    bare GET; see get_file_download_url's docstring for why that's not a new
+    exposure class versus the presigned-MinIO-URL shape it replaces.
+    """
+    token_payload = _decode_file_token_value(token, share_id, path)
+    user = _user_from_file_token(db, token_payload)
+    share = share_service.get_share(db, share_id)
+    share_service.ensure_read_access(db, share, user)
+
+    settings = get_settings()
+    object_name = f"web-assets/{share_id}/{path}"
+    minio_client = _get_minio_client()
+    try:
+        minio_resp = minio_client.get_object(settings.minio_bucket, object_name)
+        try:
+            data = minio_resp.read()
+            content_type = minio_resp.headers.get("Content-Type", "application/octet-stream")
+        finally:
+            minio_resp.close()
+            minio_resp.release_conn()
+    except S3Error as e:
+        if e.code in ("NoSuchKey", "NoSuchObject"):
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="File not found"
+            ) from e
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to retrieve file: {e}",
+        ) from e
+
+    return Response(
+        content=data,
+        media_type=content_type,
+        headers={"X-Content-Type-Options": "nosniff"},
+    )
 
 
 @router.post("/{share_id}/files/{path:path}/upload-url", response_model=UploadUrlResponse)

--- a/apps/control-plane/tests/test_agent_key_sync_protocol.py
+++ b/apps/control-plane/tests/test_agent_key_sync_protocol.py
@@ -856,14 +856,19 @@ class TestAgentKeyFileToken:
         mock_client = MagicMock()
         mock_client.bucket_exists.return_value = True
         mock_client.stat_object.return_value = MagicMock()
-        mock_client.presigned_get_object.return_value = "https://minio.test/presigned-get"
         with patch("app.api.routers.shares._get_minio_client", return_value=mock_client):
             dl_resp = client.get(
                 f"{BASE}/{share.id}/files/attachments/photo.png/download-url",
                 headers={"Authorization": f"Bearer {file_token}"},
             )
         assert dl_resp.status_code == 200, dl_resp.text
-        assert dl_resp.json()["downloadUrl"] == "https://minio.test/presigned-get"
+        # Regression for effef307: must be OUR control-plane URL (streams bytes
+        # itself via GET .../content), not a raw MinIO presigned URL — MinIO
+        # has no public endpoint, so a client outside the relay's own compose
+        # network could never reach a presigned-MinIO downloadUrl.
+        download_url = dl_resp.json()["downloadUrl"]
+        assert "minio" not in download_url.lower()
+        assert f"/shares/{share.id}/files/attachments/photo.png/content?token=" in download_url
 
     def test_write_only_key_still_cannot_mint(
         self, client: TestClient, test_user: models.User, db_session: Session

--- a/apps/control-plane/tests/test_file_token.py
+++ b/apps/control-plane/tests/test_file_token.py
@@ -71,6 +71,14 @@ def s3_not_found() -> S3Error:
     )
 
 
+def minio_object(content: bytes = b"fake-png-bytes", content_type: str = "image/png") -> MagicMock:
+    """A MinIO get_object() response: .read() + .headers.get(...) + close/release_conn."""
+    resp = MagicMock()
+    resp.read.return_value = content
+    resp.headers = {"Content-Type": content_type}
+    return resp
+
+
 def minio_patch(exists: bool = True):
     """Mocks shares.py's MinIO client — MinIO is a true external boundary."""
     mock_client = MagicMock()
@@ -79,8 +87,10 @@ def minio_patch(exists: bool = True):
         mock_client.stat_object.return_value = MagicMock()
         mock_client.presigned_get_object.return_value = "https://minio.test/presigned-get"
         mock_client.presigned_put_object.return_value = "https://minio.test/presigned-put"
+        mock_client.get_object.return_value = minio_object()
     else:
         mock_client.stat_object.side_effect = s3_not_found()
+        mock_client.get_object.side_effect = s3_not_found()
     return patch("app.api.routers.shares._get_minio_client", return_value=mock_client)
 
 
@@ -257,7 +267,13 @@ class TestHeadFile:
 
 
 class TestDownloadUrl:
-    def test_returns_presigned_url(self, client: TestClient, db_session: Session, owner):
+    def test_returns_control_plane_url_not_minio(
+        self, client: TestClient, db_session: Session, owner
+    ):
+        """Regression for effef307: must NOT be a raw MinIO presigned URL —
+        MinIO has no public endpoint, so a client outside the relay's own
+        compose network can never reach it (DNS: minio, no published port).
+        """
         share = make_folder_share(db_session, owner, slug="dlurl-ok")
         token = login(client, owner.email, "test123456")
         data = mint(client, share.id, token)
@@ -267,7 +283,11 @@ class TestDownloadUrl:
                 headers=bearer(data["token"]),
             )
         assert r.status_code == 200, r.text
-        assert r.json()["downloadUrl"] == "https://minio.test/presigned-get"
+        download_url = r.json()["downloadUrl"]
+        assert "minio" not in download_url.lower()
+        assert download_url.startswith(
+            f"http://localhost:8000/shares/{share.id}/files/attachments/photo.png/content?token="
+        )
 
     def test_missing_object_returns_404(self, client: TestClient, db_session: Session, owner):
         share = make_folder_share(db_session, owner, slug="dlurl-missing")
@@ -291,6 +311,101 @@ class TestDownloadUrl:
                 headers=bearer(data["token"]),
             )
         assert r.status_code == 200, r.text
+
+
+# ── GET /shares/{id}/files/{path}/content (byte-serving, effef307) ───────────
+
+
+def relative_url(download_url: str) -> str:
+    """download_url is absolute (control_plane_public_url); TestClient wants
+    a path+query relative to its own base_url."""
+    from urllib.parse import urlsplit
+
+    parts = urlsplit(download_url)
+    return f"{parts.path}?{parts.query}" if parts.query else parts.path
+
+
+class TestFileContent:
+    def test_end_to_end_returns_bytes(self, client: TestClient, db_session: Session, owner):
+        share = make_folder_share(db_session, owner, slug="content-e2e")
+        token = login(client, owner.email, "test123456")
+        data = mint(client, share.id, token)
+        with minio_patch(exists=True):
+            dl = client.get(
+                f"/shares/{share.id}/files/attachments/photo.png/download-url",
+                headers=bearer(data["token"]),
+            )
+            assert dl.status_code == 200, dl.text
+            # bare GET, no Authorization header — the credential is in the URL.
+            r = client.get(relative_url(dl.json()["downloadUrl"]))
+        assert r.status_code == 200, r.text
+        assert r.content == b"fake-png-bytes"
+        assert r.headers["content-type"] == "image/png"
+
+    def test_viewer_can_fetch_content(self, client: TestClient, db_session: Session, owner, viewer):
+        share = make_folder_share(db_session, owner, slug="content-viewer")
+        add_member(db_session, share, viewer, models.ShareMemberRole.VIEWER)
+        token = login(client, viewer.email, "test123456")
+        data = mint(client, share.id, token)
+        with minio_patch(exists=True):
+            dl = client.get(
+                f"/shares/{share.id}/files/attachments/photo.png/download-url",
+                headers=bearer(data["token"]),
+            )
+            r = client.get(relative_url(dl.json()["downloadUrl"]))
+        assert r.status_code == 200, r.text
+
+    def test_missing_object_returns_404(self, client: TestClient, db_session: Session, owner):
+        share = make_folder_share(db_session, owner, slug="content-missing")
+        token = login(client, owner.email, "test123456")
+        data = mint(client, share.id, token)
+        with minio_patch(exists=True):
+            dl = client.get(
+                f"/shares/{share.id}/files/attachments/photo.png/download-url",
+                headers=bearer(data["token"]),
+            )
+            assert dl.status_code == 200, dl.text
+        with minio_patch(exists=False):
+            r = client.get(relative_url(dl.json()["downloadUrl"]))
+        assert r.status_code == 404
+
+    def test_garbage_token_returns_401(self, client: TestClient, db_session: Session, owner):
+        share = make_folder_share(db_session, owner, slug="content-bad-token")
+        r = client.get(
+            f"/shares/{share.id}/files/attachments/photo.png/content?token=not-a-real-token"
+        )
+        assert r.status_code == 401
+
+    def test_no_token_returns_422(self, client: TestClient, db_session: Session, owner):
+        """token is a required query param — FastAPI 422s before our code runs."""
+        share = make_folder_share(db_session, owner, slug="content-no-token")
+        r = client.get(f"/shares/{share.id}/files/attachments/photo.png/content")
+        assert r.status_code == 422
+
+    def test_wrong_share_id_returns_403(self, client: TestClient, db_session: Session, owner):
+        share_a = make_folder_share(db_session, owner, slug="content-share-a")
+        share_b = make_folder_share(db_session, owner, slug="content-share-b")
+        token = login(client, owner.email, "test123456")
+        data = mint(client, share_a.id, token)
+        with minio_patch(exists=True):
+            dl = client.get(
+                f"/shares/{share_a.id}/files/attachments/photo.png/download-url",
+                headers=bearer(data["token"]),
+            )
+            assert dl.status_code == 200, dl.text
+            raw_token = relative_url(dl.json()["downloadUrl"]).split("token=")[-1]
+            r = client.get(
+                f"/shares/{share_b.id}/files/attachments/photo.png/content?token={raw_token}"
+            )
+        assert r.status_code == 403
+
+    def test_session_jwt_rejected_not_a_file_token(
+        self, client: TestClient, db_session: Session, owner
+    ):
+        share = make_folder_share(db_session, owner, slug="content-session-jwt")
+        token = login(client, owner.email, "test123456")
+        r = client.get(f"/shares/{share.id}/files/attachments/photo.png/content?token={token}")
+        assert r.status_code == 401
 
 
 # ── POST /shares/{id}/files/{path}/upload-url (CAS.ts writeFile) ─────────────


### PR DESCRIPTION
## Summary
- `GET .../download-url` minted a presigned MinIO GET signed for `settings.minio_endpoint` — in prod that's the internal compose hostname `minio:9000`, unreachable by any consumer outside the relay's own network.
- Control-plane now serves the bytes itself (new `GET .../files/{path}/content` route, same read/streaming shape as `web.py`'s `serve_web_asset`), instead of publishing MinIO as a new public surface every self-hoster would then have to expose too.
- `{"downloadUrl": ...}` contract unchanged — no client-side changes needed (CAS.ts, the Mesh sync client both already do a bare `GET` on whatever URL they're handed). Credential rides in the query string (the same short-lived file-token, not a fresh MinIO signature, not the agent key) — same exposure shape the presigned URL already had.

## Test plan
- [x] `TestDownloadUrl` regression: `downloadUrl` is a control-plane URL, not `minio.*`
- [x] New `TestFileContent`: end-to-end (mint → download-url → bare-GET the returned URL → correct bytes/content-type), viewer access, missing-object 404, garbage/session-JWT token 401, wrong-share 403
- [x] Updated agent-key end-to-end test for the new URL shape
- [x] Full suite: `771 passed, 1 skipped`
- [x] `ruff check` clean