### PR TITLE
fix: remove stale amd64-only platform pin on relay-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,9 @@ You want your team in Obsidian, editing together, publishing docs — without gi
 Full walkthrough — DNS, production hardening, systemd, troubleshooting — lives in the
 **[Installation Guide](docs/installation.md)**. The short version:
 
-> **arm64 hosts** (Apple Silicon, Graviton, Ampere, Raspberry Pi): `control-plane` and
-> `web-publish` publish native `linux/arm64` images, no setup needed. `relay-server` is
-> still `linux/amd64` only — Compose pulls it under emulation automatically (pinned in
-> `infra/docker-compose.yml`), nothing to export. See
+> **arm64 hosts** (Apple Silicon, Graviton, Ampere, Raspberry Pi): `control-plane`,
+> `web-publish`, and `relay-server` all publish native `linux/arm64` images — nothing to
+> export, nothing to pin. See
 > [Installation → Architecture](docs/installation.md#architecture) for details.
 
 ```bash

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -19,21 +19,14 @@ This guide covers installing EVC Team Relay on a Linux server using Docker Compo
 
 ### Architecture
 
-**`control-plane` and `web-publish` publish native `linux/amd64` and
-`linux/arm64` images** — no setup needed on Apple Silicon, AWS Graviton,
-Ampere at Hetzner/OVH, or Raspberry Pi; Docker pulls the manifest matching
-your host automatically, and `scripts/pull-published-images.sh` (step 6
-below) picks the right one on its own.
-
-**`relay-server` is still `linux/amd64` only.** It's a separately-published
-third-party image (not built by this repo), and there is no `arm64`
-manifest for it yet. `infra/docker-compose.yml` pins it to
-`platform: linux/amd64`, so `docker compose up` pulls and runs it under
-emulation automatically on an arm64 host — nothing to export, and
-`control-plane`/`web-publish` are unaffected since only `relay-server`
-carries the pin. Emulated amd64 on arm64 is noticeably slower for that
-one container — fine for a local trial or demo, not what we'd recommend
-for a production install.
+**`control-plane`, `web-publish`, and `relay-server` all publish native
+`linux/amd64` and `linux/arm64` images** — no setup needed on Apple
+Silicon, AWS Graviton, Ampere at Hetzner/OVH, or Raspberry Pi; Docker
+pulls the manifest matching your host automatically, and
+`scripts/pull-published-images.sh` (step 6 below) picks the right one on
+its own for the two images it handles. `relay-server` is pulled later, by
+`docker compose up` itself in step 7 — same automatic manifest match,
+no platform pin, nothing to export.
 
 ### Ports
 
@@ -169,9 +162,9 @@ This tags them locally as `infra-control-plane:latest` / `infra-web-publish:late
 (`bash scripts/pull-published-images.sh 1.10.0`) instead of the default `latest`.
 
 > **arm64 hosts:** nothing to do here — the script pulls the native `linux/arm64` build
-> of both images automatically. `relay-server` in step 7 is still `linux/amd64` only, but
-> that's handled by a `platform:` pin in `infra/docker-compose.yml`, not by this script;
-> see [Architecture](#architecture) above.
+> of both images automatically. `relay-server` in step 7 is native `linux/arm64` too,
+> pulled directly by `docker compose up` with no platform pin; see
+> [Architecture](#architecture) above.
 
 If you do have org access and want to build from source instead (e.g. active development),
 skip this step and run `docker compose up -d --build` in step 7.

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -240,10 +240,9 @@ services:
 
   relay-server:
     image: ghcr.io/entire-vc/evc-relay-server:0.9.12
-    # Third-party image, linux/amd64 only — no arm64 manifest yet. Pinned here
-    # (rather than via a session-wide DOCKER_DEFAULT_PLATFORM export) so an
-    # arm64 host still pulls control-plane/web-publish natively.
-    platform: linux/amd64
+    # Third-party image; publishes linux/amd64 + linux/arm64 as of 0.9.12 —
+    # no platform pin needed, Docker picks the manifest matching the host
+    # automatically, same as control-plane/web-publish.
     depends_on:
       minio:
         condition: service_healthy

--- a/scripts/pull-published-images.sh
+++ b/scripts/pull-published-images.sh
@@ -14,9 +14,8 @@
 # fires for a platform outside that pair, with an explanation rather than
 # letting the Docker daemon's own "no matching manifest for ..." surface with
 # no cause and no way forward. relay-server (pulled later by `docker compose
-# up`, not by this script) is still amd64-only third-party; it's pinned to
-# `platform: linux/amd64` in infra/docker-compose.yml so it runs under
-# emulation on an arm64 host without affecting these two images.
+# up`, not by this script) is also linux/amd64 + linux/arm64 as of 0.9.12 —
+# no platform pin needed anywhere in infra/docker-compose.yml.
 #
 # Usage:
 #   bash scripts/pull-published-images.sh [version]   # default: latest


### PR DESCRIPTION
## What

`relay-server` now publishes `linux/amd64` + `linux/arm64` (evc-relay-server
release 0.9.12, [PR #31](https://github.com/entire-vc/evc-relay-server/pull/31)).
The `platform: linux/amd64` pin in `infra/docker-compose.yml` was correct
when it was added, but now that a native arm64 image exists it would
silently keep forcing amd64 emulation for `relay-server` on arm64 hosts —
quietly defeating the point of the fix, since nothing about the pin's
presence signals that it's now unnecessary.

## Change

- Removed the `platform: linux/amd64` pin — Docker now picks the manifest
  matching the host automatically for all three images (`control-plane`,
  `web-publish`, `relay-server` alike).
- Updated the three doc/script locations that documented the old
  amd64-only state: the README quick-start callout, `docs/installation.md`'s
  Architecture section and step 6 callout, and `pull-published-images.sh`'s
  own header comment (the script itself doesn't touch `relay-server` — it's
  pulled later by `docker compose up` — but its comment described the old
  pin and needed the same update).

## Verification

- `docker manifest inspect ghcr.io/entire-vc/evc-relay-server:0.9.12` shows
  both `linux/amd64` and `linux/arm64`.
- Live positive control on Apple Silicon, no `DOCKER_DEFAULT_PLATFORM`
  override: fresh `docker pull` of `0.9.12` selects `linux/arm64`
  automatically (`docker image inspect ... --format '{{.Architecture}}'` →
  `arm64`); recreated the container and confirmed it reaches `healthy`
  (Docker's own `HEALTHCHECK` plus a direct in-container `curl .../ready` →
  200).