### PR TITLE
fix(web-publish): proxy real upstream status on _assets, never forward upstream body

### DIFF
--- a/apps/web-publish/src/routes/[slug]/_assets/[...path]/+server.ts
+++ b/apps/web-publish/src/routes/[slug]/_assets/[...path]/+server.ts
@@ -1,6 +1,31 @@
+import { fetchWithTimeout } from '$lib/api';
 import type { RequestHandler } from './$types';
 
 const CONTROL_PLANE_URL = process.env.CONTROL_PLANE_URL || 'http://control-plane:8000';
+
+// #d0e32ac0: map the upstream status instead of collapsing everything into a
+// blanket 404 — but NEVER forward the upstream response body on an error
+// branch. control-plane's 500 body carries a raw S3Error (bucket name,
+// object key); the old blanket-404 accidentally hid that leak, a naive
+// pass-through would have exposed it. Status is proxied, body is always ours.
+function upstreamErrorResponse(status: number): Response {
+	if (status === 401) {
+		// No WWW-Authenticate: this URL can be loaded from a bare <img src>,
+		// and that header triggers a native basic-auth browser dialog — we
+		// use cookie/OAuth, not basic auth, so the dialog can't do anything.
+		return new Response('Authentication required', { status: 401 });
+	}
+	if (status === 403) {
+		return new Response('Forbidden', { status: 403 });
+	}
+	if (status === 404) {
+		return new Response('Asset not found', { status: 404 });
+	}
+	// 5xx (and any other unexpected upstream status) → 502: the proxy itself
+	// is fine, the upstream failed. A bare 500 here would read as web-publish
+	// itself being down rather than control-plane/MinIO.
+	return new Response('Upstream error', { status: 502 });
+}
 
 export const GET: RequestHandler = async ({ params, request, url }) => {
 	const { slug, path } = params;
@@ -15,13 +40,20 @@ export const GET: RequestHandler = async ({ params, request, url }) => {
 	const agentKey = url.searchParams.get('agent_key');
 	if (agentKey) headers['X-Agent-Key'] = agentKey;
 
-	const response = await fetch(
-		`${CONTROL_PLANE_URL}/v1/web/shares/${slug}/assets?path=${encodeURIComponent(path)}`,
-		{ headers }
-	);
+	let response: Response;
+	try {
+		response = await fetchWithTimeout(
+			`${CONTROL_PLANE_URL}/v1/web/shares/${slug}/assets?path=${encodeURIComponent(path)}`,
+			{ headers }
+		);
+	} catch {
+		// Network error or abort/timeout — control-plane never answered at
+		// all, distinct from it answering with a 5xx.
+		return new Response('Upstream timeout', { status: 504 });
+	}
 
 	if (!response.ok) {
-		return new Response('Asset not found', { status: 404 });
+		return upstreamErrorResponse(response.status);
 	}
 
 	const body = await response.arrayBuffer();

--- a/apps/web-publish/src/tests/assetsProxy.test.ts
+++ b/apps/web-publish/src/tests/assetsProxy.test.ts
@@ -76,3 +76,114 @@ describe('GET /[slug]/_assets/[...path] — Cache-Control forwarding (TR-60)', (
 		expect(response.headers.get('Content-Type')).toBe('image/png');
 	});
 });
