### PR TITLE
fix(backup): restore-test.sh temp container superuser must match prod (relay, not postgres)

### DIFF
--- a/infra/backup/restore-test.sh
+++ b/infra/backup/restore-test.sh
@@ -9,14 +9,23 @@
 # Required env vars (or inherit from .env):
 #   BACKUP_DIR      - directory with *.sql.gz dumps (default: /opt/relay/data/backups)
 #   POSTGRES_DB     - database name to restore into (default: relay)
-#   POSTGRES_USER   - postgres superuser (default: postgres)
+#   POSTGRES_USER   - postgres superuser (default: relay — matches prod's actual
+#                     superuser role name; see the OWNER-TO note below)
 #   POSTGRES_PASSWORD - postgres password for the temp container
 
 set -euo pipefail
 
 BACKUP_DIR="${BACKUP_DIR:-/opt/relay/data/backups}"
 POSTGRES_DB="${POSTGRES_DB:-relay}"
-POSTGRES_USER="${POSTGRES_USER:-postgres}"
+# Prod's postgres container is itself started with POSTGRES_USER=relay (there is
+# no "postgres" role in prod at all) and pg_dump/pg_dumpall therefore emits
+# `ALTER TABLE/TYPE ... OWNER TO relay` for every object. Defaulting this temp
+# container to the generic "postgres" superuser name made every one of those
+# statements fail with `role "relay" does not exist` — ~27 lines on every
+# single successful run, since the role name never matched. Matching prod's
+# actual superuser name here isn't a workaround, it's fidelity: the restored
+# ownership now matches what a real disaster recovery would produce.
+POSTGRES_USER="${POSTGRES_USER:-relay}"
 POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-restore_test_$(date +%s)}"
 CONTAINER_NAME="relay-restore-test-$$"
 PG_IMAGE="postgres:16-alpine"
@@ -64,10 +73,16 @@ for i in $(seq 1 20); do
 done
 pass "Temp postgres ready"
 
-# Restore dump
+# Restore dump. -v ON_ERROR_STOP=1 makes psql abort (and thus this pipeline,
+# via `set -o pipefail`) on the FIRST real SQL error instead of printing it
+# and quietly ploughing on to the next statement — without it, an actual
+# corrupt/truncated dump can print pages of ERROR lines and still exit 0,
+# which is exactly the "ERROR that means nothing" class this script exists
+# to close (see the OWNER-TO-relay note above for the case that used to do
+# just that on every green run).
 log "Restoring ${BACKUP_FILE} into ${CONTAINER_NAME}/${POSTGRES_DB}"
 gunzip -c "${BACKUP_FILE}" | docker exec -i "${CONTAINER_NAME}" \
-    psql -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -q
+    psql -v ON_ERROR_STOP=1 -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -q
 pass "Restore complete"
 
 # Verify: table count > 0


### PR DESCRIPTION
## Problem

`infra/backup/restore-test.sh` prints ~27 `ERROR: role "relay" does not exist` lines on every single **successful** drill run. The acceptance checks (table count, key-table row counts) all pass regardless — the restore genuinely works — but a log where ERROR is normal on the green path is a log where a real ERROR won't get noticed.

## Root cause

Prod's `relay-postgres-1` container has **no `postgres` role at all** — it's started with `POSTGRES_USER=relay`, confirmed live:

```
$ ssh tr-relay-vm 'docker exec relay-postgres-1 psql -U postgres ...'
FATAL: role "postgres" does not exist
$ ssh tr-relay-vm 'docker exec relay-postgres-1 env | grep POSTGRES_USER'
POSTGRES_USER=relay
```

So `pg_dump` emits `ALTER TABLE/TYPE ... OWNER TO relay` for every one of the 27 objects in the schema (confirmed: `zcat relay_latest.sql.gz | grep -c 'OWNER TO relay'` returns 27, matching the reported count exactly). The drill's temp container defaulted to `POSTGRES_USER=postgres`, so every one of those OWNER statements failed — same 27 lines, every green run, forever.

## Fix

- Default `POSTGRES_USER` to `relay` — this isn't a workaround, it's fidelity: the temp container's superuser now matches prod's actual configuration, so the restored ownership matches what a real disaster recovery would produce. (Considered the alternative — `--no-owner --no-acl` — but that would mean the drill's restore no longer exercises the same statements a real recovery runs; matching prod's real user name is free and closer to the truth.)
- Added `-v ON_ERROR_STOP=1` to the restore's `psql` invocation so a genuinely broken dump aborts immediately and visibly instead of printing errors and quietly continuing to a false PASS — turning "ERROR" back into a real signal, not just removing the noise.

## Verification (local, real dump pulled from prod)

**Positive control** — real `relay_latest.sql.gz`, unmodified:
```
$ BACKUP_DIR=... POSTGRES_DB=relay bash infra/backup/restore-test.sh
...
=== RESTORE-TEST RESULT ===
Status: PASS
$ echo $?
0
$ grep -c ERROR run.log
0
```

**Negative control** — same dump with the `CREATE TABLE public.users` block deleted (gzip integrity intact):
```
$ BACKUP_DIR=.../negative bash infra/backup/restore-test.sh
...
ERROR:  syntax error at or near ")"
$ echo $?
3
```
Visible ERROR, non-zero exit, restore aborts before the table-count assertions — corruption is caught, not hidden.

## Test plan
- [x] Positive control: real dump restores clean, 0 ERROR lines, exit 0
- [x] Negative control: corrupted dump shows ERROR and fails (exit 3)
- [ ] Full scheduled drill run once merged, to confirm the fix holds end to end