### PR TITLE
ci: build control-plane and web-publish as native linux/arm64 + amd64 images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,26 @@ env:
   IMAGE_PREFIX: ${{ github.repository }}
 
 jobs:
-  build-and-push:
-    runs-on: ubuntu-latest
+  build:
+    # One leg per (image, platform) pair, each on a NATIVE runner for that
+    # platform -- not `platforms: linux/amd64,linux/arm64` on a single amd64
+    # runner, which would build arm64 under QEMU. Measured cost difference
+    # (runs 32436501549, 32436883170): arm64 native on ubuntu-24.04-arm ~18s
+    # vs ~130s under QEMU on ubuntu-latest, for a cold control-plane build.
+    # Native ARM runners are free on public repos, so there's no QEMU tradeoff
+    # to make here. Each leg pushes by digest only (no tag) -- `merge` below
+    # assembles the real tags from these digests via `imagetools create`,
+    # which is what makes the multi-platform manifest, not this job.
+    strategy:
+      fail-fast: false
+      matrix:
+        image: [control-plane, web-publish]
+        platform:
+          - name: linux/amd64
+            runner: ubuntu-latest
+          - name: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.platform.runner }}
     permissions:
       contents: read
       packages: write
@@ -35,11 +53,79 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata for control-plane
-        id: meta-cp
+      - name: Platform slug for artifact naming
+        id: slug
+        run: echo "slug=$(echo '${{ matrix.platform.name }}' | tr '/' '-')" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push ${{ matrix.image }} (${{ matrix.platform.name }})
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        with:
+          context: apps/${{ matrix.image }}
+          platforms: ${{ matrix.platform.name }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/${{ matrix.image }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=${{ matrix.image }}-${{ steps.slug.outputs.slug }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.image }}-${{ steps.slug.outputs.slug }}
+          # web-publish's Dockerfile needs this to `npm ci` against our
+          # private @entire-vc scope. Every leg runs its own real npm ci --
+          # there is no cross-platform GHA cache entry to replay from on a
+          # platform's first-ever build, which is exactly what caught this
+          # secret being missing in the first place (see git blame / #222).
+          secrets: |
+            github_token=${{ secrets.GITHUB_TOKEN }}
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests/${{ matrix.image }}
+          digest='${{ steps.build.outputs.digest }}'
+          touch "/tmp/digests/${{ matrix.image }}/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: digests-${{ matrix.image }}-${{ steps.slug.outputs.slug }}
+          path: /tmp/digests/${{ matrix.image }}/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    # Assembles the per-platform digests from `build` into the real
+    # multi-platform manifest for each image's semver tags -- no rebuild,
+    # imagetools just writes a manifest list pointing at the already-pushed
+    # digests. Same "merge by digest, don't rebuild" shape this workflow
+    # already used for `latest` in promote-latest below.
+    needs: build
+    strategy:
+      matrix:
+        image: [control-plane, web-publish]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+        with:
+          path: /tmp/digests
+          pattern: digests-${{ matrix.image }}-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for ${{ matrix.image }}
+        id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/control-plane
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/${{ matrix.image }}
           # No `latest` here on purpose: this job runs before smoke-test, so
           # tagging `latest` here would move it onto an unvalidated image the
           # moment a build succeeds — a failing smoke-test would then leave
@@ -51,46 +137,21 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
 
-      - name: Build and push control-plane
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
-        with:
-          context: apps/control-plane
-          push: true
-          tags: ${{ steps.meta-cp.outputs.tags }}
-          labels: ${{ steps.meta-cp.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - name: Create multi-platform manifest
+        working-directory: /tmp/digests
+        run: |
+          # shellcheck disable=SC2046 # word-splitting is deliberate here:
+          # each $() expands to multiple `-t <tag>` / `<ref>@sha256:...`
+          # arguments for imagetools create, not one string.
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/${{ matrix.image }}@sha256:%s ' *)
+        env:
+          DOCKER_METADATA_OUTPUT_JSON: ${{ steps.meta.outputs.json }}
 
-      - name: Extract metadata for web-publish
-        id: meta-wp
-        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/web-publish
-          # See the control-plane metadata step above for why `latest` is
-          # deliberately absent here.
-          tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-
-      - name: Build and push web-publish
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
-        with:
-          context: apps/web-publish
-          push: true
-          tags: ${{ steps.meta-wp.outputs.tags }}
-          labels: ${{ steps.meta-wp.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          # apps/web-publish/Dockerfile mounts this to run `npm ci` against
-          # our private @entire-vc scope. It was missing here (never present,
-          # not lost), so every release since the workflow was written has
-          # been REPLAYING a cached npm-ci layer rather than building one: a
-          # cold build fails with npm E401 on every platform. Green releases
-          # were survivorship, not evidence — the cache is evicted after 7
-          # idle days, and a new platform has no entry at all by construction.
-          # Byte-identical to what ci.yml's build-docker already passes.
-          secrets: |
-            github_token=${{ secrets.GITHUB_TOKEN }}
+      - name: Inspect merged manifest
+        run: |
+          docker buildx imagetools inspect '${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/${{ matrix.image }}:${{ steps.meta.outputs.version }}'
 
   smoke-test:
     # Boots the JUST-PUBLISHED images against a clean database and asserts
@@ -101,7 +162,7 @@ jobs:
     # from nothing. Deliberately does NOT reuse cache-from/cache-to or any
     # locally-built layer — it pulls from ghcr exactly like an external
     # installer's `bash scripts/pull-published-images.sh` would.
-    needs: build-and-push
+    needs: merge
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -171,7 +232,7 @@ jobs:
     # pull them. No rebuild here — `imagetools create` just repoints the
     # `latest` tag at the already-pushed, already-tested manifest by digest,
     # so this cannot silently diverge from what smoke-test actually checked.
-    needs: [build-and-push, smoke-test]
+    needs: [merge, smoke-test]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -197,7 +258,7 @@ jobs:
           done
 
   create-release:
-    needs: [build-and-push, smoke-test]
+    needs: [merge, smoke-test]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/README.md
+++ b/README.md
@@ -52,10 +52,11 @@ You want your team in Obsidian, editing together, publishing docs — without gi
 Full walkthrough — DNS, production hardening, systemd, troubleshooting — lives in the
 **[Installation Guide](docs/installation.md)**. The short version:
 
-> **arm64 hosts** (Apple Silicon, Graviton, Ampere, Raspberry Pi): the published images
-> are `linux/amd64` only — `control-plane`, `web-publish` and `relay-server` alike. Run
-> `export DOCKER_DEFAULT_PLATFORM=linux/amd64` first to use them under emulation, or see
-> [Installation → Architecture](docs/installation.md#architecture).
+> **arm64 hosts** (Apple Silicon, Graviton, Ampere, Raspberry Pi): `control-plane` and
+> `web-publish` publish native `linux/arm64` images, no setup needed. `relay-server` is
+> still `linux/amd64` only — Compose pulls it under emulation automatically (pinned in
+> `infra/docker-compose.yml`), nothing to export. See
+> [Installation → Architecture](docs/installation.md#architecture) for details.
 
 ```bash
 git clone https://github.com/entire-vc/evc-team-relay.git

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -19,19 +19,21 @@ This guide covers installing EVC Team Relay on a Linux server using Docker Compo
 
 ### Architecture
 
-**The published images are `linux/amd64` only** — `control-plane`, `web-publish`
-and `relay-server` alike. There is no `arm64` manifest, so on an arm64 host
-(Apple Silicon, AWS Graviton, Ampere at Hetzner/OVH, Raspberry Pi) the install
-below stops at the pull step unless you run them under emulation:
+**`control-plane` and `web-publish` publish native `linux/amd64` and
+`linux/arm64` images** — no setup needed on Apple Silicon, AWS Graviton,
+Ampere at Hetzner/OVH, or Raspberry Pi; Docker pulls the manifest matching
+your host automatically, and `scripts/pull-published-images.sh` (step 6
+below) picks the right one on its own.
 
-```bash
-export DOCKER_DEFAULT_PLATFORM=linux/amd64
-```
-
-Export it for the whole session rather than prefixing one command: `relay-server`
-is pulled later by `docker compose up`, not by the pull script, and it needs the
-same setting. Emulated amd64 on arm64 is noticeably slower — fine for a local
-trial or demo, not what we'd recommend for a production install.
+**`relay-server` is still `linux/amd64` only.** It's a separately-published
+third-party image (not built by this repo), and there is no `arm64`
+manifest for it yet. `infra/docker-compose.yml` pins it to
+`platform: linux/amd64`, so `docker compose up` pulls and runs it under
+emulation automatically on an arm64 host — nothing to export, and
+`control-plane`/`web-publish` are unaffected since only `relay-server`
+carries the pin. Emulated amd64 on arm64 is noticeably slower for that
+one container — fine for a local trial or demo, not what we'd recommend
+for a production install.
 
 ### Ports
 
@@ -166,10 +168,10 @@ This tags them locally as `infra-control-plane:latest` / `infra-web-publish:late
 `docker compose up` picks up without attempting to build. Pass a version to pin one
 (`bash scripts/pull-published-images.sh 1.10.0`) instead of the default `latest`.
 
-> **arm64 hosts:** these images are linux/amd64 only, and so is `relay-server` in step 7 —
-> `export DOCKER_DEFAULT_PLATFORM=linux/amd64` for the session before running this (see
-> [Architecture](#architecture) above). The script refuses with an explanation rather than
-> pulling something that can't run.
+> **arm64 hosts:** nothing to do here — the script pulls the native `linux/arm64` build
+> of both images automatically. `relay-server` in step 7 is still `linux/amd64` only, but
+> that's handled by a `platform:` pin in `infra/docker-compose.yml`, not by this script;
+> see [Architecture](#architecture) above.
 
 If you do have org access and want to build from source instead (e.g. active development),
 skip this step and run `docker compose up -d --build` in step 7.

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -240,6 +240,10 @@ services:
 
   relay-server:
     image: ghcr.io/entire-vc/evc-relay-server:0.9.12
+    # Third-party image, linux/amd64 only — no arm64 manifest yet. Pinned here
+    # (rather than via a session-wide DOCKER_DEFAULT_PLATFORM export) so an
+    # arm64 host still pulls control-plane/web-publish natively.
+    platform: linux/amd64
     depends_on:
       minio:
         condition: service_healthy

--- a/scripts/pull-published-images.sh
+++ b/scripts/pull-published-images.sh
@@ -10,12 +10,13 @@
 # Both images are published publicly by .github/workflows/release.yml on
 # every version tag; no login is required to pull them.
 #
-# Published images are linux/amd64 only — see the preflight below, which
-# refuses with an explanation rather than letting the Docker daemon's own
-# "no matching manifest for linux/arm64/v8" surface with no cause and no way
-# forward. relay-server (pulled later by `docker compose up`, not by this
-# script) is amd64-only for the same reason, so the workaround below has to
-# be exported for the whole session, not just this command.
+# Both images publish linux/amd64 and linux/arm64 — the preflight below only
+# fires for a platform outside that pair, with an explanation rather than
+# letting the Docker daemon's own "no matching manifest for ..." surface with
+# no cause and no way forward. relay-server (pulled later by `docker compose
+# up`, not by this script) is still amd64-only third-party; it's pinned to
+# `platform: linux/amd64` in infra/docker-compose.yml so it runs under
+# emulation on an arm64 host without affecting these two images.
 #
 # Usage:
 #   bash scripts/pull-published-images.sh [version]   # default: latest
@@ -58,18 +59,16 @@ unsupported_platform_error() {
 ERROR: the published Team Relay images do not include your platform.
 
   your platform:     ${want}
-  images published:  ${have:-linux/amd64 only}
+  images published:  ${have:-linux/amd64, linux/arm64}
 
-The images built by our release pipeline are linux/amd64 only. This affects
-every arm64 host: Apple Silicon, AWS Graviton, Ampere at Hetzner/OVH,
-Raspberry Pi. Two ways forward:
+The images built by our release pipeline currently target linux/amd64 and
+linux/arm64 (Apple Silicon, AWS Graviton, Ampere, Raspberry Pi included) —
+your platform isn't one of those. Two ways forward:
 
-  1. Run the amd64 images under emulation. Slower, but the whole documented
-     install path works unchanged. Export it for the session, because
-     'docker compose up' later pulls relay-server, which is amd64-only too:
+  1. Run the amd64 images under emulation for this pull only. Slower, but
+     the whole documented install path works unchanged:
 
-         export DOCKER_DEFAULT_PLATFORM=linux/amd64
-         bash scripts/pull-published-images.sh ${VERSION}
+         DOCKER_DEFAULT_PLATFORM=linux/amd64 bash scripts/pull-published-images.sh ${VERSION}
 
   2. Build from source for your own architecture instead of pulling:
 
@@ -80,7 +79,7 @@ Raspberry Pi. Two ways forward:
      @entire-vc npm packages (apps/web-publish/.npmrc); if you don't have
      one, option 1 is your path.
 
-Tracking arm64 images: https://github.com/entire-vc/evc-team-relay/issues
+Tracking additional platforms: https://github.com/entire-vc/evc-team-relay/issues
 
 MSG
   exit 1


### PR DESCRIPTION
## Summary

- `.github/workflows/release.yml`: replace the single amd64-only `build-and-push` job with a `build` matrix (2 images × 2 platforms, one leg per pair on a native runner — `ubuntu-latest` / `ubuntu-24.04-arm`, both free on this public repo) pushing by digest only, plus a `merge` job that assembles the final multi-arch manifest via `docker buildx imagetools create` (Docker's documented digest-export pattern, no rebuild). Downstream jobs (`smoke-test`, `promote-latest`, `create-release`) are otherwise unchanged; `imagetools create ... :latest` naturally becomes multi-arch too.
- `infra/docker-compose.yml`: pin `relay-server` (third-party, amd64-only, no arm64 manifest) to `platform: linux/amd64` — scopes the emulation requirement to that one image instead of the previous session-wide `DOCKER_DEFAULT_PLATFORM` export, which would now also force `control-plane`/`web-publish` into unnecessary emulation.
- `README.md`, `docs/installation.md`, `scripts/pull-published-images.sh`: correct arm64 guidance and informational text now that 2 of 3 images are multi-arch — no `export DOCKER_DEFAULT_PLATFORM` step needed for the install path anymore.

## Test plan

- [x] `.github/workflows/release.yml` is valid YAML and `actionlint`-clean (one pre-existing, unrelated `SC2016` warning remains in the untouched `smoke-test` step)
- [x] `shellcheck scripts/pull-published-images.sh` — clean
- [x] Both new SHA pins (`upload-artifact@v4`, `download-artifact@v5`) verified against `gh api repos/<owner>/<repo>/git/refs/tags/<tag>`
- [ ] CI on this PR proves the digest-export → `imagetools create` merge mechanism end-to-end (this can only be verified on real native amd64+arm64 runners, not locally)
- [ ] After merge, a real version tag will exercise the full `build` → `merge` → `smoke-test` → `promote-latest`/`create-release` pipeline; `docker manifest inspect` on the resulting tag should show both platforms for both images

— Daedalus, Entire VC