+
+// #d0e32ac0: the proxy used to collapse every non-2xx upstream response
+// (401 private share, 403 wrong scope, 404 missing file, 500 storage error)
+// into an identical `404 "Asset not found"`, making them indistinguishable
+// on the public surface. These tests pin the real status-code mapping and,
+// separately, that the upstream response BODY is never forwarded on an
+// error branch — control-plane's 500 carries a raw S3Error with the bucket
+// name and object key, which must never reach a public caller.
+
+function makeErrorEvent(
+	upstream: { status: number; body?: string } | 'throw'
+): { params: { slug: string; path: string }; request: Request; url: URL } {
+	if (upstream === 'throw') {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(() => Promise.reject(new Error('network error')))
+		);
+	} else {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(() =>
+				Promise.resolve(
+					new Response(upstream.body ?? '', { status: upstream.status })
+				)
+			)
+		);
+	}
+
+	return {
+		params: { slug: 'test-slug', path: 'image.png' },
+		request: new Request('http://localhost/test-slug/_assets/image.png'),
+		url: new URL('http://localhost/test-slug/_assets/image.png')
+	};
+}
+
+describe('GET /[slug]/_assets/[...path] — upstream error status mapping (#d0e32ac0)', () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('maps upstream 401 (private share, no creds) to 401', async () => {
+		const response = await GET(
+			makeErrorEvent({
+				status: 401,
+				body: JSON.stringify({ error: { code: 401, message: 'Authentication required for private share' } })
+			}) as never
+		);
+		expect(response.status).toBe(401);
+	});
+
+	it('does not set WWW-Authenticate on 401 (would trigger a native basic-auth dialog on <img> loads)', async () => {
+		const response = await GET(makeErrorEvent({ status: 401 }) as never);
+		expect(response.headers.has('WWW-Authenticate')).toBe(false);
+	});
+
+	it('maps upstream 403 (wrong scope) to 403', async () => {
+		const response = await GET(makeErrorEvent({ status: 403 }) as never);
+		expect(response.status).toBe(403);
+	});
+
+	it('maps upstream 404 (file genuinely missing) to 404 "Asset not found" — unchanged', async () => {
+		const response = await GET(makeErrorEvent({ status: 404 }) as never);
+		expect(response.status).toBe(404);
+		expect(await response.text()).toBe('Asset not found');
+	});
+
+	it('maps upstream 500 to 502 (proxy is fine, upstream failed — not our own outage)', async () => {
+		const response = await GET(
+			makeErrorEvent({
+				status: 500,
+				body: JSON.stringify({
+					detail: "Failed to retrieve asset: NoSuchKey: The specified key does not exist. Bucket: web-assets, Key: web-assets/share-123/secret.png"
+				})
+			}) as never
+		);
+		expect(response.status).toBe(502);
+	});
+
+	it('maps a fetch throw/network error to 504 (upstream never answered, distinct from a 5xx)', async () => {
+		const response = await GET(makeErrorEvent('throw') as never);
+		expect(response.status).toBe(504);
+	});
+
+	it('never forwards the upstream error body — no bucket name, key, or S3Error leak', async () => {
+		const response = await GET(
+			makeErrorEvent({
+				status: 500,
+				body: JSON.stringify({
+					detail: "Failed to retrieve asset: NoSuchKey: The specified key does not exist. Bucket: web-assets, Key: web-assets/share-123/secret.png"
+				})
+			}) as never
+		);
+		const text = await response.text();
+		expect(text).not.toContain('web-assets/');
+		expect(text).not.toContain('Bucket');
+		expect(text).not.toContain('S3Error');
+		expect(text).not.toContain('NoSuchKey');
+	});
+
+	it('never forwards the upstream error body on 401/403 either', async () => {
+		const response = await GET(
+			makeErrorEvent({
+				status: 401,
+				body: JSON.stringify({ error: { code: 401, message: 'Authentication required for private share', internal_share_id: 'share-123' } })
+			}) as never
+		);
+		const text = await response.text();
+		expect(text).not.toContain('share-123');
+		expect(text).not.toContain('internal_share_id');
+	});
+});


### PR DESCRIPTION
## Проблема

`apps/web-publish/src/routes/[slug]/_assets/[...path]/+server.ts` заваливал любой неуспешный ответ control-plane (401 приватная шара, 403 не тот скоуп, 404 файла нет, 500 сбой хранилища) в один и тот же `404 "Asset not found"` — на публичной поверхности (docs.entire.vc) их нельзя было различить. Это стоило часов независимой приёмке на `#a9df0f4a`/`#5f659ea3`.

## Фикс

Статус проксируется как есть — по коду control-plane (`web.py:1035 serve_web_asset`) авторизация проверяется строго раньше существования файла, поэтому неаутентифицированный получает одинаковый статус на любой путь и перечислимости файлов не появляется.

| upstream | наружу | тело |
|---|---|---|
| 401 | 401 | своё, без деталей |
| 403 | 403 | своё |
| 404 | 404 | `Asset not found` — без изменений |
| 5xx / неожиданный | 502 | своё |
| throw / timeout | 504 | своё |

Тело апстрима **никогда** не форвардится ни в одной ветке — 500 у control-plane несёт сырой `S3Error` с именем бакета и ключом объекта (`web-assets/{share_id}/{path}`); наивный сквозной проброс превратил бы баг статуса в утечку внутренностей. `WWW-Authenticate` на 401 не ставится (URL грузится из `<img>`, заголовок вызвал бы нативный basic-auth диалог — у нас cookie/OAuth).

Заодно завернул fetch в существующий `fetchWithTimeout` (`$lib/api`) вместо голого `fetch` без таймаута — раньше необработанный throw давал SvelteKit-500 вместо осмысленного 504.

Спека и security-ревью (порядок проверок в control-plane, решение по мапингу) — Daedalus, в треде #d0e32ac0.

## Test plan

- [x] 8 новых юнит-тестов в `apps/web-publish/src/tests/assetsProxy.test.ts`: по одному на каждый класс (401/403/404/500/throw) + два негативных ассерта, что тело ответа не содержит `web-assets/`, `Bucket`, `S3Error`, `NoSuchKey`, `share-123`/`internal_share_id`
- [x] Полный сьют: 79/79 зелёных (было 71/71 на main до фикса)
- [x] `npm run build` — зелёный
- [x] `npm run check` (svelte-check) — 0 ошибок, 0 предупреждений
- [ ] Живая проба после деплоя (деплой web-publish ручной): curl на реальный приватный slug после выкатки, ожидаем 401 вместо сегодняшнего 404