### PR TITLE
scratch: throwaway workflow to verify multi-arch digest-merge mechanism

### DIFF
--- a/.github/workflows/_scratch-arch-test.yml
+++ b/.github/workflows/_scratch-arch-test.yml
@@ -1,0 +1,97 @@
+name: scratch-arch-test
+
+on:
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE: entire-vc/evc-team-relay/scratch-arch-test
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - name: linux/amd64
+            runner: ubuntu-latest
+          - name: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.platform.runner }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Platform slug for artifact naming
+        id: slug
+        run: echo "slug=$(echo '${{ matrix.platform.name }}' | tr '/' '-')" >> "$GITHUB_OUTPUT"
+      - name: Build tiny per-arch test image
+        run: |
+          mkdir -p /tmp/ctx
+          cat > /tmp/ctx/Dockerfile <<'EOF'
+          FROM alpine:3.20
+          ARG TARGETPLATFORM
+          RUN echo "built for ${TARGETPLATFORM}" > /platform.txt
+          CMD ["cat", "/platform.txt"]
+          EOF
+      - name: Build and push (digest only)
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        with:
+          context: /tmp/ctx
+          platforms: ${{ matrix.platform.name }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest='${{ steps.build.outputs.digest }}'
+          touch "/tmp/digests/${digest#sha256:}"
+      - name: Upload digest
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: digests-${{ steps.slug.outputs.slug }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create multi-platform manifest
+        working-directory: /tmp/digests
+        run: |
+          # shellcheck disable=SC2046 # word-splitting is deliberate: $() expands
+          # to multiple `<ref>@sha256:...` arguments for imagetools create.
+          docker buildx imagetools create \
+            -t ${{ env.REGISTRY }}/${{ env.IMAGE }}:scratch-test \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE }}@sha256:%s ' *)
+      - name: Inspect merged manifest
+        run: |
+          docker buildx imagetools inspect '${{ env.REGISTRY }}/${{ env.IMAGE }}:scratch-test'


### PR DESCRIPTION
## Summary

Throwaway workflow, not a product change — verifies the digest-export +
`docker buildx imagetools create` merge pattern used in #225 actually
produces a working multi-arch manifest on real native amd64+arm64 runners
before that PR is trusted. Pushes to a distinctly-named test image
(`scratch-arch-test`), not any production image.

Will be removed in a follow-up PR right after the verification run.

## Test plan

- [x] YAML valid, `actionlint`-clean
- [ ] `workflow_dispatch` run produces a manifest with both `linux/amd64` and `linux/arm64`

— Daedalus, Entire VC